### PR TITLE
fix(frontend): prevent duplicate treecluster selection on rapid clicks

### DIFF
--- a/frontend/app/src/routes/_protected/map/watering-plan/select/cluster/index.tsx
+++ b/frontend/app/src/routes/_protected/map/watering-plan/select/cluster/index.tsx
@@ -121,9 +121,12 @@ function SelectCluster() {
   const handleClick = (cluster: TreeCluster) => {
     if (disabledClusters.includes(cluster.id)) return
 
-    if (clusterIds.includes(cluster.id))
-      setClusterIds((prev) => prev.filter((id) => id !== cluster.id))
-    else setClusterIds((prev) => [...prev, cluster.id])
+    setClusterIds((prev) => {
+      if (prev.includes(cluster.id)) {
+        return prev.filter((id) => id !== cluster.id)
+      }
+      return [...prev, cluster.id]
+    })
   }
 
   const disabledClusters = useMemo(() => {


### PR DESCRIPTION
## Summary
- Fix race condition that allowed treeclusters to be added multiple times when clicking rapidly during route calculation

close #85

## Problem
When clicking a TreeCluster while the route is being calculated, the cluster could be added multiple times to the selection. This happened because `handleClick` checked `clusterIds.includes(cluster.id)` using a stale closure value instead of the current state.

## Solution
Moved the duplicate check inside the state updater function, which always receives the current state. This ensures that even with rapid clicks, the check uses the up-to-date state.

```typescript
// Before (buggy)
if (clusterIds.includes(cluster.id))
  setClusterIds((prev) => prev.filter((id) => id !== cluster.id))
else setClusterIds((prev) => [...prev, cluster.id])

// After (fixed)
setClusterIds((prev) => {
  if (prev.includes(cluster.id)) {
    return prev.filter((id) => id !== cluster.id)
  }
  return [...prev, cluster.id]
})
```

## Definition of Done
- [x] Code compiles without errors
- [x] All tests pass (`make test`)
- [x] No new linter warnings (`make lint`)
- [ ] Code reviewed by at least 1 person
- [ ] Documentation updated (if applicable)
- [x] Acceptance criteria from issue fulfilled

## Test Plan

- [x] Navigate to watering plan creation and select a vehicle
- [x] Click "Bewässerungsgruppen hinzufügen" to open cluster selection
- [x] Rapidly click on a cluster multiple times
- [x] Verify cluster only appears once in the selection list

## Screenshots (if applicable)

N/A - No UI changes