### PR TITLE
fix(seed): overhaul vehicle seed data with realistic values

### DIFF
--- a/backend/internal/storage/postgres/seed/99_demo_data.sql
+++ b/backend/internal/storage/postgres/seed/99_demo_data.sql
@@ -1,11 +1,22 @@
 -- +goose Up
 -- +goose StatementBegin
-INSERT INTO vehicles (id, number_plate, description, water_capacity, type, status, driving_license, model, width, height, length, weight) 
-VALUES 
-  (1, 'B-1111', 'Test vehicle 1', 1000.0, 'trailer', 'active', 'BE', 'LK1615/17 - Conrad - MAN TGE 3.180', 2.0, 1.5, 2.0, 3.5),
-  (2, 'B-2222', 'Test vehicle 2', 1000.0, 'transporter', 'unknown', 'C', 'Actros L Mercedes Benz', 2.4, 2.1, 5.0, 2.5),
-  (3, 'B-3333', 'Test vehicle 3', 2800.0, 'transporter', 'available', 'C', 'Ford Ranger XL', 2.55, 4.0, 9.09, 26),
-  (4, 'B-4444', 'Test vehicle 4', 1000.0, 'trailer', 'available', 'BE', 'VW Crafter Pritsche', 2.4, 2.1, 5.0, 5.5);
+INSERT INTO vehicles (id, number_plate, description, water_capacity, type, status, driving_license, model, width, height, length, weight)
+VALUES
+  -- Realistic transporters
+  (1, 'FL-GE-101', 'Kleintransporter für Stadtgebiete', 500.0, 'transporter', 'active', 'B', 'VW Transporter T6.1', 1.90, 1.99, 5.30, 2.0),
+  (2, 'FL-GE-201', 'Transporter für mittlere Einsätze', 800.0, 'transporter', 'available', 'B', 'Ford Transit Custom', 2.06, 2.52, 5.53, 2.3),
+  (3, 'FL-GE-301', 'Pritschenwagen für Anhängerbetrieb', 300.0, 'transporter', 'active', 'BE', 'MAN TGE 3.180 Pritsche', 2.04, 2.35, 5.99, 3.5),
+  (4, 'FL-GE-401', 'Mittlerer Tankwagen', 5000.0, 'transporter', 'available', 'C', 'Mercedes Atego 1218', 2.30, 3.20, 7.50, 12.0),
+  (5, 'FL-GE-501', 'Großer Tankwagen für Außenbereiche', 10000.0, 'transporter', 'available', 'CE', 'MAN TGS 18.320', 2.55, 3.50, 9.50, 18.0),
+  -- Realistic trailers
+  (6, 'FL-GE-A01', 'Kleiner Wassertankanhänger für Stadtgebiete', 1000.0, 'trailer', 'available', 'B', 'Humbaur HA 132513', 1.32, 1.50, 2.50, 0.75),
+  (7, 'FL-GE-A02', 'Mittlerer Wassertankanhänger', 2000.0, 'trailer', 'active', 'BE', 'Unsinn WEB 30', 1.80, 1.80, 4.00, 1.2),
+  (8, 'FL-GE-A03', 'Großer Wassertankanhänger für Außeneinsätze', 4000.0, 'trailer', 'available', 'BE', 'Humbaur HTK 3500', 2.10, 2.00, 5.50, 2.5),
+  -- Unrealistic test vehicles for edge-case and boundary testing
+  (9, 'FL-TEST-01', '[TEST] Unrealistisch: Viel zu groß und schwer für Routing-Tests', 50000.0, 'transporter', 'available', 'CE', 'Test Mega Truck', 3.50, 5.00, 25.0, 80.0),
+  (10, 'FL-TEST-02', '[TEST] Unrealistisch: Viel zu klein für Edge-Case-Tests', 100.0, 'transporter', 'available', 'B', 'Test Mini Van', 1.20, 1.00, 2.0, 0.3),
+  (11, 'FL-TEST-03', '[TEST] Unrealistisch: Extreme Werte für Grenzwert-Tests', 99999.0, 'transporter', 'not available', 'CE', 'Test Heavy Loader', 4.00, 6.00, 30.0, 150.0),
+  (12, 'FL-TEST-A01', '[TEST] Unrealistisch: Riesiger Testanhänger', 30000.0, 'trailer', 'available', 'CE', 'Test Giant Trailer', 3.00, 4.00, 15.0, 25.0);
 SELECT setval('vehicles_id_seq', (SELECT MAX(id) FROM vehicles));
 
 INSERT INTO tree_clusters (id, name, watering_status, moisture_level, region_id, address, description, soil_condition, latitude, longitude, geometry)


### PR DESCRIPTION
## Summary
- Overhaul vehicle seed data with realistic values and German license plate format
- Add realistic trailers alongside transporters

close #630
close #631

## Problem
The existing seed data contained unrealistic vehicle values:
- **B-3333 (Ford Ranger XL):** 26t weight, 4.0m height, 9.09m length - completely unrealistic for a pickup truck
- **B-4444 (VW Crafter Pritsche):** 5.5t weight - too heavy for this vehicle type
- **B-2222 (Actros L Mercedes Benz):** 2.5t weight - Actros is a heavy truck (>7t)
- **B-1111 (MAN TGE):** 1.5m height, 2.0m length - way too short for a transporter
- No vehicles with license class B (up to 3.5t)

## Solution
Complete overhaul of the vehicle fleet:

### Realistic Transporters (ID 1-5)
| License Plate | Model | Water Cap. | License | Weight |
|---------------|-------|------------|---------|--------|
| FL-GE-101 | VW Transporter T6.1 | 500L | B | 2.0t |
| FL-GE-201 | Ford Transit Custom | 800L | B | 2.3t |
| FL-GE-301 | MAN TGE 3.180 Pritsche | 300L | BE | 3.5t |
| FL-GE-401 | Mercedes Atego 1218 | 5000L | C | 12.0t |
| FL-GE-501 | MAN TGS 18.320 | 10000L | CE | 18.0t |

### Realistic Trailers (ID 6-8)
| License Plate | Model | Water Cap. | License | Weight |
|---------------|-------|------------|---------|--------|
| FL-GE-A01 | Humbaur HA 132513 | 1000L | B | 0.75t |
| FL-GE-A02 | Unsinn WEB 30 | 2000L | BE | 1.2t |
| FL-GE-A03 | Humbaur HTK 3500 | 4000L | BE | 2.5t |

### Unrealistic Test Vehicles (ID 9-12)
| License Plate | Type | Purpose |
|---------------|------|---------|
| FL-TEST-01 | transporter | Too large/heavy for routing tests |
| FL-TEST-02 | transporter | Unrealistically small for edge cases |
| FL-TEST-03 | transporter | Extreme values for boundary tests |
| FL-TEST-A01 | trailer | Giant test trailer |

## Definition of Done
- [x] Code compiles without errors
- [x] All tests pass (`make test`)
- [x] No new linter warnings (`make lint`)
- [ ] Code reviewed by at least 1 person
- [ ] Documentation updated (if applicable)
- [x] Acceptance criteria from issue fulfilled

## Test Plan
- [ ] `SELECT * FROM vehicles;` shows 12 vehicles
- [ ] All license classes present (B, BE, C, CE)
- [ ] Both types present: 8 transporters, 4 trailers
- [ ] Test vehicles have `[TEST]` prefix in description
- [ ] Frontend vehicle list displays correct values

## Screenshots (if applicable)
N/A - Data changes only