### PR TITLE
feat(frontend): add copy-to-clipboard button for sensor ID in QR scan result

### DIFF
--- a/frontend/app/src/components/scanner/QRScanResult.tsx
+++ b/frontend/app/src/components/scanner/QRScanResult.tsx
@@ -1,6 +1,6 @@
 import createToast from '@/hooks/createToast'
 import { Button, Card, CardContent, CardFooter, CardHeader, CardTitle } from '@green-ecolution/ui'
-import { ArrowRight, CheckCircle2, RotateCcw } from 'lucide-react'
+import { ArrowRight, CheckCircle2, Copy, RotateCcw } from 'lucide-react'
 
 interface QRScanResultProps {
   sensorId: string
@@ -41,8 +41,21 @@ const QRScanResult = ({
       <CardContent className="flex flex-col gap-4">
         <div className="flex flex-col gap-2">
           <span className="text-xs uppercase tracking-widest text-muted-foreground">Sensor-ID</span>
-          <code className="font-mono text-lg md:text-xl font-semibold break-all bg-dark-50 rounded-lg px-3 py-2 border border-dark-100">
-            {sensorId}
+          <code className="relative flex items-center font-mono text-lg md:text-xl font-semibold break-all bg-dark-50 rounded-lg pl-3 pr-10 py-2 border border-dark-100">
+            <span className="flex-1">{sensorId}</span>
+            <button
+              type="button"
+              onClick={() => {
+                navigator.clipboard
+                  .writeText(sensorId)
+                  .then(() => showToast('Sensor-ID kopiert', 'success'))
+                  .catch(() => showToast('Sensor-ID konnte nicht kopiert werden', 'error'))
+              }}
+              aria-label="Sensor-ID kopieren"
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-dark-100 transition-colors cursor-pointer"
+            >
+              <Copy className="size-4" />
+            </button>
           </code>
         </div>
         {extra}


### PR DESCRIPTION
- Add inline copy-to-clipboard button for sensor ID in QR scan result card
- Button is positioned inside the code field for a cleaner look