### PR TITLE
feat(ui): add filter functionality to map CRUD selection pages

### DIFF
--- a/frontend/app/src/components/map/marker/WithFilterableClusters.tsx
+++ b/frontend/app/src/components/map/marker/WithFilterableClusters.tsx
@@ -1,0 +1,234 @@
+import { TreeClusterInList } from '@green-ecolution/backend-client'
+import { memo, useCallback, useDeferredValue, useMemo, useState } from 'react'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { treeClusterQuery } from '@/api/queries'
+import FilterProvider, { useFilter, Filters } from '@/context/FilterContext'
+import FilterButton from '@/components/general/buttons/FilterButton'
+import StatusFieldset from '@/components/general/filter/fieldsets/StatusFieldset'
+import RegionFieldset from '@/components/general/filter/fieldsets/RegionFieldset'
+import useMapInteractions from '@/hooks/useMapInteractions'
+import MarkerList from './MarkerList'
+import { ClusterIcon } from '../MapMarker'
+import { getStatusColor } from '../utils'
+import {
+  Button,
+  Dialog as DialogRoot,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@green-ecolution/ui'
+import { MoveRight, X } from 'lucide-react'
+
+const defaultHighlighted: number[] = []
+const defaultDisabled: number[] = []
+
+const tooltipOptions = {
+  direction: 'top' as const,
+  offset: [5, -40] as [number, number],
+  className: 'font-nunito-sans font-semibold',
+}
+
+export interface WithFilterableClustersProps {
+  onClick?: (cluster: TreeClusterInList) => void
+  highlightedClusters?: number[]
+  disabledClusters?: number[]
+}
+
+interface AppliedFilters {
+  wateringStatuses?: string[]
+  regions?: string[]
+}
+
+interface FilterableClustersContentProps extends WithFilterableClustersProps {
+  appliedFilters: AppliedFilters
+}
+
+const FilterableClustersContent = memo(
+  ({
+    onClick,
+    highlightedClusters = defaultHighlighted,
+    disabledClusters = defaultDisabled,
+    appliedFilters,
+  }: FilterableClustersContentProps) => {
+    const hasActiveFilter = useMemo(
+      () =>
+        (appliedFilters.wateringStatuses?.length ?? 0) > 0 ||
+        (appliedFilters.regions?.length ?? 0) > 0,
+      [appliedFilters.wateringStatuses, appliedFilters.regions],
+    )
+
+    const { data } = useSuspenseQuery(
+      treeClusterQuery(
+        hasActiveFilter
+          ? {
+              wateringStatuses: appliedFilters.wateringStatuses,
+              regions: appliedFilters.regions,
+            }
+          : undefined,
+      ),
+    )
+
+    const filteredData = useMemo(
+      () =>
+        data.data.filter(
+          (cluster) =>
+            cluster.latitude !== null &&
+            cluster.longitude !== null &&
+            cluster.treeIds !== undefined,
+        ),
+      [data.data],
+    )
+    const deferredData = useDeferredValue(filteredData)
+
+    const highlightedSet = useMemo(() => new Set(highlightedClusters), [highlightedClusters])
+    const disabledSet = useMemo(() => new Set(disabledClusters), [disabledClusters])
+
+    const getIcon = useCallback(
+      (c: TreeClusterInList) =>
+        ClusterIcon(
+          getStatusColor(c.wateringStatus),
+          highlightedSet.has(c.id),
+          disabledSet.has(c.id),
+          c.treeIds?.length ?? 0,
+        ),
+      [highlightedSet, disabledSet],
+    )
+
+    const getId = useCallback((c: TreeClusterInList) => c.id, [])
+    const getTooltip = useCallback((c: TreeClusterInList) => c.name, [])
+
+    return (
+      <MarkerList
+        data={deferredData}
+        onClick={onClick}
+        icon={getIcon}
+        getId={getId}
+        tooltipContent={getTooltip}
+        tooltipOptions={tooltipOptions}
+      />
+    )
+  },
+)
+
+FilterableClustersContent.displayName = 'FilterableClustersContent'
+
+const FilterableClustersInner = memo(
+  ({ onClick, highlightedClusters, disabledClusters }: WithFilterableClustersProps) => {
+    const { enableDragging, disableDragging } = useMapInteractions()
+    const { filters, resetFilters, applyOldStateToTags } = useFilter()
+    const [isOpen, setIsOpen] = useState(false)
+    const [oldValues, setOldValues] = useState<Filters>({
+      statusTags: [],
+      regionTags: [],
+      hasCluster: undefined,
+      plantingYears: [],
+    })
+    const [appliedFilters, setAppliedFilters] = useState<AppliedFilters>({})
+
+    const handleMapInteractions = useCallback(
+      (isOpen: boolean) => {
+        if (isOpen) {
+          disableDragging()
+        } else {
+          enableDragging()
+        }
+      },
+      [disableDragging, enableDragging],
+    )
+
+    const handleOpen = useCallback(() => {
+      setOldValues(filters)
+      setIsOpen(true)
+      handleMapInteractions(true)
+    }, [filters, handleMapInteractions])
+
+    const handleClose = useCallback(() => {
+      setIsOpen(false)
+      applyOldStateToTags(oldValues)
+      handleMapInteractions(false)
+    }, [applyOldStateToTags, oldValues, handleMapInteractions])
+
+    const handleSubmit = useCallback(() => {
+      setAppliedFilters({
+        wateringStatuses: filters.statusTags.length > 0 ? filters.statusTags : undefined,
+        regions: filters.regionTags.length > 0 ? filters.regionTags : undefined,
+      })
+      setIsOpen(false)
+      handleMapInteractions(false)
+    }, [filters, handleMapInteractions])
+
+    const handleReset = useCallback(() => {
+      applyOldStateToTags({
+        statusTags: [],
+        regionTags: [],
+        hasCluster: undefined,
+        plantingYears: [],
+      })
+      resetFilters()
+      setAppliedFilters({})
+      setIsOpen(false)
+      handleMapInteractions(false)
+    }, [applyOldStateToTags, resetFilters, handleMapInteractions])
+
+    const filterCount = useMemo(
+      () => (appliedFilters.wateringStatuses?.length ?? 0) + (appliedFilters.regions?.length ?? 0),
+      [appliedFilters],
+    )
+
+    return (
+      <>
+        <div className="absolute top-6 left-4 z-[1000]">
+          <div className="font-nunito-sans text-base">
+            <FilterButton
+              activeCount={filterCount}
+              ariaLabel="Bewässerungsgruppen filtern"
+              isOnMap
+              onClick={() => (isOpen ? handleClose() : handleOpen())}
+            />
+
+            <DialogRoot open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+              <DialogContent className="max-h-[80dvh] overflow-y-auto">
+                <DialogHeader>
+                  <DialogTitle>Bewässerungsgruppen filtern</DialogTitle>
+                </DialogHeader>
+                <StatusFieldset />
+                <RegionFieldset />
+
+                <div className="flex flex-wrap gap-5 mt-6">
+                  <Button type="button" onClick={handleSubmit}>
+                    Anwenden
+                    <MoveRight className="icon-arrow-animate" />
+                  </Button>
+                  <Button variant="outline" onClick={handleReset}>
+                    Zurücksetzen
+                    <X />
+                  </Button>
+                </div>
+              </DialogContent>
+            </DialogRoot>
+          </div>
+        </div>
+        <FilterableClustersContent
+          onClick={onClick}
+          highlightedClusters={highlightedClusters}
+          disabledClusters={disabledClusters}
+          appliedFilters={appliedFilters}
+        />
+      </>
+    )
+  },
+)
+
+FilterableClustersInner.displayName = 'FilterableClustersInner'
+
+const WithFilterableClusters = memo((props: WithFilterableClustersProps) => {
+  return (
+    <FilterProvider>
+      <FilterableClustersInner {...props} />
+    </FilterProvider>
+  )
+})
+
+WithFilterableClusters.displayName = 'WithFilterableClusters'
+
+export default WithFilterableClusters

--- a/frontend/app/src/components/map/marker/WithFilterableTrees.tsx
+++ b/frontend/app/src/components/map/marker/WithFilterableTrees.tsx
@@ -1,0 +1,204 @@
+import { Tree } from '@green-ecolution/backend-client'
+import { memo, useCallback, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { treeQuery } from '@/api/queries'
+import FilterProvider, { useFilter, Filters } from '@/context/FilterContext'
+import FilterButton from '@/components/general/buttons/FilterButton'
+import StatusFieldset from '@/components/general/filter/fieldsets/StatusFieldset'
+import ClusterFieldset from '@/components/general/filter/fieldsets/ClusterFieldset'
+import PlantingYearFieldset from '@/components/general/filter/fieldsets/PlantingYearFieldset'
+import useMapInteractions from '@/hooks/useMapInteractions'
+import WithAllTrees from './WithAllTrees'
+import WithFilterdTrees from './WithFilterdTrees'
+import {
+  Button,
+  Dialog as DialogRoot,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@green-ecolution/ui'
+import { MoveRight, X } from 'lucide-react'
+
+export interface WithFilterableTreesProps {
+  onClick?: (tree: Tree) => void
+  selectedTrees?: number[]
+  hasHighlightedTree?: number
+}
+
+interface AppliedFilters {
+  wateringStatuses?: string[]
+  hasCluster?: boolean
+  plantingYears?: number[]
+}
+
+interface FilterableTreesContentProps extends WithFilterableTreesProps {
+  appliedFilters: AppliedFilters
+}
+
+const FilterableTreesContent = memo(
+  ({ onClick, selectedTrees, hasHighlightedTree, appliedFilters }: FilterableTreesContentProps) => {
+    const hasActiveFilter = useMemo(
+      () =>
+        (appliedFilters.wateringStatuses?.length ?? 0) > 0 ||
+        appliedFilters.hasCluster !== undefined ||
+        (appliedFilters.plantingYears?.length ?? 0) > 0,
+      [appliedFilters.wateringStatuses, appliedFilters.hasCluster, appliedFilters.plantingYears],
+    )
+
+    const { data: treesRes } = useQuery({
+      enabled: hasActiveFilter,
+      ...treeQuery({
+        wateringStatuses: appliedFilters.wateringStatuses,
+        hasCluster: appliedFilters.hasCluster,
+        plantingYears: appliedFilters.plantingYears,
+      }),
+    })
+
+    if (hasActiveFilter) {
+      return (
+        <WithFilterdTrees
+          onClick={onClick}
+          selectedTrees={selectedTrees}
+          hasHighlightedTree={hasHighlightedTree}
+          filterdTrees={treesRes?.data ?? []}
+        />
+      )
+    }
+
+    return (
+      <WithAllTrees
+        onClick={onClick}
+        selectedTrees={selectedTrees}
+        hasHighlightedTree={hasHighlightedTree}
+      />
+    )
+  },
+)
+
+FilterableTreesContent.displayName = 'FilterableTreesContent'
+
+const FilterableTreesInner = memo(
+  ({ onClick, selectedTrees, hasHighlightedTree }: WithFilterableTreesProps) => {
+    const { enableDragging, disableDragging } = useMapInteractions()
+    const { filters, resetFilters, applyOldStateToTags } = useFilter()
+    const [isOpen, setIsOpen] = useState(false)
+    const [oldValues, setOldValues] = useState<Filters>({
+      statusTags: [],
+      regionTags: [],
+      hasCluster: undefined,
+      plantingYears: [],
+    })
+    const [appliedFilters, setAppliedFilters] = useState<AppliedFilters>({})
+
+    const handleMapInteractions = useCallback(
+      (isOpen: boolean) => {
+        if (isOpen) {
+          disableDragging()
+        } else {
+          enableDragging()
+        }
+      },
+      [disableDragging, enableDragging],
+    )
+
+    const handleOpen = useCallback(() => {
+      setOldValues(filters)
+      setIsOpen(true)
+      handleMapInteractions(true)
+    }, [filters, handleMapInteractions])
+
+    const handleClose = useCallback(() => {
+      setIsOpen(false)
+      applyOldStateToTags(oldValues)
+      handleMapInteractions(false)
+    }, [applyOldStateToTags, oldValues, handleMapInteractions])
+
+    const handleSubmit = useCallback(() => {
+      setAppliedFilters({
+        wateringStatuses: filters.statusTags.length > 0 ? filters.statusTags : undefined,
+        hasCluster: filters.hasCluster,
+        plantingYears: filters.plantingYears.length > 0 ? filters.plantingYears : undefined,
+      })
+      setIsOpen(false)
+      handleMapInteractions(false)
+    }, [filters, handleMapInteractions])
+
+    const handleReset = useCallback(() => {
+      applyOldStateToTags({
+        statusTags: [],
+        regionTags: [],
+        hasCluster: undefined,
+        plantingYears: [],
+      })
+      resetFilters()
+      setAppliedFilters({})
+      setIsOpen(false)
+      handleMapInteractions(false)
+    }, [applyOldStateToTags, resetFilters, handleMapInteractions])
+
+    const filterCount = useMemo(
+      () =>
+        (appliedFilters.wateringStatuses?.length ?? 0) +
+        (appliedFilters.hasCluster !== undefined ? 1 : 0) +
+        (appliedFilters.plantingYears?.length ?? 0),
+      [appliedFilters],
+    )
+
+    return (
+      <>
+        <div className="absolute top-6 left-4 z-[1000]">
+          <div className="font-nunito-sans text-base">
+            <FilterButton
+              activeCount={filterCount}
+              ariaLabel="Bäume filtern"
+              isOnMap
+              onClick={() => (isOpen ? handleClose() : handleOpen())}
+            />
+
+            <DialogRoot open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+              <DialogContent className="max-h-[80dvh] overflow-y-auto">
+                <DialogHeader>
+                  <DialogTitle>Bäume filtern</DialogTitle>
+                </DialogHeader>
+                <StatusFieldset />
+                <ClusterFieldset />
+                <PlantingYearFieldset />
+
+                <div className="flex flex-wrap gap-5 mt-6">
+                  <Button type="button" onClick={handleSubmit}>
+                    Anwenden
+                    <MoveRight className="icon-arrow-animate" />
+                  </Button>
+                  <Button variant="outline" onClick={handleReset}>
+                    Zurücksetzen
+                    <X />
+                  </Button>
+                </div>
+              </DialogContent>
+            </DialogRoot>
+          </div>
+        </div>
+        <FilterableTreesContent
+          onClick={onClick}
+          selectedTrees={selectedTrees}
+          hasHighlightedTree={hasHighlightedTree}
+          appliedFilters={appliedFilters}
+        />
+      </>
+    )
+  },
+)
+
+FilterableTreesInner.displayName = 'FilterableTreesInner'
+
+const WithFilterableTrees = memo((props: WithFilterableTreesProps) => {
+  return (
+    <FilterProvider>
+      <FilterableTreesInner {...props} />
+    </FilterProvider>
+  )
+})
+
+WithFilterableTrees.displayName = 'WithFilterableTrees'
+
+export default WithFilterableTrees

--- a/frontend/app/src/routes/_protected/map/sensor/select/tree/index.tsx
+++ b/frontend/app/src/routes/_protected/map/sensor/select/tree/index.tsx
@@ -3,7 +3,7 @@ import { sensorIdQuery, treeIdQuery } from '@/api/queries'
 import SelectedCard from '@/components/general/cards/SelectedCard'
 import MapSelectEntitiesModal from '@/components/map/MapSelectEntitiesModal'
 import SensorMarker from '@/components/map/marker/SensorMarker'
-import WithAllTrees from '@/components/map/marker/WithAllTrees'
+import WithFilterableTrees from '@/components/map/marker/WithFilterableTrees'
 import createToast from '@/hooks/createToast'
 import { Tree, TreeUpdate as TreeUpdateReq } from '@green-ecolution/backend-client'
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
@@ -100,7 +100,7 @@ function LinkTreeToSensor() {
           </>
         }
       />
-      <WithAllTrees
+      <WithFilterableTrees
         selectedTrees={treeId ? [treeId] : []}
         onClick={(tree: Tree) => setTreeId(tree.id)}
       />

--- a/frontend/app/src/routes/_protected/map/treecluster/select/tree/index.tsx
+++ b/frontend/app/src/routes/_protected/map/treecluster/select/tree/index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, useNavigate, useBlocker } from '@tanstack/react-router
 import { Tree } from '@green-ecolution/backend-client'
 import { useCallback, useRef, useState } from 'react'
 import SelectedCard from '@/components/general/cards/SelectedCard'
-import WithAllTrees from '@/components/map/marker/WithAllTrees'
+import WithFilterableTrees from '@/components/map/marker/WithFilterableTrees'
 import MapSelectEntitiesModal from '@/components/map/MapSelectEntitiesModal'
 import {
   AlertDialog,
@@ -136,7 +136,7 @@ function SelectTrees() {
           </ul>
         }
       />
-      <WithAllTrees selectedTrees={treeIds} onClick={handleTreeClick} />
+      <WithFilterableTrees selectedTrees={treeIds} onClick={handleTreeClick} />
 
       <AlertDialog open={status === 'blocked'} onOpenChange={(open) => !open && reset?.()}>
         <AlertDialogContent>

--- a/frontend/app/src/routes/_protected/map/watering-plan/select/cluster/index.tsx
+++ b/frontend/app/src/routes/_protected/map/watering-plan/select/cluster/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate, useBlocker } from '@tanstack/react-router'
-import { TreeCluster } from '@green-ecolution/backend-client'
+import { TreeClusterInList } from '@green-ecolution/backend-client'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import {
   AlertDialog,
@@ -15,7 +15,7 @@ import {
 import { MoveRight, X } from 'lucide-react'
 import { WateringPlanForm } from '@/schema/wateringPlanSchema'
 import MapSelectEntitiesModal from '@/components/map/MapSelectEntitiesModal'
-import WithAllClusters from '@/components/map/marker/WithAllClusters'
+import WithFilterableClusters from '@/components/map/marker/WithFilterableClusters'
 import ShowRoutePreview from '@/components/map/marker/ShowRoutePreview'
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { treeClusterQuery, vehicleIdQuery } from '@/api/queries'
@@ -124,7 +124,7 @@ function SelectCluster() {
     setClusterIds((prev) => prev.filter((id) => id !== clusterId))
   }
 
-  const handleClick = (cluster: TreeCluster) => {
+  const handleClick = (cluster: TreeClusterInList) => {
     if (disabledClusters.includes(cluster.id)) return
 
     setClusterIds((prev) => {
@@ -194,7 +194,7 @@ function SelectCluster() {
           </ul>
         }
       />
-      <WithAllClusters
+      <WithFilterableClusters
         onClick={handleClick}
         highlightedClusters={clusterIds}
         disabledClusters={disabledClusters}


### PR DESCRIPTION
## Summary
- Add filter dialogs to tree and cluster selection pages on the map
- Create reusable `WithFilterableTrees` and `WithFilterableClusters` components

close #146

## Problem
On CRUD selection pages in the map, there were no filter options available. This made it difficult to find the right trees or clusters when selecting them for tree
clusters, sensors, or watering plans.

## Solution
Created two reusable wrapper components that combine filter functionality with entity selection:

### WithFilterableTrees
- Used on `/map/treecluster/select/tree/` and `/map/sensor/select/tree/`
- Filters: Watering status, cluster membership, planting year
- Conditionally renders `WithAllTrees` or `WithFilterdTrees` based on active filters

### WithFilterableClusters
- Used on `/map/watering-plan/select/cluster/`
- Filters: Watering status, region
- Preserves existing disabled clusters logic for water capacity validation

Both components use local filter state (no URL navigation) to avoid conflicts with existing route search params.

## Definition of Done
- [x] Code compiles without errors
- [x] All tests pass (`make test`)
- [x] No new linter warnings (`make lint`)
- [ ] Code reviewed by at least 1 person
- [ ] Documentation updated (if applicable)
- [x] Acceptance criteria from issue fulfilled

## Test Plan
- [x] Create a new tree cluster → select trees → verify filter button appears and filters work
- [x] Edit sensor → link tree → verify filter button appears and filters work
- [x] Create a new watering plan → select clusters → verify filter button appears and filters work
- [x] Verify selected entities persist after applying/resetting filters
- [x] Verify map dragging is disabled when filter dialog is open

## Screenshots (if applicable)

<img width="1475" height="321" alt="grafik" src="https://github.com/user-attachments/assets/2f82e3ee-91c2-4c82-af36-ed492db2a4dd" />

<img width="1468" height="387" alt="grafik" src="https://github.com/user-attachments/assets/7622cadb-1487-46a5-bad9-31a0af1d9afd" />

