### PR TITLE
fix(frontend): resolve map filter for cluster membership

### DIFF
--- a/frontend/app/src/api/queries.test.ts
+++ b/frontend/app/src/api/queries.test.ts
@@ -68,6 +68,29 @@ describe('Query Functions', () => {
         expect(options.queryKey).toContain('trees')
       })
 
+      it('includes hasCluster in query key when true', () => {
+        const options = treeQuery({ hasCluster: true })
+
+        expect(options.queryKey).toContain(true)
+      })
+
+      it('includes hasCluster in query key when false', () => {
+        const options = treeQuery({ hasCluster: false })
+
+        expect(options.queryKey).toContain(false)
+      })
+
+      it('uses different query keys for different hasCluster values', () => {
+        const optionsTrue = treeQuery({ hasCluster: true })
+        const optionsFalse = treeQuery({ hasCluster: false })
+        const optionsUndefined = treeQuery({})
+
+        // All should have different query keys
+        expect(optionsTrue.queryKey).not.toEqual(optionsFalse.queryKey)
+        expect(optionsTrue.queryKey).not.toEqual(optionsUndefined.queryKey)
+        expect(optionsFalse.queryKey).not.toEqual(optionsUndefined.queryKey)
+      })
+
       it('calls treeApi.getAllTrees when queryFn is executed', async () => {
         const mockResponse = { data: [] } as TreeList
         // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/frontend/app/src/api/queries.ts
+++ b/frontend/app/src/api/queries.ts
@@ -95,9 +95,13 @@ export const sensorIdQuery = (id: string) =>
 
 export const treeQuery = (params?: GetAllTreesRequest) =>
   queryOptions<TreeList>({
-    queryKey: ['trees', params?.page, params?.wateringStatuses, params?.plantingYears].filter(
-      (e) => e != undefined || e != null,
-    ),
+    queryKey: [
+      'trees',
+      params?.page,
+      params?.wateringStatuses,
+      params?.plantingYears,
+      params?.hasCluster,
+    ].filter((e) => e != undefined || e != null),
     queryFn: () => treeApi.getAllTrees(params),
   })
 

--- a/frontend/app/src/context/FilterContext.test.tsx
+++ b/frontend/app/src/context/FilterContext.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import FilterProvider, { useFilter } from './FilterContext'
+import { ReactNode } from 'react'
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <FilterProvider>{children}</FilterProvider>
+)
+
+describe('FilterContext', () => {
+  describe('handleClusterChange', () => {
+    it('sets hasCluster to true when "Gruppe zugehörig" is checked', () => {
+      const { result } = renderHook(() => useFilter(), { wrapper })
+
+      act(() => {
+        result.current.handleClusterChange({
+          target: { checked: true, value: 'true' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      expect(result.current.filters.hasCluster).toBe(true)
+    })
+
+    it('sets hasCluster to false when "Keiner Gruppe zugehörig" is checked', () => {
+      const { result } = renderHook(() => useFilter(), { wrapper })
+
+      act(() => {
+        result.current.handleClusterChange({
+          target: { checked: true, value: 'false' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      expect(result.current.filters.hasCluster).toBe(false)
+    })
+
+    it('resets hasCluster to undefined when option is unchecked', () => {
+      const { result } = renderHook(() => useFilter(), { wrapper })
+
+      // First select an option
+      act(() => {
+        result.current.handleClusterChange({
+          target: { checked: true, value: 'true' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+      expect(result.current.filters.hasCluster).toBe(true)
+
+      // Then uncheck it - this should reset to undefined
+      act(() => {
+        result.current.handleClusterChange({
+          target: { checked: false, value: 'true' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+      expect(result.current.filters.hasCluster).toBeUndefined()
+    })
+  })
+
+  describe('handleStatusChange', () => {
+    it('adds status to array when checked', () => {
+      const { result } = renderHook(() => useFilter(), { wrapper })
+
+      act(() => {
+        result.current.handleStatusChange({
+          target: { checked: true, value: 'good' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      expect(result.current.filters.statusTags).toContain('good')
+    })
+
+    it('removes status from array when unchecked', () => {
+      const { result } = renderHook(() => useFilter(), { wrapper })
+
+      act(() => {
+        result.current.handleStatusChange({
+          target: { checked: true, value: 'good' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      act(() => {
+        result.current.handleStatusChange({
+          target: { checked: false, value: 'good' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      expect(result.current.filters.statusTags).not.toContain('good')
+    })
+  })
+
+  describe('handlePlantingYearChange', () => {
+    it('adds year to array when checked', () => {
+      const { result } = renderHook(() => useFilter(), { wrapper })
+
+      act(() => {
+        result.current.handlePlantingYearChange({
+          target: { checked: true, value: '2024' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      expect(result.current.filters.plantingYears).toContain(2024)
+    })
+
+    it('removes year from array when unchecked', () => {
+      const { result } = renderHook(() => useFilter(), { wrapper })
+
+      act(() => {
+        result.current.handlePlantingYearChange({
+          target: { checked: true, value: '2024' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      act(() => {
+        result.current.handlePlantingYearChange({
+          target: { checked: false, value: '2024' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      expect(result.current.filters.plantingYears).not.toContain(2024)
+    })
+  })
+
+  describe('resetFilters', () => {
+    it('resets all filters to initial state', () => {
+      const { result } = renderHook(() => useFilter(), { wrapper })
+
+      // Set some filters
+      act(() => {
+        result.current.handleClusterChange({
+          target: { checked: true, value: 'true' },
+        } as React.ChangeEvent<HTMLInputElement>)
+        result.current.handleStatusChange({
+          target: { checked: true, value: 'good' },
+        } as React.ChangeEvent<HTMLInputElement>)
+        result.current.handlePlantingYearChange({
+          target: { checked: true, value: '2024' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      // Reset
+      act(() => {
+        result.current.resetFilters()
+      })
+
+      expect(result.current.filters.hasCluster).toBeUndefined()
+      expect(result.current.filters.statusTags).toEqual([])
+      expect(result.current.filters.plantingYears).toEqual([])
+      expect(result.current.filters.regionTags).toEqual([])
+    })
+  })
+
+  describe('applyOldStateToTags', () => {
+    it('restores previous filter state', () => {
+      const { result } = renderHook(() => useFilter(), { wrapper })
+
+      const oldState = {
+        statusTags: ['good'],
+        regionTags: ['region1'],
+        hasCluster: true,
+        plantingYears: [2024],
+      }
+
+      act(() => {
+        result.current.applyOldStateToTags(oldState)
+      })
+
+      expect(result.current.filters.statusTags).toEqual(['good'])
+      expect(result.current.filters.regionTags).toEqual(['region1'])
+      expect(result.current.filters.hasCluster).toBe(true)
+      expect(result.current.filters.plantingYears).toEqual([2024])
+    })
+  })
+})

--- a/frontend/app/src/context/FilterContext.tsx
+++ b/frontend/app/src/context/FilterContext.tsx
@@ -55,8 +55,12 @@ const FilterProvider: React.FC<FilterProviderProps> = ({
   }
 
   const handleClusterChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { value } = event.target
-    setHasCluster(value === 'true')
+    const { checked, value } = event.target
+    if (checked) {
+      setHasCluster(value === 'true')
+    } else {
+      setHasCluster(undefined)
+    }
   }
 
   const handlePlantingYearChange = (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary
- Fix map filter for cluster membership ("Gruppe zugehörig" / "Keiner Gruppe zugehörig")

## Problem
The map filter for cluster membership was not working correctly. Two bugs were identified:

1. **TanStack Query Cache-Key missing `hasCluster`**: In `queries.ts`, the `hasCluster` parameter was missing from the
`queryKey` array. This caused TanStack Query to return cached results without considering the `hasCluster` value - different
filter states (`true`, `false`, `undefined`) returned the same cached result.

2. **Deselecting filter not possible**: In `FilterContext.tsx`, the `handleClusterChange` function ignored the `checked` value
from the event. This meant unchecking a filter option didn't reset `hasCluster` to `undefined`.

## Solution
1. **Fix 1** (`frontend/app/src/api/queries.ts`): Added `params?.hasCluster` to the `queryKey` array so TanStack Query properly
 caches results based on the cluster filter value.

2. **Fix 2** (`frontend/app/src/context/FilterContext.tsx`): Updated `handleClusterChange` to use the `checked` value:
   - When checked → sets `hasCluster` to `true` or `false` based on the value
   - When unchecked → resets `hasCluster` to `undefined`

3. Added unit tests for `FilterContext` and extended `queries.test.ts` to cover these scenarios.

## Definition of Done
- [x] Code compiles without errors
- [x] All tests pass (`make test`)
- [x] No new linter warnings (`make lint`)
- [x] Code reviewed by at least 1 person
- [ ] Documentation updated (if applicable)
- [x] Acceptance criteria from issue fulfilled

## Test Plan
- [x] Navigate to map (`/map`)
- [x] Open filter dialog
- [x] Select "Keiner Gruppe zugehörig" → verify only trees WITHOUT cluster are shown
- [x] Select "Gruppe zugehörig" → verify only trees WITH cluster are shown
- [x] Deselect the active filter → verify all trees are shown again
- [x] Verify other filters (watering status, planting year) still work correctly

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->