### PR TITLE
fix(frontend): prevent search engine indexing

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/images/favicons/favicon.svg" sizes="any" />
     <link rel="apple-touch-icon" sizes="180x180" href="/images/favicons/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/images/favicons/favicon-16x16.png" />

--- a/frontend/app/public/robots.txt
+++ b/frontend/app/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Summary
- Add robots.txt and noindex meta tag to prevent search engine indexing

close #528 

## Problem
The demo instance (demo.green-ecolution.de) is being indexed by search engines. Internal app routes appear in Google search results because the landing page links to the demo instance.

## Solution
- Add `robots.txt` with `Disallow: /` to block all crawlers
- Add `<meta name="robots" content="noindex, nofollow" />` to `index.html` as additional protection