### PR TITLE
feat(frontend): update footer links and add version display

### DIFF
--- a/frontend/app/src/components/layout/Footer.tsx
+++ b/frontend/app/src/components/layout/Footer.tsx
@@ -1,8 +1,15 @@
 import { useLocation } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { infoQuery } from '@/api/queries'
 
 function Footer() {
   const location = useLocation()
   const isMapPage = location.pathname.includes('/map')
+  const { data: appInfo } = useQuery(infoQuery())
+
+  const version = appInfo?.version?.startsWith('v')
+    ? appInfo.version
+    : `v${appInfo?.version ?? 'unkown'}`
 
   const navItems = [
     {
@@ -10,11 +17,11 @@ function Footer() {
       label: 'Kontakt',
     },
     {
-      url: 'https://hs-flensburg.de/impressum',
+      url: 'https://green-ecolution.de/impressum',
       label: 'Impressum',
     },
     {
-      url: 'https://hs-flensburg.de/datenschutz',
+      url: 'https://green-ecolution.de/datenschutz',
       label: 'Datenschutz',
     },
   ]
@@ -23,8 +30,7 @@ function Footer() {
     <footer className={`bg-white lg:pl-20 mt-16 ${isMapPage ? 'hidden' : ''}`}>
       <div className="container text-sm border-t border-dark-50 py-4 lg:flex lg:justify-between lg:items-center">
         <p className="text-dark-400 mb-5 lg:mb-0">
-          Diese Webseite wurde im Rahmen eines Forschungsprojektes der Hochschule Flensburg
-          erstellt.
+          Smartes Grünflächenmanagement - Green Ecolution {version}
         </p>
         <nav aria-label="Fußnavigation">
           <ul className="flex flex-wrap gap-x-4">


### PR DESCRIPTION
## Summary
- Update imprint and privacy policy links to point to green-ecolution.de
- Display app version fetched from backend API in footer
- Update footer text to "Smartes Grünflächenmanagement - Green Ecolution"

close #585

## Problem
Footer links for imprint and privacy policy were pointing to the university website instead of the green-ecolution website.

## Solution
- Changed footer links to `https://green-ecolution.de/impressum` and `https://green-ecolution.de/datenschutz`
- Added `infoQuery` to fetch app version from backend
- Updated footer text to show version and new tagline

## Test plan
- [x] Verify imprint link opens green-ecolution.de/impressum
- [x] Verify privacy policy link opens green-ecolution.de/datenschutz
- [x] Verify version is displayed in footer (e.g., "v0.1.1")