### PR TITLE
fix(frontend): convert treeClusterId to number on form submit

### DIFF
--- a/frontend/app/src/components/general/form/FormForTree.tsx
+++ b/frontend/app/src/components/general/form/FormForTree.tsx
@@ -72,7 +72,7 @@ const FormForTree = (props: FormForTreeProps) => {
             placeholder="Wählen Sie eine Bewässerungsgruppe aus"
             label="Bewässerungsgruppe"
             error={errors.treeClusterId?.message}
-            {...register('treeClusterId')}
+            {...register('treeClusterId', { valueAsNumber: true })}
           />
         )}
         <Select


### PR DESCRIPTION
Fixes issue where selecting a tree cluster would pass string value instead of number to the API 

close #513
