### PR TITLE
fix(backend): save description when creating a tree

### DIFF
--- a/backend/internal/service/domain/tree/tree.go
+++ b/backend/internal/service/domain/tree/tree.go
@@ -113,6 +113,7 @@ func (s *TreeService) Create(ctx context.Context, treeCreate *entities.TreeCreat
 		tree.Number = treeCreate.Number
 		tree.Latitude = treeCreate.Latitude
 		tree.Longitude = treeCreate.Longitude
+		tree.Description = treeCreate.Description
 		tree.Provider = treeCreate.Provider
 		tree.AdditionalInfo = treeCreate.AdditionalInfo
 

--- a/backend/internal/service/domain/tree/tree_test.go
+++ b/backend/internal/service/domain/tree/tree_test.go
@@ -307,6 +307,16 @@ func TestTreeService_Create(t *testing.T) {
 					return nil, err
 				}
 
+				// verify that all fields are correctly set on the tree entity
+				assert.Equal(t, TestTreeCreate.PlantingYear, testTree.PlantingYear)
+				assert.Equal(t, TestTreeCreate.Species, testTree.Species)
+				assert.Equal(t, TestTreeCreate.Number, testTree.Number)
+				assert.Equal(t, TestTreeCreate.Latitude, testTree.Latitude)
+				assert.Equal(t, TestTreeCreate.Longitude, testTree.Longitude)
+				assert.Equal(t, TestTreeCreate.Description, testTree.Description)
+				assert.Equal(t, expectedCluster, testTree.TreeCluster)
+				assert.Equal(t, expectedSensor, testTree.Sensor)
+
 				return expectedTree, nil
 			},
 		)

--- a/backend/internal/service/domain/tree/utils_test.go
+++ b/backend/internal/service/domain/tree/utils_test.go
@@ -125,6 +125,7 @@ var (
 		Longitude:     testLongitude,
 		PlantingYear:  2023,
 		Number:        "T001",
+		Description:   "Test tree description",
 		TreeClusterID: utils.P(int32(1)),
 		SensorID:      utils.P("sensor-1"),
 	}


### PR DESCRIPTION
## Summary
- Fix missing description assignment in TreeService.Create method
- Add test assertions to verify all fields are correctly set during tree creation

close #570

## Problem
When creating a new tree, the description/note field was not being saved. The `TreeService.Create` method was missing the line `tree.Description = treeCreate.Description`, while the `Update` method had it correctly implemented.

The bug also went undetected because the test didn't verify that fields were correctly assigned to the tree entity.

## Solution
- Added `tree.Description = treeCreate.Description` in `backend/internal/service/domain/tree/tree.go:116`
- Added `Description` field to `TestTreeCreate` test data
- Added assertions in the create test to verify all fields (PlantingYear, Species, Number, Latitude, Longitude, Description, TreeCluster, Sensor) are correctly set

## Definition of Done
- [x] Code compiles without errors
- [x] All tests pass (`make test`)
- [x] No new linter warnings (`make lint`)
- [ ] Code reviewed by at least 1 person
- [ ] Documentation updated (if applicable)
- [x] Acceptance criteria from issue fulfilled

## Test Plan
- [x] Create a new tree with a note/description
- [x] Verify the note is saved and visible when viewing the tree
- [x] Update an existing tree's note (regression test)

## Screenshots (if applicable)
N/A - Backend change only