### PR TITLE
chore(frontend): allow map interactions without triggering leave dialog

### DIFF
--- a/frontend/app/src/routes/_protected/map/tree/edit/index.tsx
+++ b/frontend/app/src/routes/_protected/map/tree/edit/index.tsx
@@ -41,9 +41,11 @@ function EditTree() {
         return false
       }
 
-      const isFormPath =
-        next.pathname.startsWith('/trees/new') || next.pathname.startsWith('/trees/')
-      if (isFormPath) {
+      const isAllowedPath =
+        next.pathname.startsWith('/trees/new') ||
+        next.pathname.startsWith('/trees/') ||
+        next.pathname.startsWith('/map/tree/edit')
+      if (isAllowedPath) {
         return false
       }
 


### PR DESCRIPTION
## Summary
- Allow map interactions (pan/zoom) on `/map/tree/edit` without triggering the "Leave page?" dialog

close #569

## Problem
On `/map/tree/edit`, when panning or zooming the map, the "Leave page?" dialog appeared unexpectedly. This was a regression from #517.

The root cause: `MapController.tsx` calls `navigate({ to: '.', search: {...} })` on every map interaction to update URL parameters. The `useBlocker` in the route treated this as a navigation attempt and blocked it because `/map/tree/edit` was not in the allowed paths.

## Solution
Added `/map/tree/edit` to the allowed paths in the `shouldBlockFn`, so search-param-only updates (same path navigation) are permitted while actual navigation away from the page still triggers the warning dialog as expected.

## Definition of Done
- [x] Code compiles without errors
- [x] All tests pass (`make test`)
- [x] No new linter warnings (`make lint`)
- [ ] Code reviewed by at least 1 person
- [x] Documentation updated (if applicable)
- [x] Acceptance criteria from issue fulfilled

## Test Plan
- [x] Go to `/trees/new`, fill form, click "Standort ändern"
- [x] On `/map/tree/edit`, pan and zoom the map → no dialog should appear
- [x] Try to navigate away (e.g., click browser back or navigate to `/map`) → dialog should appear
