### PR TITLE
feat(frontend): capture GPS location during sensor onboarding

### DIFF
--- a/frontend/app/src/components/debug/GeolocationDebugView.tsx
+++ b/frontend/app/src/components/debug/GeolocationDebugView.tsx
@@ -1,0 +1,272 @@
+import GPSStatusCard from '@/components/geolocation/GPSStatusCard'
+import LocationMapPreview from '@/components/geolocation/LocationMapPreview'
+import useGeolocation, { type GeolocationStatus } from '@/hooks/useGeolocation'
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@green-ecolution/ui'
+import { Compass, Crosshair, Loader2, MapPin } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+
+interface EnvInfo {
+  hasGeolocation: boolean
+  hasPermissionsApi: boolean
+  isSecureContext: boolean
+  userAgent: string
+}
+
+type PermissionLabel = PermissionState | 'unknown' | 'unavailable'
+
+const permissionBadge = (state: PermissionLabel) => {
+  switch (state) {
+    case 'granted':
+      return <Badge variant="success">{state}</Badge>
+    case 'denied':
+      return <Badge variant="error">{state}</Badge>
+    case 'prompt':
+      return <Badge variant="warning">{state}</Badge>
+    default:
+      return <Badge variant="muted">{state}</Badge>
+  }
+}
+
+const statusBadge = (status: GeolocationStatus) => {
+  switch (status) {
+    case 'watching':
+      return <Badge variant="success">watching</Badge>
+    case 'requesting':
+      return <Badge variant="warning">requesting</Badge>
+    case 'denied':
+      return <Badge variant="error">denied</Badge>
+    case 'unsupported':
+      return <Badge variant="error">unsupported</Badge>
+    case 'error':
+      return <Badge variant="error">error</Badge>
+    default:
+      return <Badge variant="muted">idle</Badge>
+  }
+}
+
+const boolBadge = (value: boolean) =>
+  value ? <Badge variant="success">true</Badge> : <Badge variant="error">false</Badge>
+
+const formatTime = (ts: number) => {
+  const d = new Date(ts)
+  return (
+    d.toLocaleTimeString('de-DE', { hour12: false }) +
+    '.' +
+    String(d.getMilliseconds()).padStart(3, '0')
+  )
+}
+
+const KV = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div className="flex items-start justify-between gap-3">
+    <span className="text-muted-foreground shrink-0">{label}</span>
+    <span className="text-right">{children}</span>
+  </div>
+)
+
+const EmptyMapState = ({ status }: { status: GeolocationStatus }) => {
+  const isLoading = status === 'requesting'
+  return (
+    <div
+      className="flex aspect-[4/3] sm:aspect-[16/10] lg:aspect-auto lg:h-full lg:min-h-72 w-full flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-dark-200 bg-dark-50 text-muted-foreground"
+      role="status"
+      aria-live="polite"
+    >
+      {isLoading ? (
+        <>
+          <Loader2 className="size-6 animate-spin" aria-hidden />
+          <p className="text-sm">GPS wird ermittelt …</p>
+        </>
+      ) : (
+        <>
+          <Crosshair className="size-6" aria-hidden />
+          <p className="text-sm">Noch keine Position erfasst</p>
+        </>
+      )}
+    </div>
+  )
+}
+
+const GeolocationDebugView = () => {
+  const { status, position, history, errorMessage, start, stop, reset } = useGeolocation({
+    trackHistory: true,
+  })
+
+  const [permission, setPermission] = useState<PermissionLabel>('unknown')
+  const env = useMemo<EnvInfo>(() => {
+    if (typeof window === 'undefined') {
+      return { hasGeolocation: false, hasPermissionsApi: false, isSecureContext: false, userAgent: '' }
+    }
+    return {
+      hasGeolocation: !!navigator.geolocation,
+      hasPermissionsApi: typeof navigator.permissions?.query === 'function',
+      isSecureContext: window.isSecureContext,
+      userAgent: navigator.userAgent,
+    }
+  }, [])
+
+  // Observe geolocation permission state.
+  useEffect(() => {
+    let permStatus: PermissionStatus | null = null
+    const sub = async () => {
+      try {
+        permStatus = await navigator.permissions.query({ name: 'geolocation' as PermissionName })
+        setPermission(permStatus.state)
+        permStatus.onchange = () => {
+          if (permStatus) setPermission(permStatus.state)
+        }
+      } catch {
+        setPermission('unavailable')
+      }
+    }
+    void sub()
+    return () => {
+      if (permStatus) permStatus.onchange = null
+    }
+  }, [])
+
+  const isWatching = status === 'watching' || status === 'requesting'
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* 1. Hero readout band */}
+      <div className="grid gap-4 lg:grid-cols-5">
+        <div className="lg:col-span-3">
+          {position ? (
+            <LocationMapPreview
+              latitude={position.latitude}
+              longitude={position.longitude}
+              accuracyMeters={position.accuracy}
+              className="aspect-[4/3] sm:aspect-[16/10] lg:aspect-auto lg:h-full lg:min-h-72"
+              ariaLabel="Live-Karte mit aktueller GPS-Position"
+            />
+          ) : (
+            <EmptyMapState status={status} />
+          )}
+        </div>
+        <div className="lg:col-span-2">
+          <GPSStatusCard fix={position} />
+        </div>
+      </div>
+
+      {/* 2. Controls */}
+      <div className="flex flex-wrap gap-2">
+        <Button size="sm" onClick={() => void start()} disabled={isWatching}>
+          <MapPin className="size-4" />
+          Ortung starten
+        </Button>
+        <Button size="sm" variant="outline" onClick={stop} disabled={!isWatching}>
+          Ortung stoppen
+        </Button>
+        <Button size="sm" variant="ghost" onClick={reset} disabled={history.length === 0}>
+          Log leeren
+        </Button>
+      </div>
+
+      {/* 3. Diagnostics grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Card variant="outlined">
+          <CardHeader>
+            <CardTitle className="text-base">Umgebung</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2 text-sm">
+            <KV label="Secure Context">{boolBadge(env.isSecureContext)}</KV>
+            <KV label="navigator.geolocation">{boolBadge(env.hasGeolocation)}</KV>
+            <KV label="Permissions API">{boolBadge(env.hasPermissionsApi)}</KV>
+            <KV label="User-Agent">
+              <span className="font-mono text-xs break-all text-muted-foreground">
+                {env.userAgent}
+              </span>
+            </KV>
+          </CardContent>
+        </Card>
+
+        <Card variant="outlined">
+          <CardHeader>
+            <CardTitle className="text-base">Permission &amp; Sensoren</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2 text-sm">
+            <KV label="navigator.permissions">{permissionBadge(permission)}</KV>
+            <KV label="Hook-Status">{statusBadge(status)}</KV>
+            <KV label="Erfasste Fixes">
+              <span className="font-mono">{history.length}</span>
+            </KV>
+            <KV label="Heading">
+              <span className="font-mono">
+                {position?.heading != null ? `${position.heading.toFixed(1)}°` : '—'}
+              </span>
+            </KV>
+            <KV label="Speed">
+              <span className="font-mono">
+                {position?.speed != null ? `${position.speed.toFixed(2)} m/s` : '—'}
+              </span>
+            </KV>
+            {errorMessage && (
+              <p className="mt-2 text-xs font-mono text-red break-all" role="alert">
+                <Compass className="inline size-3 mr-1" aria-hidden />
+                {errorMessage}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 4. Verlauf */}
+      <Card variant="outlined">
+        <CardHeader>
+          <CardTitle className="text-base">
+            Verlauf <span className="text-muted-foreground font-normal">({history.length})</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0 px-0">
+          {history.length === 0 ? (
+            <p className="px-6 py-4 text-sm text-muted-foreground">
+              Noch keine Position erfasst. Starte die Ortung, um Live-Daten zu sehen.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-32">Zeit</TableHead>
+                  <TableHead>Lat / Lng</TableHead>
+                  <TableHead className="w-28">Accuracy</TableHead>
+                  <TableHead className="w-24">Heading</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {history.map((fix) => (
+                  <TableRow key={fix.timestamp}>
+                    <TableCell className="font-mono text-xs">{formatTime(fix.timestamp)}</TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {fix.latitude.toFixed(6)}, {fix.longitude.toFixed(6)}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      ± {fix.accuracy.toFixed(1)} m
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {fix.heading != null ? `${fix.heading.toFixed(0)}°` : '—'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default GeolocationDebugView

--- a/frontend/app/src/components/debug/GeolocationDebugView.tsx
+++ b/frontend/app/src/components/debug/GeolocationDebugView.tsx
@@ -107,7 +107,12 @@ const GeolocationDebugView = () => {
   const [permission, setPermission] = useState<PermissionLabel>('unknown')
   const env = useMemo<EnvInfo>(() => {
     if (typeof window === 'undefined') {
-      return { hasGeolocation: false, hasPermissionsApi: false, isSecureContext: false, userAgent: '' }
+      return {
+        hasGeolocation: false,
+        hasPermissionsApi: false,
+        isSecureContext: false,
+        userAgent: '',
+      }
     }
     return {
       hasGeolocation: !!navigator.geolocation,

--- a/frontend/app/src/components/debug/GeolocationDebugView.tsx
+++ b/frontend/app/src/components/debug/GeolocationDebugView.tsx
@@ -16,7 +16,7 @@ import {
   TableRow,
 } from '@green-ecolution/ui'
 import { Compass, Crosshair, Loader2, MapPin } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 interface EnvInfo {
   hasGeolocation: boolean
@@ -105,7 +105,8 @@ const GeolocationDebugView = () => {
   })
 
   const [permission, setPermission] = useState<PermissionLabel>('unknown')
-  const env = useMemo<EnvInfo>(() => {
+  // Captured once on first render — window/navigator are stable within a session.
+  const [env] = useState<EnvInfo>(() => {
     if (typeof window === 'undefined') {
       return {
         hasGeolocation: false,
@@ -120,25 +121,29 @@ const GeolocationDebugView = () => {
       isSecureContext: window.isSecureContext,
       userAgent: navigator.userAgent,
     }
-  }, [])
+  })
 
   // Observe geolocation permission state.
   useEffect(() => {
     let permStatus: PermissionStatus | null = null
+    let handler: (() => void) | null = null
     const sub = async () => {
       try {
         permStatus = await navigator.permissions.query({ name: 'geolocation' as PermissionName })
         setPermission(permStatus.state)
-        permStatus.onchange = () => {
+        handler = () => {
           if (permStatus) setPermission(permStatus.state)
         }
+        permStatus.addEventListener('change', handler)
       } catch {
         setPermission('unavailable')
       }
     }
     void sub()
     return () => {
-      if (permStatus) permStatus.onchange = null
+      if (permStatus && handler) {
+        permStatus.removeEventListener('change', handler)
+      }
     }
   }, [])
 
@@ -156,6 +161,7 @@ const GeolocationDebugView = () => {
               accuracyMeters={position.accuracy}
               className="aspect-[4/3] sm:aspect-[16/10] lg:aspect-auto lg:h-full lg:min-h-72"
               ariaLabel="Live-Karte mit aktueller GPS-Position"
+              interactive
             />
           ) : (
             <EmptyMapState status={status} />

--- a/frontend/app/src/components/geolocation/GPSStatusCard.tsx
+++ b/frontend/app/src/components/geolocation/GPSStatusCard.tsx
@@ -1,0 +1,74 @@
+import { AccuracyBadge, Card, CardContent, CardHeader, CardTitle } from '@green-ecolution/ui'
+import { MapPin } from 'lucide-react'
+import type { GeolocationFix } from '@/hooks/useGeolocation'
+
+interface GPSStatusCardProps {
+  fix: GeolocationFix | null
+  /** Optional headline override. */
+  title?: string
+}
+
+const formatCoord = (value: number) => value.toFixed(6)
+
+const formatTime = (timestamp: number) => {
+  const d = new Date(timestamp)
+  return d.toLocaleTimeString('de-DE', { hour12: false })
+}
+
+const formatAltitude = (alt: number | null, altAcc: number | null) => {
+  if (alt == null) return '—'
+  const accSuffix = altAcc != null ? ` ± ${altAcc.toFixed(0)} m` : ''
+  return `${alt.toFixed(1)} m${accSuffix}`
+}
+
+const GPSStatusCard = ({ fix, title = 'Aktuelle Position' }: GPSStatusCardProps) => {
+  return (
+    <Card variant="outlined">
+      <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
+        <div className="flex items-center gap-2">
+          <MapPin className="size-4 text-green-dark" aria-hidden />
+          <CardTitle className="text-base">{title}</CardTitle>
+        </div>
+        <AccuracyBadge accuracyMeters={fix?.accuracy ?? null} />
+      </CardHeader>
+      <CardContent>
+        <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+          <Field label="Breitengrad" value={fix ? formatCoord(fix.latitude) : '—'} mono />
+          <Field label="Längengrad" value={fix ? formatCoord(fix.longitude) : '—'} mono />
+          <Field
+            label="Genauigkeit"
+            value={fix ? `± ${fix.accuracy.toFixed(1)} m` : '—'}
+            mono
+          />
+          <Field
+            label="Höhe"
+            value={formatAltitude(fix?.altitude ?? null, fix?.altitudeAccuracy ?? null)}
+            mono
+          />
+          <Field
+            label="Erfasst um"
+            value={fix ? formatTime(fix.timestamp) : '—'}
+            mono
+            className="col-span-2"
+          />
+        </dl>
+      </CardContent>
+    </Card>
+  )
+}
+
+interface FieldProps {
+  label: string
+  value: string
+  mono?: boolean
+  className?: string
+}
+
+const Field = ({ label, value, mono, className }: FieldProps) => (
+  <div className={className}>
+    <dt className="text-xs uppercase tracking-wide text-muted-foreground">{label}</dt>
+    <dd className={mono ? 'mt-0.5 font-mono text-sm text-foreground' : 'mt-0.5 text-sm'}>{value}</dd>
+  </div>
+)
+
+export default GPSStatusCard

--- a/frontend/app/src/components/geolocation/GPSStatusCard.tsx
+++ b/frontend/app/src/components/geolocation/GPSStatusCard.tsx
@@ -35,11 +35,7 @@ const GPSStatusCard = ({ fix, title = 'Aktuelle Position' }: GPSStatusCardProps)
         <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
           <Field label="Breitengrad" value={fix ? formatCoord(fix.latitude) : '—'} mono />
           <Field label="Längengrad" value={fix ? formatCoord(fix.longitude) : '—'} mono />
-          <Field
-            label="Genauigkeit"
-            value={fix ? `± ${fix.accuracy.toFixed(1)} m` : '—'}
-            mono
-          />
+          <Field label="Genauigkeit" value={fix ? `± ${fix.accuracy.toFixed(1)} m` : '—'} mono />
           <Field
             label="Höhe"
             value={formatAltitude(fix?.altitude ?? null, fix?.altitudeAccuracy ?? null)}
@@ -67,7 +63,9 @@ interface FieldProps {
 const Field = ({ label, value, mono, className }: FieldProps) => (
   <div className={className}>
     <dt className="text-xs uppercase tracking-wide text-muted-foreground">{label}</dt>
-    <dd className={mono ? 'mt-0.5 font-mono text-sm text-foreground' : 'mt-0.5 text-sm'}>{value}</dd>
+    <dd className={mono ? 'mt-0.5 font-mono text-sm text-foreground' : 'mt-0.5 text-sm'}>
+      {value}
+    </dd>
   </div>
 )
 

--- a/frontend/app/src/components/geolocation/GeolocationPermissionNotice.tsx
+++ b/frontend/app/src/components/geolocation/GeolocationPermissionNotice.tsx
@@ -1,0 +1,70 @@
+import {
+  Alert,
+  AlertContent,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+  Button,
+} from '@green-ecolution/ui'
+
+interface GeolocationPermissionNoticeProps {
+  status: 'denied' | 'unsupported' | 'error'
+  errorMessage?: string | null
+  onRetry?: () => void
+}
+
+const COPY = {
+  denied: {
+    variant: 'destructive' as const,
+    title: 'Standortzugriff verweigert',
+    description:
+      'Um den Sensorstandort automatisch zu erfassen, benötigt die App Zugriff auf deinen GPS-Standort. Erlaube den Zugriff in den Einstellungen deines Browsers und versuche es erneut.',
+  },
+  unsupported: {
+    variant: 'warning' as const,
+    title: 'Standort nicht verfügbar',
+    description:
+      'Dein Browser oder Gerät unterstützt die Geolocation-API in diesem Kontext nicht. Stelle sicher, dass du die App über HTTPS aufrufst.',
+  },
+  error: {
+    variant: 'destructive' as const,
+    title: 'Standort konnte nicht ermittelt werden',
+    description:
+      'Beim Zugriff auf die Position ist ein Fehler aufgetreten. Prüfe, ob GPS aktiviert ist und du im Freien stehst.',
+  },
+} as const
+
+const GeolocationPermissionNotice = ({
+  status,
+  errorMessage,
+  onRetry,
+}: GeolocationPermissionNoticeProps) => {
+  const copy = COPY[status]
+  const canRetry = (status === 'denied' || status === 'error') && onRetry
+
+  return (
+    <div className="flex flex-col gap-3 items-center">
+      <Alert variant={copy.variant} className="w-full">
+        <div className="flex items-start gap-3">
+          <AlertIcon variant={copy.variant} />
+          <AlertContent>
+            <AlertTitle>{copy.title}</AlertTitle>
+            <AlertDescription>{copy.description}</AlertDescription>
+            {errorMessage && (
+              <AlertDescription className="font-mono text-xs mt-2 opacity-80">
+                {errorMessage}
+              </AlertDescription>
+            )}
+          </AlertContent>
+        </div>
+      </Alert>
+      {canRetry && (
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          Erneut versuchen
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export default GeolocationPermissionNotice

--- a/frontend/app/src/components/geolocation/InlineGPSReadout.tsx
+++ b/frontend/app/src/components/geolocation/InlineGPSReadout.tsx
@@ -1,0 +1,42 @@
+import type { GeolocationFix, GeolocationStatus } from '@/hooks/useGeolocation'
+import { AccuracyBadge } from '@green-ecolution/ui'
+import { Loader2, MapPinOff } from 'lucide-react'
+
+interface InlineGPSReadoutProps {
+  position: GeolocationFix | null
+  status: GeolocationStatus
+}
+
+const InlineGPSReadout = ({ position, status }: InlineGPSReadoutProps) => {
+  const isLoading = status === 'requesting' || status === 'idle'
+  const isUnavailable =
+    status === 'denied' || status === 'unsupported' || status === 'error'
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-dark-100 pt-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs uppercase tracking-widest text-muted-foreground">
+          Erfasster Standort
+        </span>
+        <AccuracyBadge accuracyMeters={position?.accuracy ?? null} />
+      </div>
+      {position ? (
+        <code className="font-mono text-sm md:text-base break-all bg-dark-50 rounded-lg px-3 py-2 border border-dark-100">
+          {position.latitude.toFixed(6)}, {position.longitude.toFixed(6)}
+        </code>
+      ) : isLoading ? (
+        <p className="flex items-center gap-2 text-sm text-muted-foreground px-3 py-2">
+          <Loader2 className="size-4 animate-spin" aria-hidden />
+          GPS-Standort wird ermittelt …
+        </p>
+      ) : isUnavailable ? (
+        <p className="flex items-center gap-2 text-sm text-red px-3 py-2">
+          <MapPinOff className="size-4" aria-hidden />
+          Standort konnte nicht ermittelt werden.
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+export default InlineGPSReadout

--- a/frontend/app/src/components/geolocation/InlineGPSReadout.tsx
+++ b/frontend/app/src/components/geolocation/InlineGPSReadout.tsx
@@ -9,8 +9,7 @@ interface InlineGPSReadoutProps {
 
 const InlineGPSReadout = ({ position, status }: InlineGPSReadoutProps) => {
   const isLoading = status === 'requesting' || status === 'idle'
-  const isUnavailable =
-    status === 'denied' || status === 'unsupported' || status === 'error'
+  const isUnavailable = status === 'denied' || status === 'unsupported' || status === 'error'
 
   return (
     <div className="flex flex-col gap-2 border-t border-dark-100 pt-3">

--- a/frontend/app/src/components/geolocation/LocationMapPreview.tsx
+++ b/frontend/app/src/components/geolocation/LocationMapPreview.tsx
@@ -1,0 +1,93 @@
+import defaultIconPng from 'leaflet/dist/images/marker-icon.png'
+import shadowIconPng from 'leaflet/dist/images/marker-shadow.png'
+import L, { Icon } from 'leaflet'
+import { useEffect } from 'react'
+import { Circle, MapContainer, Marker, TileLayer, useMap } from 'react-leaflet'
+import { cn } from '@green-ecolution/ui'
+
+const markerIcon = new Icon({
+  iconUrl: defaultIconPng,
+  shadowUrl: shadowIconPng,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+})
+
+interface LocationMapPreviewProps {
+  latitude: number
+  longitude: number
+  /** Accuracy radius in meters — drawn as a circle around the marker. */
+  accuracyMeters?: number | null
+  /** Tailwind classes applied to the wrapper. */
+  className?: string
+  /** Initial zoom (default: 18 — close enough to read a city block). */
+  zoom?: number
+  /** ARIA label for the wrapper. */
+  ariaLabel?: string
+}
+
+const RecenterOnPosition = ({ latitude, longitude }: { latitude: number; longitude: number }) => {
+  const map = useMap()
+  useEffect(() => {
+    map.setView([latitude, longitude], map.getZoom(), { animate: true })
+  }, [map, latitude, longitude])
+  return null
+}
+
+const LocationMapPreview = ({
+  latitude,
+  longitude,
+  accuracyMeters,
+  className,
+  zoom = 18,
+  ariaLabel = 'Karte mit aktueller GPS-Position',
+}: LocationMapPreviewProps) => {
+  const center = L.latLng(latitude, longitude)
+  const radius = accuracyMeters && accuracyMeters > 0 ? accuracyMeters : null
+
+  return (
+    <div
+      role="img"
+      aria-label={ariaLabel}
+      className={cn(
+        'relative w-full overflow-hidden rounded-2xl border border-dark-100 shadow-cards',
+        'aspect-[4/3] sm:aspect-[16/10]',
+        className,
+      )}
+    >
+      <MapContainer
+        preferCanvas
+        zoomControl={false}
+        attributionControl={false}
+        scrollWheelZoom={false}
+        className="z-0 h-full w-full"
+        center={center}
+        zoom={zoom}
+        maxZoom={19}
+        minZoom={3}
+      >
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" keepBuffer={2} />
+        {radius && (
+          <Circle
+            center={center}
+            radius={radius}
+            pathOptions={{
+              color: 'oklch(0.62 0.20 145)',
+              fillColor: 'oklch(0.62 0.20 145)',
+              fillOpacity: 0.15,
+              weight: 1.5,
+            }}
+          />
+        )}
+        <Marker position={center} icon={markerIcon} />
+        <RecenterOnPosition latitude={latitude} longitude={longitude} />
+      </MapContainer>
+      <span className="pointer-events-none absolute bottom-1 right-2 text-[10px] text-dark-600/80 font-mono bg-white/70 px-1 rounded">
+        © OpenStreetMap
+      </span>
+    </div>
+  )
+}
+
+export default LocationMapPreview

--- a/frontend/app/src/components/geolocation/LocationMapPreview.tsx
+++ b/frontend/app/src/components/geolocation/LocationMapPreview.tsx
@@ -25,12 +25,27 @@ interface LocationMapPreviewProps {
   zoom?: number
   /** ARIA label for the wrapper. */
   ariaLabel?: string
+  /**
+   * When `true`, users can pan and pinch-zoom. Default: `false` — the preview
+   * stays locked on the reported position, which is the right default for
+   * onboarding summaries where the map is an anchor, not a tool.
+   */
+  interactive?: boolean
+  /**
+   * Keep the marker centered as the position updates. When `true`, re-centers
+   * only if the new position drifts out of the current viewport, so a user
+   * who panned manually isn't yanked back to center on every update.
+   * Default: `true`.
+   */
+  follow?: boolean
 }
 
-const RecenterOnPosition = ({ latitude, longitude }: { latitude: number; longitude: number }) => {
+const FollowPosition = ({ latitude, longitude }: { latitude: number; longitude: number }) => {
   const map = useMap()
   useEffect(() => {
-    map.setView([latitude, longitude], map.getZoom(), { animate: true })
+    const next = L.latLng(latitude, longitude)
+    if (map.getBounds().contains(next)) return
+    map.panTo(next, { animate: true })
   }, [map, latitude, longitude])
   return null
 }
@@ -42,13 +57,16 @@ const LocationMapPreview = ({
   className,
   zoom = 18,
   ariaLabel = 'Karte mit aktueller GPS-Position',
+  interactive = false,
+  follow = true,
 }: LocationMapPreviewProps) => {
   const center = L.latLng(latitude, longitude)
   const radius = accuracyMeters && accuracyMeters > 0 ? accuracyMeters : null
 
   return (
     <div
-      role="img"
+      // A dragging/zooming container isn't an `img` — set role only when locked.
+      role={interactive ? undefined : 'img'}
       aria-label={ariaLabel}
       className={cn(
         'relative w-full overflow-hidden rounded-2xl border border-dark-100 shadow-cards',
@@ -60,7 +78,12 @@ const LocationMapPreview = ({
         preferCanvas
         zoomControl={false}
         attributionControl={false}
-        scrollWheelZoom={false}
+        dragging={interactive}
+        touchZoom={interactive}
+        doubleClickZoom={interactive}
+        scrollWheelZoom={interactive}
+        boxZoom={interactive}
+        keyboard={interactive}
         className="z-0 h-full w-full"
         center={center}
         zoom={zoom}
@@ -81,7 +104,7 @@ const LocationMapPreview = ({
           />
         )}
         <Marker position={center} icon={markerIcon} />
-        <RecenterOnPosition latitude={latitude} longitude={longitude} />
+        {follow && <FollowPosition latitude={latitude} longitude={longitude} />}
       </MapContainer>
       <span className="pointer-events-none absolute bottom-1 right-2 text-[10px] text-dark-600/80 font-mono bg-white/70 px-1 rounded">
         © OpenStreetMap

--- a/frontend/app/src/components/scanner/QRScanResult.tsx
+++ b/frontend/app/src/components/scanner/QRScanResult.tsx
@@ -9,6 +9,8 @@ interface QRScanResultProps {
   continueLabel?: string
   /** If provided, called instead of the default placeholder toast */
   onContinue?: (sensorId: string) => void
+  /** Optional extra block rendered below the sensor-ID (e.g. GPS readout). */
+  extra?: React.ReactNode
 }
 
 const QRScanResult = ({
@@ -16,6 +18,7 @@ const QRScanResult = ({
   onScanAgain,
   continueLabel = 'Weiter',
   onContinue,
+  extra,
 }: QRScanResultProps) => {
   const showToast = createToast()
 
@@ -35,11 +38,14 @@ const QRScanResult = ({
           <CardTitle className="text-xl">QR-Code erkannt</CardTitle>
         </div>
       </CardHeader>
-      <CardContent className="flex flex-col gap-2">
-        <span className="text-xs uppercase tracking-widest text-muted-foreground">Sensor-ID</span>
-        <code className="font-mono text-lg md:text-xl font-semibold break-all bg-dark-50 rounded-lg px-3 py-2 border border-dark-100">
-          {sensorId}
-        </code>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <span className="text-xs uppercase tracking-widest text-muted-foreground">Sensor-ID</span>
+          <code className="font-mono text-lg md:text-xl font-semibold break-all bg-dark-50 rounded-lg px-3 py-2 border border-dark-100">
+            {sensorId}
+          </code>
+        </div>
+        {extra}
       </CardContent>
       <CardFooter className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2">
         <Button variant="outline" size="sm" onClick={onScanAgain} className="w-full sm:w-auto">

--- a/frontend/app/src/components/scanner/QRScannerView.tsx
+++ b/frontend/app/src/components/scanner/QRScannerView.tsx
@@ -32,11 +32,13 @@ interface QRScannerViewProps {
   continueLabel?: string
   /** Invoked with the decoded value when the user confirms via the continue button */
   onContinue?: (value: string) => void
+  /** Optional extra block rendered inside the success card (e.g. GPS readout). */
+  resultExtra?: React.ReactNode
 }
 
 const SCAN_VIBRATE_MS = 40
 
-const QRScannerView = ({ continueLabel, onContinue }: QRScannerViewProps = {}) => {
+const QRScannerView = ({ continueLabel, onContinue, resultExtra }: QRScannerViewProps = {}) => {
   const showToast = createToast()
 
   const { videoRef, status, scannedData, startScanning, resetScan } = useQRScanner({
@@ -98,6 +100,7 @@ const QRScannerView = ({ continueLabel, onContinue }: QRScannerViewProps = {}) =
           onScanAgain={handleScanAgain}
           continueLabel={continueLabel}
           onContinue={onContinue}
+          extra={resultExtra}
         />
       )}
 

--- a/frontend/app/src/components/scanner/QRScannerView.tsx
+++ b/frontend/app/src/components/scanner/QRScannerView.tsx
@@ -33,12 +33,12 @@ interface QRScannerViewProps {
   /** Invoked with the decoded value when the user confirms via the continue button */
   onContinue?: (value: string) => void
   /** Optional extra block rendered inside the success card (e.g. GPS readout). */
-  resultExtra?: React.ReactNode
+  extra?: React.ReactNode
 }
 
 const SCAN_VIBRATE_MS = 40
 
-const QRScannerView = ({ continueLabel, onContinue, resultExtra }: QRScannerViewProps = {}) => {
+const QRScannerView = ({ continueLabel, onContinue, extra }: QRScannerViewProps = {}) => {
   const showToast = createToast()
 
   const { videoRef, status, scannedData, startScanning, resetScan } = useQRScanner({
@@ -100,7 +100,7 @@ const QRScannerView = ({ continueLabel, onContinue, resultExtra }: QRScannerView
           onScanAgain={handleScanAgain}
           continueLabel={continueLabel}
           onContinue={onContinue}
-          extra={resultExtra}
+          extra={extra}
         />
       )}
 

--- a/frontend/app/src/components/sensor/SensorGeolocationSummary.tsx
+++ b/frontend/app/src/components/sensor/SensorGeolocationSummary.tsx
@@ -1,0 +1,125 @@
+import GeolocationPermissionNotice from '@/components/geolocation/GeolocationPermissionNotice'
+import GPSStatusCard from '@/components/geolocation/GPSStatusCard'
+import LocationMapPreview from '@/components/geolocation/LocationMapPreview'
+import type { GeolocationFix, GeolocationStatus } from '@/hooks/useGeolocation'
+import {
+  AccuracyBadge,
+  Card,
+  CardContent,
+  Button,
+  InlineAlert,
+} from '@green-ecolution/ui'
+import { CheckCircle2, Crosshair, Loader2, MapPin, RotateCw } from 'lucide-react'
+
+interface SensorGeolocationSummaryProps {
+  sensorId: string
+  position: GeolocationFix | null
+  status: GeolocationStatus
+  errorMessage: string | null
+  onScanAgain: () => void
+  onRelocate: () => void
+}
+
+const MapPlaceholder = ({ status }: { status: GeolocationStatus }) => {
+  const isLoading = status === 'requesting' || status === 'idle'
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex aspect-[4/3] sm:aspect-[16/10] w-full flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-dark-200 bg-dark-50 text-muted-foreground"
+    >
+      {isLoading ? (
+        <>
+          <Loader2 className="size-6 animate-spin" aria-hidden />
+          <p className="text-sm">GPS wird ermittelt …</p>
+        </>
+      ) : (
+        <>
+          <Crosshair className="size-6" aria-hidden />
+          <p className="text-sm">Keine Position verfügbar</p>
+        </>
+      )}
+    </div>
+  )
+}
+
+const SensorGeolocationSummary = ({
+  sensorId,
+  position,
+  status,
+  errorMessage,
+  onScanAgain,
+  onRelocate,
+}: SensorGeolocationSummaryProps) => {
+  const noticeStatus: 'denied' | 'unsupported' | 'error' | null =
+    status === 'denied' || status === 'unsupported' || status === 'error' ? status : null
+
+  return (
+    <div className="mx-auto w-full max-w-3xl pb-[env(safe-area-inset-bottom)]">
+      {/* Status line */}
+      <div className="flex items-center gap-2 text-sm font-medium text-green-dark mb-4">
+        <CheckCircle2 className="size-4" aria-hidden />
+        <span>Sensor erfasst</span>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 md:gap-6">
+        {/* Sensor-ID — spans both columns */}
+        <Card variant="outlined" className="md:col-span-2">
+          <CardContent className="flex flex-col gap-3 p-5 sm:flex-row sm:items-end sm:justify-between">
+            <div className="min-w-0">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Sensor-ID</p>
+              <p className="mt-1 font-mono text-2xl font-semibold tracking-tight break-all">
+                {sensorId}
+              </p>
+            </div>
+            <AccuracyBadge accuracyMeters={position?.accuracy ?? null} />
+          </CardContent>
+        </Card>
+
+        {/* Map (anchor) */}
+        <div className="md:col-span-1">
+          {position ? (
+            <LocationMapPreview
+              latitude={position.latitude}
+              longitude={position.longitude}
+              accuracyMeters={position.accuracy}
+            />
+          ) : noticeStatus ? (
+            <GeolocationPermissionNotice
+              status={noticeStatus}
+              errorMessage={errorMessage}
+              onRetry={noticeStatus === 'unsupported' ? undefined : onRelocate}
+            />
+          ) : (
+            <MapPlaceholder status={status} />
+          )}
+        </div>
+
+        {/* GPS status */}
+        <div className="md:col-span-1">
+          <GPSStatusCard fix={position} title="Erfasster Standort" />
+        </div>
+
+        {/* Actions */}
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:col-span-2">
+          <Button variant="outline" onClick={onScanAgain}>
+            <RotateCw className="size-4" />
+            Erneut scannen
+          </Button>
+          <Button onClick={onRelocate} disabled={status === 'requesting'}>
+            <MapPin className="size-4" />
+            Erneut lokalisieren
+          </Button>
+        </div>
+
+        <InlineAlert
+          variant="warning"
+          description="Die Speicherung des Sensors ist noch nicht implementiert."
+          className="md:col-span-2 w-full"
+        />
+      </div>
+    </div>
+  )
+}
+
+export default SensorGeolocationSummary

--- a/frontend/app/src/components/sensor/SensorGeolocationSummary.tsx
+++ b/frontend/app/src/components/sensor/SensorGeolocationSummary.tsx
@@ -2,7 +2,7 @@ import GeolocationPermissionNotice from '@/components/geolocation/GeolocationPer
 import GPSStatusCard from '@/components/geolocation/GPSStatusCard'
 import LocationMapPreview from '@/components/geolocation/LocationMapPreview'
 import type { GeolocationFix, GeolocationStatus } from '@/hooks/useGeolocation'
-import { AccuracyBadge, Card, CardContent, Button, InlineAlert } from '@green-ecolution/ui'
+import { Card, CardContent, Button, InlineAlert } from '@green-ecolution/ui'
 import { CheckCircle2, Crosshair, Loader2, MapPin, RotateCw } from 'lucide-react'
 
 interface SensorGeolocationSummaryProps {
@@ -56,17 +56,20 @@ const SensorGeolocationSummary = ({
         <span>Sensor erfasst</span>
       </div>
 
+      <InlineAlert
+        variant="warning"
+        description="Die Speicherung des Sensors ist noch nicht implementiert."
+        className="mb-4 w-full"
+      />
+
       <div className="grid gap-4 md:grid-cols-2 md:gap-6">
         {/* Sensor-ID — spans both columns */}
         <Card variant="outlined" className="md:col-span-2">
-          <CardContent className="flex flex-col gap-3 p-5 sm:flex-row sm:items-end sm:justify-between">
-            <div className="min-w-0">
-              <p className="text-xs uppercase tracking-wide text-muted-foreground">Sensor-ID</p>
-              <p className="mt-1 font-mono text-2xl font-semibold tracking-tight break-all">
-                {sensorId}
-              </p>
-            </div>
-            <AccuracyBadge accuracyMeters={position?.accuracy ?? null} />
+          <CardContent className="p-5">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Sensor-ID</p>
+            <p className="mt-1 font-mono text-2xl font-semibold tracking-tight break-all">
+              {sensorId}
+            </p>
           </CardContent>
         </Card>
 
@@ -94,23 +97,17 @@ const SensorGeolocationSummary = ({
           <GPSStatusCard fix={position} title="Erfasster Standort" />
         </div>
 
-        {/* Actions */}
+        {/* Actions — both secondary until "Sensor speichern" exists. */}
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:col-span-2">
           <Button variant="outline" onClick={onScanAgain}>
             <RotateCw className="size-4" />
             Erneut scannen
           </Button>
-          <Button onClick={onRelocate} disabled={status === 'requesting'}>
+          <Button variant="outline" onClick={onRelocate} disabled={status === 'requesting'}>
             <MapPin className="size-4" />
             Erneut lokalisieren
           </Button>
         </div>
-
-        <InlineAlert
-          variant="warning"
-          description="Die Speicherung des Sensors ist noch nicht implementiert."
-          className="md:col-span-2 w-full"
-        />
       </div>
     </div>
   )

--- a/frontend/app/src/components/sensor/SensorGeolocationSummary.tsx
+++ b/frontend/app/src/components/sensor/SensorGeolocationSummary.tsx
@@ -2,13 +2,7 @@ import GeolocationPermissionNotice from '@/components/geolocation/GeolocationPer
 import GPSStatusCard from '@/components/geolocation/GPSStatusCard'
 import LocationMapPreview from '@/components/geolocation/LocationMapPreview'
 import type { GeolocationFix, GeolocationStatus } from '@/hooks/useGeolocation'
-import {
-  AccuracyBadge,
-  Card,
-  CardContent,
-  Button,
-  InlineAlert,
-} from '@green-ecolution/ui'
+import { AccuracyBadge, Card, CardContent, Button, InlineAlert } from '@green-ecolution/ui'
 import { CheckCircle2, Crosshair, Loader2, MapPin, RotateCw } from 'lucide-react'
 
 interface SensorGeolocationSummaryProps {

--- a/frontend/app/src/hooks/useGeolocation.ts
+++ b/frontend/app/src/hooks/useGeolocation.ts
@@ -22,11 +22,13 @@ export interface GeolocationFix {
 interface UseGeolocationOptions {
   /** Capture every position update in `history` (e.g. for the debug view). */
   trackHistory?: boolean
-  /** Auto-start watching on mount. */
+  /** Auto-start watching on mount. Options below are read once at start. */
   autoStart?: boolean
-  /** Forwarded to the Geolocation API. Defaults: high accuracy, 15s timeout. */
+  /** Forwarded to the Geolocation API. Default: high accuracy. */
   enableHighAccuracy?: boolean
+  /** Forwarded to the Geolocation API. Default: Infinity (no per-fix timeout). */
   timeout?: number
+  /** Forwarded to the Geolocation API. Default: 0. */
   maximumAge?: number
   /** Invoked once the first fix is delivered. */
   onLocated?: (fix: GeolocationFix) => void
@@ -37,9 +39,14 @@ interface UseGeolocationReturn {
   position: GeolocationFix | null
   history: GeolocationFix[]
   errorMessage: string | null
-  start: () => Promise<void>
+  /** Register a watch and resolve with the first fix (or reject on fatal error). */
+  start: () => Promise<GeolocationFix | null>
+  /** Stop the active watch. Keeps the last known position. */
   stop: () => void
+  /** Stop + clear state. */
   reset: () => void
+  /** Atomic stop + start — prefer this over calling reset()+start() manually. */
+  relocate: () => Promise<GeolocationFix | null>
 }
 
 const toFix = (position: GeolocationPosition): GeolocationFix => ({
@@ -57,13 +64,22 @@ const useGeolocation = ({
   trackHistory = false,
   autoStart = false,
   enableHighAccuracy = true,
-  timeout = 15000,
+  timeout,
   maximumAge = 0,
   onLocated,
 }: UseGeolocationOptions = {}): UseGeolocationReturn => {
   const watchIdRef = useRef<number | null>(null)
   const startingRef = useRef(false)
   const locatedRef = useRef(false)
+  // Pending start() promise — resolved on first fix, rejected on fatal error.
+  const pendingResolveRef = useRef<((fix: GeolocationFix | null) => void) | null>(null)
+  const pendingRejectRef = useRef<((reason: unknown) => void) | null>(null)
+
+  // Always read the latest options via refs so the Effect only runs once.
+  const optionsRef = useRef({ enableHighAccuracy, timeout, maximumAge })
+  useEffect(() => {
+    optionsRef.current = { enableHighAccuracy, timeout, maximumAge }
+  }, [enableHighAccuracy, timeout, maximumAge])
 
   const onLocatedRef = useRef(onLocated)
   useEffect(() => {
@@ -82,20 +98,33 @@ const useGeolocation = ({
     watchIdRef.current = null
   }, [])
 
+  const settlePending = useCallback((fix: GeolocationFix | null, error?: unknown) => {
+    if (error && pendingRejectRef.current) {
+      pendingRejectRef.current(error)
+    } else if (pendingResolveRef.current) {
+      pendingResolveRef.current(fix)
+    }
+    pendingResolveRef.current = null
+    pendingRejectRef.current = null
+  }, [])
+
   const handleSuccess = useCallback(
     (raw: GeolocationPosition) => {
       const fix = toFix(raw)
       setPosition(fix)
       setStatus('watching')
+      // A successful fix implicitly clears a stale transient error.
+      setErrorMessage(null)
       if (trackHistory) {
         setHistory((prev) => [fix, ...prev].slice(0, 200))
       }
       if (!locatedRef.current) {
         locatedRef.current = true
         onLocatedRef.current?.(fix)
+        settlePending(fix)
       }
     },
-    [trackHistory],
+    [trackHistory, settlePending],
   )
 
   const handleError = useCallback(
@@ -104,60 +133,84 @@ const useGeolocation = ({
       if (err.code === err.PERMISSION_DENIED) {
         setStatus('denied')
         clearWatch()
-      } else {
-        // POSITION_UNAVAILABLE / TIMEOUT — keep watching, surface as error state
-        // only when we have no fix yet; otherwise stay in 'watching' with last value.
-        if (!locatedRef.current) {
-          setStatus('error')
-        }
-      }
-    },
-    [clearWatch],
-  )
-
-  const start = useCallback(async (): Promise<void> => {
-    if (startingRef.current || watchIdRef.current !== null) return
-    startingRef.current = true
-
-    setStatus('requesting')
-    setErrorMessage(null)
-
-    if (typeof navigator === 'undefined' || !navigator.geolocation) {
-      setStatus('unsupported')
-      startingRef.current = false
-      return
-    }
-
-    // Optional permission pre-flight (not supported everywhere — Safari throws).
-    try {
-      const perm = await navigator.permissions.query({
-        name: 'geolocation' as PermissionName,
-      })
-      if (perm.state === 'denied') {
-        setStatus('denied')
-        startingRef.current = false
+        settlePending(null, err)
         return
       }
-    } catch {
-      // ignore
+      // POSITION_UNAVAILABLE / TIMEOUT — keep watching, surface as error state
+      // only when we have no fix yet; otherwise stay in 'watching' with last value.
+      if (!locatedRef.current) {
+        setStatus('error')
+        settlePending(null, err)
+      }
+    },
+    [clearWatch, settlePending],
+  )
+
+  const start = useCallback((): Promise<GeolocationFix | null> => {
+    // Already watching — return a no-op promise resolving to the last fix.
+    if (watchIdRef.current !== null) {
+      return Promise.resolve(position)
+    }
+    // A start() is mid-flight (permissions pre-flight).
+    if (startingRef.current) {
+      return new Promise((resolve, reject) => {
+        pendingResolveRef.current = resolve
+        pendingRejectRef.current = reject
+      })
     }
 
+    startingRef.current = true
+    setStatus('requesting')
+    setErrorMessage(null)
     locatedRef.current = false
 
-    try {
-      watchIdRef.current = navigator.geolocation.watchPosition(handleSuccess, handleError, {
-        enableHighAccuracy,
-        timeout,
-        maximumAge,
-      })
-    } catch (err) {
-      console.error('Failed to start geolocation watch', err)
-      setStatus('error')
-      setErrorMessage(err instanceof Error ? err.message : String(err))
-    } finally {
-      startingRef.current = false
-    }
-  }, [enableHighAccuracy, timeout, maximumAge, handleSuccess, handleError])
+    return new Promise<GeolocationFix | null>((resolve, reject) => {
+      pendingResolveRef.current = resolve
+      pendingRejectRef.current = reject
+
+      const run = async () => {
+        if (typeof navigator === 'undefined' || !navigator.geolocation) {
+          setStatus('unsupported')
+          startingRef.current = false
+          settlePending(null)
+          return
+        }
+
+        // Optional permission pre-flight (not supported everywhere — Safari throws).
+        try {
+          const perm = await navigator.permissions.query({
+            name: 'geolocation' as PermissionName,
+          })
+          if (perm.state === 'denied') {
+            setStatus('denied')
+            startingRef.current = false
+            settlePending(null)
+            return
+          }
+        } catch {
+          // ignore
+        }
+
+        try {
+          const opts = optionsRef.current
+          watchIdRef.current = navigator.geolocation.watchPosition(handleSuccess, handleError, {
+            enableHighAccuracy: opts.enableHighAccuracy,
+            timeout: opts.timeout,
+            maximumAge: opts.maximumAge,
+          })
+        } catch (err) {
+          console.error('Failed to start geolocation watch', err)
+          setStatus('error')
+          setErrorMessage(err instanceof Error ? err.message : String(err))
+          settlePending(null, err)
+        } finally {
+          startingRef.current = false
+        }
+      }
+
+      void run()
+    })
+  }, [handleSuccess, handleError, settlePending, position])
 
   const stop = useCallback(() => {
     clearWatch()
@@ -167,19 +220,31 @@ const useGeolocation = ({
   const reset = useCallback(() => {
     clearWatch()
     locatedRef.current = false
+    settlePending(null)
     setPosition(null)
     setHistory([])
     setErrorMessage(null)
     setStatus('idle')
-  }, [clearWatch])
+  }, [clearWatch, settlePending])
 
-  // autoStart on mount
+  const relocate = useCallback((): Promise<GeolocationFix | null> => {
+    clearWatch()
+    locatedRef.current = false
+    settlePending(null)
+    setErrorMessage(null)
+    // Keep the stale `position` visible until the next fix arrives — feels
+    // smoother than flashing an empty state.
+    return start()
+  }, [clearWatch, settlePending, start])
+
+  // autoStart on mount; options are captured via optionsRef so this runs once.
   useEffect(() => {
     if (autoStart) {
       void start()
     }
     return () => {
       clearWatch()
+      settlePending(null)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -192,6 +257,7 @@ const useGeolocation = ({
     start,
     stop,
     reset,
+    relocate,
   }
 }
 

--- a/frontend/app/src/hooks/useGeolocation.ts
+++ b/frontend/app/src/hooks/useGeolocation.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export type GeolocationStatus =
+  | 'idle'
+  | 'requesting'
+  | 'watching'
+  | 'denied'
+  | 'unsupported'
+  | 'error'
+
+export interface GeolocationFix {
+  latitude: number
+  longitude: number
+  accuracy: number
+  altitude: number | null
+  altitudeAccuracy: number | null
+  heading: number | null
+  speed: number | null
+  timestamp: number
+}
+
+interface UseGeolocationOptions {
+  /** Capture every position update in `history` (e.g. for the debug view). */
+  trackHistory?: boolean
+  /** Auto-start watching on mount. */
+  autoStart?: boolean
+  /** Forwarded to the Geolocation API. Defaults: high accuracy, 15s timeout. */
+  enableHighAccuracy?: boolean
+  timeout?: number
+  maximumAge?: number
+  /** Invoked once the first fix is delivered. */
+  onLocated?: (fix: GeolocationFix) => void
+}
+
+interface UseGeolocationReturn {
+  status: GeolocationStatus
+  position: GeolocationFix | null
+  history: GeolocationFix[]
+  errorMessage: string | null
+  start: () => Promise<void>
+  stop: () => void
+  reset: () => void
+}
+
+const toFix = (position: GeolocationPosition): GeolocationFix => ({
+  latitude: position.coords.latitude,
+  longitude: position.coords.longitude,
+  accuracy: position.coords.accuracy,
+  altitude: position.coords.altitude,
+  altitudeAccuracy: position.coords.altitudeAccuracy,
+  heading: position.coords.heading,
+  speed: position.coords.speed,
+  timestamp: position.timestamp,
+})
+
+const useGeolocation = ({
+  trackHistory = false,
+  autoStart = false,
+  enableHighAccuracy = true,
+  timeout = 15000,
+  maximumAge = 0,
+  onLocated,
+}: UseGeolocationOptions = {}): UseGeolocationReturn => {
+  const watchIdRef = useRef<number | null>(null)
+  const startingRef = useRef(false)
+  const locatedRef = useRef(false)
+
+  const onLocatedRef = useRef(onLocated)
+  useEffect(() => {
+    onLocatedRef.current = onLocated
+  }, [onLocated])
+
+  const [status, setStatus] = useState<GeolocationStatus>('idle')
+  const [position, setPosition] = useState<GeolocationFix | null>(null)
+  const [history, setHistory] = useState<GeolocationFix[]>([])
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const clearWatch = useCallback(() => {
+    if (watchIdRef.current !== null && navigator.geolocation) {
+      navigator.geolocation.clearWatch(watchIdRef.current)
+    }
+    watchIdRef.current = null
+  }, [])
+
+  const handleSuccess = useCallback(
+    (raw: GeolocationPosition) => {
+      const fix = toFix(raw)
+      setPosition(fix)
+      setStatus('watching')
+      if (trackHistory) {
+        setHistory((prev) => [fix, ...prev].slice(0, 200))
+      }
+      if (!locatedRef.current) {
+        locatedRef.current = true
+        onLocatedRef.current?.(fix)
+      }
+    },
+    [trackHistory],
+  )
+
+  const handleError = useCallback((err: GeolocationPositionError) => {
+    setErrorMessage(err.message || null)
+    if (err.code === err.PERMISSION_DENIED) {
+      setStatus('denied')
+      clearWatch()
+    } else {
+      // POSITION_UNAVAILABLE / TIMEOUT — keep watching, surface as error state
+      // only when we have no fix yet; otherwise stay in 'watching' with last value.
+      if (!locatedRef.current) {
+        setStatus('error')
+      }
+    }
+  }, [clearWatch])
+
+  const start = useCallback(async (): Promise<void> => {
+    if (startingRef.current || watchIdRef.current !== null) return
+    startingRef.current = true
+
+    setStatus('requesting')
+    setErrorMessage(null)
+
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      setStatus('unsupported')
+      startingRef.current = false
+      return
+    }
+
+    // Optional permission pre-flight (not supported everywhere — Safari throws).
+    try {
+      const perm = await navigator.permissions.query({
+        name: 'geolocation' as PermissionName,
+      })
+      if (perm.state === 'denied') {
+        setStatus('denied')
+        startingRef.current = false
+        return
+      }
+    } catch {
+      // ignore
+    }
+
+    locatedRef.current = false
+
+    try {
+      watchIdRef.current = navigator.geolocation.watchPosition(handleSuccess, handleError, {
+        enableHighAccuracy,
+        timeout,
+        maximumAge,
+      })
+    } catch (err) {
+      console.error('Failed to start geolocation watch', err)
+      setStatus('error')
+      setErrorMessage(err instanceof Error ? err.message : String(err))
+    } finally {
+      startingRef.current = false
+    }
+  }, [enableHighAccuracy, timeout, maximumAge, handleSuccess, handleError])
+
+  const stop = useCallback(() => {
+    clearWatch()
+    setStatus('idle')
+  }, [clearWatch])
+
+  const reset = useCallback(() => {
+    clearWatch()
+    locatedRef.current = false
+    setPosition(null)
+    setHistory([])
+    setErrorMessage(null)
+    setStatus('idle')
+  }, [clearWatch])
+
+  // autoStart on mount
+  useEffect(() => {
+    if (autoStart) {
+      void start()
+    }
+    return () => {
+      clearWatch()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return {
+    status,
+    position,
+    history,
+    errorMessage,
+    start,
+    stop,
+    reset,
+  }
+}
+
+export default useGeolocation

--- a/frontend/app/src/hooks/useGeolocation.ts
+++ b/frontend/app/src/hooks/useGeolocation.ts
@@ -98,19 +98,22 @@ const useGeolocation = ({
     [trackHistory],
   )
 
-  const handleError = useCallback((err: GeolocationPositionError) => {
-    setErrorMessage(err.message || null)
-    if (err.code === err.PERMISSION_DENIED) {
-      setStatus('denied')
-      clearWatch()
-    } else {
-      // POSITION_UNAVAILABLE / TIMEOUT — keep watching, surface as error state
-      // only when we have no fix yet; otherwise stay in 'watching' with last value.
-      if (!locatedRef.current) {
-        setStatus('error')
+  const handleError = useCallback(
+    (err: GeolocationPositionError) => {
+      setErrorMessage(err.message || null)
+      if (err.code === err.PERMISSION_DENIED) {
+        setStatus('denied')
+        clearWatch()
+      } else {
+        // POSITION_UNAVAILABLE / TIMEOUT — keep watching, surface as error state
+        // only when we have no fix yet; otherwise stay in 'watching' with last value.
+        if (!locatedRef.current) {
+          setStatus('error')
+        }
       }
-    }
-  }, [clearWatch])
+    },
+    [clearWatch],
+  )
 
   const start = useCallback(async (): Promise<void> => {
     if (startingRef.current || watchIdRef.current !== null) return

--- a/frontend/app/src/routeTree.gen.ts
+++ b/frontend/app/src/routeTree.gen.ts
@@ -54,6 +54,7 @@ import { Route as ProtectedSettingsPluginIndexRouteImport } from './routes/_prot
 import { Route as ProtectedSensorsNewIndexRouteImport } from './routes/_protected/sensors/new/index'
 import { Route as ProtectedSensorsSensorIdIndexRouteImport } from './routes/_protected/sensors/$sensorId/index'
 import { Route as ProtectedDebugQrScannerIndexRouteImport } from './routes/_protected/debug/qr-scanner/index'
+import { Route as ProtectedDebugGeolocationIndexRouteImport } from './routes/_protected/debug/geolocation/index'
 import { Route as ProtectedWateringPlansFormularNewRouteRouteImport } from './routes/_protected/watering-plans/_formular/new/route'
 import { Route as ProtectedWateringPlansFormularWateringPlanIdRouteRouteImport } from './routes/_protected/watering-plans/_formular/$wateringPlanId/route'
 import { Route as ProtectedVehiclesFormularNewRouteRouteImport } from './routes/_protected/vehicles/_formular/new/route'
@@ -333,6 +334,12 @@ const ProtectedDebugQrScannerIndexRoute =
     path: '/qr-scanner/',
     getParentRoute: () => ProtectedDebugRouteRoute,
   } as any)
+const ProtectedDebugGeolocationIndexRoute =
+  ProtectedDebugGeolocationIndexRouteImport.update({
+    id: '/geolocation/',
+    path: '/geolocation/',
+    getParentRoute: () => ProtectedDebugRouteRoute,
+  } as any)
 const ProtectedWateringPlansFormularNewRouteRoute =
   ProtectedWateringPlansFormularNewRouteRouteImport.update({
     id: '/_formular/new',
@@ -590,6 +597,7 @@ export interface FileRoutesByFullPath {
   '/trees/new': typeof ProtectedTreesFormularNewRouteRouteWithChildren
   '/vehicles/new': typeof ProtectedVehiclesFormularNewRouteRouteWithChildren
   '/watering-plans/new': typeof ProtectedWateringPlansFormularNewRouteRouteWithChildren
+  '/debug/geolocation/': typeof ProtectedDebugGeolocationIndexRoute
   '/debug/qr-scanner/': typeof ProtectedDebugQrScannerIndexRoute
   '/sensors/$sensorId/': typeof ProtectedSensorsSensorIdIndexRoute
   '/sensors/new/': typeof ProtectedSensorsNewIndexRoute
@@ -644,6 +652,7 @@ export interface FileRoutesByTo {
   '/trees/$treeId': typeof ProtectedTreesTreeIdIndexRoute
   '/vehicles/$vehicleId': typeof ProtectedVehiclesVehicleIdIndexRoute
   '/watering-plans/$wateringPlanId': typeof ProtectedWateringPlansWateringPlanIdIndexRoute
+  '/debug/geolocation': typeof ProtectedDebugGeolocationIndexRoute
   '/debug/qr-scanner': typeof ProtectedDebugQrScannerIndexRoute
   '/sensors/$sensorId': typeof ProtectedSensorsSensorIdIndexRoute
   '/sensors/new': typeof ProtectedSensorsNewIndexRoute
@@ -714,6 +723,7 @@ export interface FileRoutesById {
   '/_protected/vehicles/_formular/new': typeof ProtectedVehiclesFormularNewRouteRouteWithChildren
   '/_protected/watering-plans/_formular/$wateringPlanId': typeof ProtectedWateringPlansFormularWateringPlanIdRouteRouteWithChildren
   '/_protected/watering-plans/_formular/new': typeof ProtectedWateringPlansFormularNewRouteRouteWithChildren
+  '/_protected/debug/geolocation/': typeof ProtectedDebugGeolocationIndexRoute
   '/_protected/debug/qr-scanner/': typeof ProtectedDebugQrScannerIndexRoute
   '/_protected/sensors/$sensorId/': typeof ProtectedSensorsSensorIdIndexRoute
   '/_protected/sensors/new/': typeof ProtectedSensorsNewIndexRoute
@@ -791,6 +801,7 @@ export interface FileRouteTypes {
     | '/trees/new'
     | '/vehicles/new'
     | '/watering-plans/new'
+    | '/debug/geolocation/'
     | '/debug/qr-scanner/'
     | '/sensors/$sensorId/'
     | '/sensors/new/'
@@ -845,6 +856,7 @@ export interface FileRouteTypes {
     | '/trees/$treeId'
     | '/vehicles/$vehicleId'
     | '/watering-plans/$wateringPlanId'
+    | '/debug/geolocation'
     | '/debug/qr-scanner'
     | '/sensors/$sensorId'
     | '/sensors/new'
@@ -914,6 +926,7 @@ export interface FileRouteTypes {
     | '/_protected/vehicles/_formular/new'
     | '/_protected/watering-plans/_formular/$wateringPlanId'
     | '/_protected/watering-plans/_formular/new'
+    | '/_protected/debug/geolocation/'
     | '/_protected/debug/qr-scanner/'
     | '/_protected/sensors/$sensorId/'
     | '/_protected/sensors/new/'
@@ -1272,6 +1285,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedDebugQrScannerIndexRouteImport
       parentRoute: typeof ProtectedDebugRouteRoute
     }
+    '/_protected/debug/geolocation/': {
+      id: '/_protected/debug/geolocation/'
+      path: '/geolocation'
+      fullPath: '/debug/geolocation/'
+      preLoaderRoute: typeof ProtectedDebugGeolocationIndexRouteImport
+      parentRoute: typeof ProtectedDebugRouteRoute
+    }
     '/_protected/watering-plans/_formular/new': {
       id: '/_protected/watering-plans/_formular/new'
       path: '/new'
@@ -1515,11 +1535,13 @@ declare module '@tanstack/react-router' {
 
 interface ProtectedDebugRouteRouteChildren {
   ProtectedDebugIndexRoute: typeof ProtectedDebugIndexRoute
+  ProtectedDebugGeolocationIndexRoute: typeof ProtectedDebugGeolocationIndexRoute
   ProtectedDebugQrScannerIndexRoute: typeof ProtectedDebugQrScannerIndexRoute
 }
 
 const ProtectedDebugRouteRouteChildren: ProtectedDebugRouteRouteChildren = {
   ProtectedDebugIndexRoute: ProtectedDebugIndexRoute,
+  ProtectedDebugGeolocationIndexRoute: ProtectedDebugGeolocationIndexRoute,
   ProtectedDebugQrScannerIndexRoute: ProtectedDebugQrScannerIndexRoute,
 }
 

--- a/frontend/app/src/routes/_protected/debug/geolocation/index.tsx
+++ b/frontend/app/src/routes/_protected/debug/geolocation/index.tsx
@@ -1,0 +1,29 @@
+import GeolocationDebugView from '@/components/debug/GeolocationDebugView'
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_protected/debug/geolocation/')({
+  component: GeolocationDebugPage,
+  loader: () => ({
+    crumb: {
+      title: 'GPS-Ortung',
+    },
+  }),
+})
+
+function GeolocationDebugPage() {
+  return (
+    <div className="container mt-6 pb-[env(safe-area-inset-bottom)]">
+      <article className="2xl:w-4/5 mb-8">
+        <h1 className="font-lato font-bold text-3xl mb-2 lg:text-4xl xl:text-5xl">
+          GPS-Ortung Debug
+        </h1>
+        <p className="text-sm text-muted-foreground max-w-prose">
+          Diagnose der Browser-Geolocation-API: Sicherheitskontext, Berechtigungs-Status,
+          Live-Position mit Genauigkeitskreis und Verlaufsprotokoll. Ideal zum Testen der
+          Hardware-Seite unabhängig vom Produktiv-Flow.
+        </p>
+      </article>
+      <GeolocationDebugView />
+    </div>
+  )
+}

--- a/frontend/app/src/routes/_protected/debug/index.tsx
+++ b/frontend/app/src/routes/_protected/debug/index.tsx
@@ -1,7 +1,7 @@
 import { useAuthStore, useMapStore, useUserStore } from '@/store/store'
 import { Button } from '@green-ecolution/ui'
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { QrCode } from 'lucide-react'
+import { MapPin, QrCode } from 'lucide-react'
 
 export const Route = createFileRoute('/_protected/debug/')({
   component: Debug,
@@ -25,6 +25,12 @@ function Debug() {
           <Link to="/debug/qr-scanner">
             <QrCode />
             QR-Scanner öffnen
+          </Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/debug/geolocation">
+            <MapPin />
+            GPS-Ortung öffnen
           </Link>
         </Button>
       </div>

--- a/frontend/app/src/routes/_protected/sensors/new/index.tsx
+++ b/frontend/app/src/routes/_protected/sensors/new/index.tsx
@@ -2,9 +2,9 @@ import BackLink from '@/components/general/links/BackLink'
 import InlineGPSReadout from '@/components/geolocation/InlineGPSReadout'
 import QRScannerView from '@/components/scanner/QRScannerView'
 import SensorGeolocationSummary from '@/components/sensor/SensorGeolocationSummary'
-import useGeolocation from '@/hooks/useGeolocation'
+import useGeolocation, { type GeolocationFix } from '@/hooks/useGeolocation'
 import { createFileRoute } from '@tanstack/react-router'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export const Route = createFileRoute('/_protected/sensors/new/')({
   component: NewSensor,
@@ -13,22 +13,49 @@ export const Route = createFileRoute('/_protected/sensors/new/')({
 function NewSensor() {
   // Start GPS in parallel with the QR-scan so a fix is usually ready by the
   // time the technician confirms the scanned sensor.
-  const { status, position, errorMessage, start, reset } = useGeolocation({ autoStart: true })
+  const { status, position, errorMessage, stop, relocate } = useGeolocation({ autoStart: true })
 
   const [scannedSensorId, setScannedSensorId] = useState<string | null>(null)
+  // Frozen snapshot shown in the summary. Decouples the displayed fix from
+  // further watchPosition updates so the map / accuracy don't keep drifting
+  // after the user has accepted the sensor.
+  const [frozenFix, setFrozenFix] = useState<GeolocationFix | null>(null)
+  const pendingStopRef = useRef(false)
+
+  useEffect(() => {
+    if (!pendingStopRef.current || !position) return
+    pendingStopRef.current = false
+    stop()
+  }, [position, stop])
 
   const handleContinue = (sensorId: string) => {
     setScannedSensorId(sensorId)
+    if (position) {
+      setFrozenFix(position)
+      stop()
+    } else {
+      pendingStopRef.current = true
+    }
   }
 
   const handleScanAgain = () => {
     setScannedSensorId(null)
+    setFrozenFix(null)
+    pendingStopRef.current = false
+    void relocate()
   }
 
-  const handleRelocate = () => {
-    reset()
-    void start()
+  const handleRelocate = async () => {
+    setFrozenFix(null)
+    pendingStopRef.current = false
+    const next = await relocate().catch(() => null)
+    if (next) {
+      setFrozenFix(next)
+      stop()
+    }
   }
+
+  const summaryFix = frozenFix ?? (scannedSensorId ? position : null)
 
   return (
     <div className="container mt-6">
@@ -47,7 +74,7 @@ function NewSensor() {
       {scannedSensorId ? (
         <SensorGeolocationSummary
           sensorId={scannedSensorId}
-          position={position}
+          position={summaryFix}
           status={status}
           errorMessage={errorMessage}
           onScanAgain={handleScanAgain}
@@ -57,7 +84,7 @@ function NewSensor() {
         <QRScannerView
           continueLabel="Sensor übernehmen"
           onContinue={handleContinue}
-          resultExtra={<InlineGPSReadout position={position} status={status} />}
+          extra={<InlineGPSReadout position={position} status={status} />}
         />
       )}
     </div>

--- a/frontend/app/src/routes/_protected/sensors/new/index.tsx
+++ b/frontend/app/src/routes/_protected/sensors/new/index.tsx
@@ -1,17 +1,33 @@
-import createToast from '@/hooks/createToast'
 import BackLink from '@/components/general/links/BackLink'
+import InlineGPSReadout from '@/components/geolocation/InlineGPSReadout'
 import QRScannerView from '@/components/scanner/QRScannerView'
+import SensorGeolocationSummary from '@/components/sensor/SensorGeolocationSummary'
+import useGeolocation from '@/hooks/useGeolocation'
 import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
 
 export const Route = createFileRoute('/_protected/sensors/new/')({
   component: NewSensor,
 })
 
 function NewSensor() {
-  const showToast = createToast()
+  // Start GPS in parallel with the QR-scan so a fix is usually ready by the
+  // time the technician confirms the scanned sensor.
+  const { status, position, errorMessage, start, reset } = useGeolocation({ autoStart: true })
+
+  const [scannedSensorId, setScannedSensorId] = useState<string | null>(null)
 
   const handleContinue = (sensorId: string) => {
-    showToast(`Sensor-Verknüpfung ist noch nicht implementiert (erkannt: ${sensorId})`, 'error')
+    setScannedSensorId(sensorId)
+  }
+
+  const handleScanAgain = () => {
+    setScannedSensorId(null)
+  }
+
+  const handleRelocate = () => {
+    reset()
+    void start()
   }
 
   return (
@@ -22,10 +38,28 @@ function NewSensor() {
           Sensor hinzufügen
         </h1>
         <p className="text-sm text-muted-foreground max-w-prose">
-          Scanne den QR-Code auf der Sensoreinheit, um den Sensor zu identifizieren.
+          {scannedSensorId
+            ? 'Überprüfe Sensor-ID und Standort. Anhand des erfassten GPS-Standorts wird automatisch der nächstgelegene Baum gesucht und mit dem Sensor verknüpft.'
+            : 'Scanne den QR-Code auf der Sensoreinheit, um den Sensor zu identifizieren. Parallel wird dein GPS-Standort ermittelt, um den nächstgelegenen Baum automatisch zu finden und mit dem Sensor zu verknüpfen.'}
         </p>
       </article>
-      <QRScannerView continueLabel="Sensor übernehmen" onContinue={handleContinue} />
+
+      {scannedSensorId ? (
+        <SensorGeolocationSummary
+          sensorId={scannedSensorId}
+          position={position}
+          status={status}
+          errorMessage={errorMessage}
+          onScanAgain={handleScanAgain}
+          onRelocate={handleRelocate}
+        />
+      ) : (
+        <QRScannerView
+          continueLabel="Sensor übernehmen"
+          onContinue={handleContinue}
+          resultExtra={<InlineGPSReadout position={position} status={status} />}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/packages/ui/src/components/ui/accuracy-badge.tsx
+++ b/frontend/packages/ui/src/components/ui/accuracy-badge.tsx
@@ -31,9 +31,7 @@ const LEVEL_LABEL: Record<AccuracyLevel, string> = {
   searching: 'Suche …',
 }
 
-export const accuracyLevelFromMeters = (
-  meters: number | null | undefined,
-): AccuracyLevel => {
+export const accuracyLevelFromMeters = (meters: number | null | undefined): AccuracyLevel => {
   if (meters == null || !Number.isFinite(meters) || meters < 0) return 'searching'
   if (meters < 10) return 'excellent'
   if (meters < 30) return 'good'
@@ -81,8 +79,10 @@ const formatMeters = (m: number): string => {
   return `~${Math.round(m)} m`
 }
 
-export interface AccuracyBadgeProps
-  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
+export interface AccuracyBadgeProps extends Omit<
+  React.HTMLAttributes<HTMLSpanElement>,
+  'children'
+> {
   /** Accuracy in meters (e.g. GeolocationCoordinates.accuracy). */
   accuracyMeters?: number | null
   /** Hide the numeric value — show only level label + bars. */
@@ -94,7 +94,10 @@ const AccuracyBadge = React.forwardRef<HTMLSpanElement, AccuracyBadgeProps>(
     const level = accuracyLevelFromMeters(accuracyMeters)
     const label = LEVEL_LABEL[level]
     const showValue =
-      level !== 'searching' && !hideValue && accuracyMeters != null && Number.isFinite(accuracyMeters)
+      level !== 'searching' &&
+      !hideValue &&
+      accuracyMeters != null &&
+      Number.isFinite(accuracyMeters)
     const value = showValue ? formatMeters(accuracyMeters as number) : null
     const aria = `GPS-Genauigkeit: ${label}${value ? `, ${value}` : ''}`
 

--- a/frontend/packages/ui/src/components/ui/accuracy-badge.tsx
+++ b/frontend/packages/ui/src/components/ui/accuracy-badge.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const accuracyBadgeVariants = cva(
+  'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold leading-none tabular-nums transition-colors',
+  {
+    variants: {
+      level: {
+        excellent: 'border-green-dark-200 bg-green-dark-50 text-green-dark',
+        good: 'border-green-light-200 bg-green-light-50 text-green-light-900',
+        fair: 'border-yellow-200 bg-yellow-50 text-yellow-900',
+        poor: 'border-red-200 bg-red-50 text-red',
+        searching: 'border-dark-200 bg-dark-50 text-dark-600',
+      },
+    },
+    defaultVariants: {
+      level: 'searching',
+    },
+  },
+)
+
+export type AccuracyLevel = NonNullable<VariantProps<typeof accuracyBadgeVariants>['level']>
+
+const LEVEL_LABEL: Record<AccuracyLevel, string> = {
+  excellent: 'Sehr gut',
+  good: 'Gut',
+  fair: 'Mäßig',
+  poor: 'Ungenau',
+  searching: 'Suche …',
+}
+
+export const accuracyLevelFromMeters = (
+  meters: number | null | undefined,
+): AccuracyLevel => {
+  if (meters == null || !Number.isFinite(meters) || meters < 0) return 'searching'
+  if (meters < 10) return 'excellent'
+  if (meters < 30) return 'good'
+  if (meters < 75) return 'fair'
+  return 'poor'
+}
+
+const BAR_COUNT: Record<AccuracyLevel, number> = {
+  excellent: 4,
+  good: 3,
+  fair: 2,
+  poor: 1,
+  searching: 0,
+}
+
+const BAR_HEIGHTS = ['h-[30%]', 'h-[55%]', 'h-[80%]', 'h-full'] as const
+
+const SignalBars = ({ level }: { level: AccuracyLevel }) => {
+  const filled = BAR_COUNT[level]
+  const isLive = level === 'excellent' || level === 'good'
+  return (
+    <span aria-hidden className="flex h-3.5 items-end gap-[2px]">
+      {BAR_HEIGHTS.map((h, i) => {
+        const isFilled = i < filled
+        const isLeading = i === filled - 1
+        return (
+          <span
+            key={i}
+            className={cn(
+              'w-[3px] rounded-[1px] bg-current',
+              h,
+              isFilled ? 'opacity-90' : 'opacity-25',
+              isFilled && isLeading && isLive && 'animate-pulse',
+            )}
+          />
+        )
+      })}
+    </span>
+  )
+}
+
+const formatMeters = (m: number): string => {
+  if (m >= 100) return `${Math.round(m)} m`
+  if (m < 10) return `~${m.toFixed(1)} m`
+  return `~${Math.round(m)} m`
+}
+
+export interface AccuracyBadgeProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
+  /** Accuracy in meters (e.g. GeolocationCoordinates.accuracy). */
+  accuracyMeters?: number | null
+  /** Hide the numeric value — show only level label + bars. */
+  hideValue?: boolean
+}
+
+const AccuracyBadge = React.forwardRef<HTMLSpanElement, AccuracyBadgeProps>(
+  ({ accuracyMeters, hideValue, className, ...rest }, ref) => {
+    const level = accuracyLevelFromMeters(accuracyMeters)
+    const label = LEVEL_LABEL[level]
+    const showValue =
+      level !== 'searching' && !hideValue && accuracyMeters != null && Number.isFinite(accuracyMeters)
+    const value = showValue ? formatMeters(accuracyMeters as number) : null
+    const aria = `GPS-Genauigkeit: ${label}${value ? `, ${value}` : ''}`
+
+    return (
+      <span
+        ref={ref}
+        role="status"
+        aria-label={aria}
+        className={cn(accuracyBadgeVariants({ level }), className)}
+        {...rest}
+      >
+        <SignalBars level={level} />
+        <span>{label}</span>
+        {value && <span className="ml-0.5 text-[0.95em] font-normal opacity-70">{value}</span>}
+      </span>
+    )
+  },
+)
+AccuracyBadge.displayName = 'AccuracyBadge'
+
+export { AccuracyBadge, accuracyBadgeVariants }

--- a/frontend/packages/ui/src/index.ts
+++ b/frontend/packages/ui/src/index.ts
@@ -1,6 +1,14 @@
 // Styles
 import './styles/globals.css'
 
+// AccuracyBadge
+export {
+  AccuracyBadge,
+  accuracyBadgeVariants,
+  accuracyLevelFromMeters,
+} from './components/ui/accuracy-badge'
+export type { AccuracyBadgeProps, AccuracyLevel } from './components/ui/accuracy-badge'
+
 // Alert
 export {
   Alert,

--- a/frontend/packages/ui/stories/AccuracyBadge.stories.tsx
+++ b/frontend/packages/ui/stories/AccuracyBadge.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { AccuracyBadge } from '../src/components/ui/accuracy-badge'
+
+const meta: Meta<typeof AccuracyBadge> = {
+  title: 'UI/AccuracyBadge',
+  component: AccuracyBadge,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Pill-style badge that visualizes a GPS accuracy reading (in meters) as one of four quality levels — `excellent` (< 10 m), `good` (10–30 m), `fair` (30–75 m), `poor` (> 75 m). A 4-bar signal-strength icon mirrors common cellular UX so the level is readable at a glance, and the leading bar gently pulses on the two best levels to communicate live tracking. Pass `null`/`undefined` to render the `searching` state.',
+      },
+    },
+  },
+  argTypes: {
+    accuracyMeters: {
+      control: { type: 'number', min: 0, max: 200, step: 0.5 },
+      description: 'Accuracy in meters (e.g. `GeolocationCoordinates.accuracy`).',
+    },
+    hideValue: {
+      control: 'boolean',
+      description: 'Hide the numeric value — show only level label + bars.',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Excellent: Story = {
+  args: { accuracyMeters: 5 },
+}
+
+export const Good: Story = {
+  args: { accuracyMeters: 18 },
+}
+
+export const Fair: Story = {
+  args: { accuracyMeters: 50 },
+}
+
+export const Poor: Story = {
+  args: { accuracyMeters: 120 },
+}
+
+export const Searching: Story = {
+  args: { accuracyMeters: null },
+}
+
+export const ValueHidden: Story = {
+  args: { accuracyMeters: 12, hideValue: true },
+}
+
+export const AllLevels: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      <AccuracyBadge accuracyMeters={4.2} />
+      <AccuracyBadge accuracyMeters={18} />
+      <AccuracyBadge accuracyMeters={50} />
+      <AccuracyBadge accuracyMeters={120} />
+      <AccuracyBadge accuracyMeters={null} />
+    </div>
+  ),
+}
+
+export const Interactive: Story = {
+  args: { accuracyMeters: 12 },
+}
+
+export const InContext: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 max-w-sm">
+      <div className="flex items-baseline justify-between gap-3 rounded-lg border border-dark-100 bg-white p-3">
+        <div className="flex flex-col">
+          <span className="text-xs text-muted-foreground">Aktueller Standort</span>
+          <span className="font-mono text-sm">54.79228, 9.43581</span>
+        </div>
+        <AccuracyBadge accuracyMeters={6.4} />
+      </div>
+      <div className="flex items-baseline justify-between gap-3 rounded-lg border border-dark-100 bg-white p-3">
+        <div className="flex flex-col">
+          <span className="text-xs text-muted-foreground">Aktueller Standort</span>
+          <span className="font-mono text-sm">54.79231, 9.43577</span>
+        </div>
+        <AccuracyBadge accuracyMeters={42} />
+      </div>
+      <div className="flex items-baseline justify-between gap-3 rounded-lg border border-dark-100 bg-white p-3">
+        <div className="flex flex-col">
+          <span className="text-xs text-muted-foreground">Aktueller Standort</span>
+          <span className="font-mono text-sm">— —</span>
+        </div>
+        <AccuracyBadge accuracyMeters={null} />
+      </div>
+    </div>
+  ),
+}


### PR DESCRIPTION
## Summary
- Automatically captures the field worker's GPS location via the browser Geolocation API when registering a new sensor.
- Displays the captured location live (coordinates + accuracy + map with accuracy circle) inline in the QR scan result card and on a summary screen after confirmation.
- Adds a new reusable `AccuracyBadge` to the UI package with a signal-bar visualization and Storybook story.
- Adds a new `/debug/geolocation` debug view to inspect the Geolocation API (analog to the existing QR scanner debug).

## Problem
Until now only the sensor ID (via QR scan) could be captured when installing a sensor. To enable automatic linking of a sensor to the nearest tree, the field worker's position must be recorded at capture time - but the frontend had no UI or API integration for this. There was also no permission/error path for unavailable or denied GPS, and no visual feedback about the accuracy of the captured position.

## Solution
- **`useGeolocation` hook** (mirrors `useQRScanner`): wraps permission pre-flight, `watchPosition` lifecycle, status machine (`idle | requesting | watching | denied | unsupported | error`), optional history tracking, and cleanup.
- **`AccuracyBadge`** (UI package): pill badge with 4-bar signal icon, four quality levels (excellent < 10 m, good 10–30 m, fair 30–75 m, poor > 75 m) plus a `searching` state. Uses the existing OKLCH palette and includes a Storybook story.
- **App components** in `frontend/app/src/components/geolocation/`:
  - `GeolocationPermissionNotice` — `Alert`-based permission/error UI
  - `LocationMapPreview` — small Leaflet map with marker + accuracy circle (auto-recenters on updates)
  - `GPSStatusCard` — coordinate/accuracy/altitude/timestamp readout
  - `InlineGPSReadout` — compact display embedded inside the QR result card
- **Debug view** `/debug/geolocation` with diagnostics grid (secure context, permission state, derived sensors), live map and history table.
- **Production flow** (`/sensors/new`): GPS is started in parallel with the QR scan so a fix is usually ready by the time the user confirms. Coordinates appear inline in the result card; after "Sensor übernehmen" a `SensorGeolocationSummary` shows sensor ID, GPS card and map.

## Definition of Done
- [x] Code compiles without errors
- [x] All tests pass (`make test`)
- [x] No new linter warnings (`make lint`)
- [ ] Code reviewed by at least 1 person
- [ ] Documentation updated (if applicable)
- [x] Acceptance criteria from issue fulfilled
  - [x] GPS coordinates captured via Geolocation API
  - [x] Location permission requested from the user
  - [x] Notice shown when GPS permission is missing or unavailable
  - [x] Captured position displayed on a map view
  - [x] GPS accuracy considered and visually represented (`AccuracyBadge`)

## Test Plan
- [x] Open `/debug/geolocation` → grant permission → coordinates and accuracy circle update live; deny permission via DevTools → permission notice appears, no crash.
- [x] Override location in DevTools (Sensors panel) with varying accuracy values → `AccuracyBadge` color/level changes accordingly.
- [x] Open `/sensors/new` → camera and GPS start in parallel → scan a sensor QR code → result card shows coordinates inline.
- [x] Click "Sensor übernehmen" → summary screen shows sensor ID, coordinates, accuracy badge and map with accuracy circle.
- [x] Click "Erneut lokalisieren" → GPS state resets and re-acquires.
- [x] Click "Erneut scannen" → returns to scanner without losing GPS context.
- [x] On a real mobile device (PWA install), confirm `enableHighAccuracy` produces meaningful accuracy values and the map fits the viewport.

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->
