### PR TITLE
feat(frontend): redesign debug dashboard with structured card layout

### DIFF
--- a/frontend/app/src/components/debug/GeolocationDebugView.tsx
+++ b/frontend/app/src/components/debug/GeolocationDebugView.tsx
@@ -1,6 +1,8 @@
 import GPSStatusCard from '@/components/geolocation/GPSStatusCard'
 import LocationMapPreview from '@/components/geolocation/LocationMapPreview'
 import useGeolocation, { type GeolocationStatus } from '@/hooks/useGeolocation'
+import KV from './KV'
+import { boolBadge } from './badgeHelpers'
 import {
   Badge,
   Button,
@@ -57,9 +59,6 @@ const statusBadge = (status: GeolocationStatus) => {
   }
 }
 
-const boolBadge = (value: boolean) =>
-  value ? <Badge variant="success">true</Badge> : <Badge variant="error">false</Badge>
-
 const formatTime = (ts: number) => {
   const d = new Date(ts)
   return (
@@ -68,13 +67,6 @@ const formatTime = (ts: number) => {
     String(d.getMilliseconds()).padStart(3, '0')
   )
 }
-
-const KV = ({ label, children }: { label: string; children: React.ReactNode }) => (
-  <div className="flex items-start justify-between gap-3">
-    <span className="text-muted-foreground shrink-0">{label}</span>
-    <span className="text-right">{children}</span>
-  </div>
-)
 
 const EmptyMapState = ({ status }: { status: GeolocationStatus }) => {
   const isLoading = status === 'requesting'

--- a/frontend/app/src/components/debug/KV.tsx
+++ b/frontend/app/src/components/debug/KV.tsx
@@ -1,0 +1,8 @@
+const KV = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div className="flex items-start justify-between gap-3">
+    <span className="text-muted-foreground shrink-0">{label}</span>
+    <span className="text-right">{children}</span>
+  </div>
+)
+
+export default KV

--- a/frontend/app/src/components/debug/QRScannerDebugView.tsx
+++ b/frontend/app/src/components/debug/QRScannerDebugView.tsx
@@ -1,4 +1,6 @@
 import type { BarcodeDetector as BarcodeDetectorType } from 'barcode-detector/pure'
+import KV from './KV'
+import { boolBadge } from './badgeHelpers'
 import {
   Badge,
   Button,
@@ -48,9 +50,6 @@ const permissionBadge = (state: PermissionLabel) => {
       return <Badge variant="muted">{state}</Badge>
   }
 }
-
-const boolBadge = (value: boolean) =>
-  value ? <Badge variant="success">true</Badge> : <Badge variant="error">false</Badge>
 
 const formatTime = (ts: number) => {
   const d = new Date(ts)
@@ -344,12 +343,5 @@ const QRScannerDebugView = () => {
     </div>
   )
 }
-
-const KV = ({ label, children }: { label: string; children: React.ReactNode }) => (
-  <div className="flex items-start justify-between gap-3">
-    <span className="text-muted-foreground shrink-0">{label}</span>
-    <span className="text-right">{children}</span>
-  </div>
-)
 
 export default QRScannerDebugView

--- a/frontend/app/src/components/debug/badgeHelpers.tsx
+++ b/frontend/app/src/components/debug/badgeHelpers.tsx
@@ -1,0 +1,4 @@
+import { Badge } from '@green-ecolution/ui'
+
+export const boolBadge = (value: boolean) =>
+  value ? <Badge variant="success">true</Badge> : <Badge variant="error">false</Badge>

--- a/frontend/app/src/routes/_protected/debug/index.tsx
+++ b/frontend/app/src/routes/_protected/debug/index.tsx
@@ -1,25 +1,71 @@
+import KV from '@/components/debug/KV'
+import { boolBadge } from '@/components/debug/badgeHelpers'
+import useStore from '@/store/store'
 import { useAuthStore, useMapStore, useUserStore } from '@/store/store'
-import { Button } from '@green-ecolution/ui'
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  DetailedList,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@green-ecolution/ui'
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { MapPin, QrCode } from 'lucide-react'
+import { Copy, MapPin, QrCode } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from '@green-ecolution/ui'
+import { Eye } from 'lucide-react'
 
 export const Route = createFileRoute('/_protected/debug/')({
   component: Debug,
 })
 
+const truncate = (s: string, max = 24) => (s.length > max ? `${s.slice(0, max)}…` : s)
+
+const copyToClipboard = async (text: string) => {
+  try {
+    await navigator.clipboard.writeText(text)
+    toast.success('In Zwischenablage kopiert')
+  } catch {
+    toast.error('Kopieren fehlgeschlagen')
+  }
+}
+
 function Debug() {
   const authStore = useAuthStore()
   const mapStore = useMapStore()
   const userStore = useUserStore()
+  const formDrafts = useStore((s) => s.formDrafts)
+
+  const [env] = useState(() => ({
+    isSecureContext: typeof window !== 'undefined' && window.isSecureContext,
+    userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+  }))
+
+  const draftEntries = Object.entries(formDrafts)
+  const [draftPreview, setDraftPreview] = useState<{ key: string; data: unknown } | null>(null)
 
   return (
-    <div className="container mt-6">
+    <div className="container mt-6 pb-10">
       <article className="2xl:w-4/5">
-        <h1 className="font-lato font-bold text3xl mb-4 lg:text-4xl xl:text-5xl">Debugging</h1>
-        <p>
-          Diese Ansicht liefert debugging Informationen zu den aktuellen React-Stores im Frontend.
+        <h1 className="font-lato font-bold text-3xl mb-2 lg:text-4xl xl:text-5xl">Debugging</h1>
+        <p className="text-sm text-muted-foreground max-w-prose">
+          Entwickler-Dashboard mit Übersicht über Stores, Umgebung und App-Konfiguration. Nur in
+          Entwicklungs-Builds verfügbar.
         </p>
       </article>
+
       <div className="mt-6 flex flex-wrap gap-2">
         <Button asChild variant="outline" size="sm">
           <Link to="/debug/qr-scanner">
@@ -34,11 +80,258 @@ function Debug() {
           </Link>
         </Button>
       </div>
-      <div className="mt-6">
-        {JSON.stringify(authStore)}
-        {JSON.stringify(mapStore)}
-        {JSON.stringify(userStore)}
+
+      <div className="mt-6 flex flex-col gap-4">
+        {/* Umgebung + Auth nebeneinander */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Card variant="outlined">
+            <CardHeader>
+              <CardTitle className="text-base">Umgebung &amp; App</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-2 text-sm">
+              <KV label="Version">
+                <span className="font-mono">{__APP_VERSION__}</span>
+              </KV>
+              <KV label="Build">
+                <span className="font-mono">{__APP_BUILD_TIME__}</span>
+              </KV>
+              <KV label="Stadt">
+                <span className="font-mono">{__APP_CITY__}</span>
+              </KV>
+              <KV label="Backend-URL">
+                <span className="font-mono text-xs">{import.meta.env.VITE_BACKEND_BASEURL}</span>
+              </KV>
+              <KV label="Modus">
+                <Badge variant={import.meta.env.DEV ? 'success' : 'warning'}>
+                  {import.meta.env.MODE}
+                </Badge>
+              </KV>
+              <KV label="Base-URL">
+                <span className="font-mono text-xs">{import.meta.env.BASE_URL}</span>
+              </KV>
+              <KV label="Secure Context">{boolBadge(env.isSecureContext)}</KV>
+              <KV label="User-Agent">
+                <span className="font-mono text-xs break-all text-muted-foreground">
+                  {env.userAgent}
+                </span>
+              </KV>
+            </CardContent>
+          </Card>
+
+          <Card variant="outlined">
+            <CardHeader>
+              <CardTitle className="text-base">Authentifizierung</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-2 text-sm">
+              <KV label="Angemeldet">{boolBadge(authStore.isAuthenticated)}</KV>
+              <KV label="Token vorhanden">{boolBadge(!!authStore.token)}</KV>
+              <KV label="Ablauf">
+                <span className="font-mono text-xs">
+                  {authStore.token?.expiry
+                    ? new Date(authStore.token.expiry).toLocaleString('de-DE')
+                    : '—'}
+                </span>
+              </KV>
+              <KV label="Läuft bald ab">
+                {authStore.token ? (
+                  boolBadge(authStore.isTokenExpiringSoon())
+                ) : (
+                  <span className="text-muted-foreground">—</span>
+                )}
+              </KV>
+              <KV label="Access-Token">
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="font-mono text-xs break-all text-muted-foreground">
+                    {authStore.token?.accessToken ? truncate(authStore.token.accessToken) : '—'}
+                  </span>
+                  {authStore.token?.accessToken && (
+                    <button
+                      onClick={() => void copyToClipboard(authStore.token!.accessToken)}
+                      className="p-1 hover:bg-dark-200 rounded transition-colors shrink-0 cursor-pointer"
+                      title="Access-Token kopieren"
+                    >
+                      <Copy className="size-3.5 text-dark-500 hover:text-dark-700" />
+                    </button>
+                  )}
+                </span>
+              </KV>
+              <KV label="Refresh-Token">
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="font-mono text-xs break-all text-muted-foreground">
+                    {authStore.token?.refreshToken ? truncate(authStore.token.refreshToken) : '—'}
+                  </span>
+                  {authStore.token?.refreshToken && (
+                    <button
+                      onClick={() => void copyToClipboard(authStore.token!.refreshToken)}
+                      className="p-1 hover:bg-dark-200 rounded transition-colors shrink-0 cursor-pointer"
+                      title="Refresh-Token kopieren"
+                    >
+                      <Copy className="size-3.5 text-dark-500 hover:text-dark-700" />
+                    </button>
+                  )}
+                </span>
+              </KV>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Benutzer */}
+        <Card variant="outlined">
+          <CardHeader>
+            <CardTitle className="text-base">Benutzer</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <DetailedList
+              columns={2}
+              details={[
+                { label: 'Benutzername', value: userStore.username || '—' },
+                { label: 'E-Mail', value: userStore.email || '—' },
+                { label: 'Vorname', value: userStore.firstName || '—' },
+                { label: 'Nachname', value: userStore.lastName || '—' },
+                {
+                  label: 'Status',
+                  value: <Badge variant="muted">{userStore.userStatus}</Badge>,
+                },
+                {
+                  label: 'Rollen',
+                  value:
+                    userStore.userRoles.length > 0 ? (
+                      <div className="flex flex-wrap gap-1">
+                        {userStore.userRoles.map((role) => (
+                          <Badge key={role} variant="outline">
+                            {role}
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : (
+                      '—'
+                    ),
+                },
+                {
+                  label: 'Führerscheine',
+                  value:
+                    userStore.drivingLicenses.length > 0 ? (
+                      <div className="flex flex-wrap gap-1">
+                        {userStore.drivingLicenses.map((license) => (
+                          <Badge key={license} variant="outline">
+                            {license}
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : (
+                      '—'
+                    ),
+                },
+              ]}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Karten-Store */}
+        <Card variant="outlined">
+          <CardHeader>
+            <CardTitle className="text-base">Karten-Store</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2 text-sm">
+            <KV label="Mittelpunkt">
+              <span className="inline-flex items-center gap-1.5">
+                <span className="font-mono text-xs">
+                  {mapStore.mapCenter[0].toFixed(6)}, {mapStore.mapCenter[1].toFixed(6)}
+                </span>
+                <button
+                  onClick={() =>
+                    void copyToClipboard(
+                      `${mapStore.mapCenter[0].toFixed(6)}, ${mapStore.mapCenter[1].toFixed(6)}`,
+                    )
+                  }
+                  className="p-1 hover:bg-dark-200 rounded transition-colors shrink-0 cursor-pointer"
+                  title="Mittelpunkt kopieren"
+                >
+                  <Copy className="size-3.5 text-dark-500 hover:text-dark-700" />
+                </button>
+              </span>
+            </KV>
+            <KV label="Zoom">
+              <span className="font-mono">{mapStore.mapZoom}</span>
+            </KV>
+            <KV label="Min-Zoom">
+              <span className="font-mono">{mapStore.mapMinZoom}</span>
+            </KV>
+            <KV label="Max-Zoom">
+              <span className="font-mono">{mapStore.mapMaxZoom}</span>
+            </KV>
+            <KV label="Auswahl-Modal">{boolBadge(mapStore.showSelectModal)}</KV>
+          </CardContent>
+        </Card>
+
+        {/* Formular-Entwürfe */}
+        <Card variant="outlined">
+          <CardHeader>
+            <CardTitle className="text-base">
+              Formular-Entwürfe{' '}
+              <span className="text-muted-foreground font-normal">({draftEntries.length})</span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0 px-0">
+            {draftEntries.length === 0 ? (
+              <p className="px-6 py-4 text-sm text-muted-foreground">Keine aktiven Entwürfe.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Schlüssel</TableHead>
+                    <TableHead className="w-28">Änderungen</TableHead>
+                    <TableHead>Daten-Vorschau</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {draftEntries.map(([key, draft]) => (
+                    <TableRow key={key}>
+                      <TableCell className="font-mono text-xs">{key}</TableCell>
+                      <TableCell>
+                        {draft?.hasChanges ? (
+                          <Badge variant="warning">Ja</Badge>
+                        ) : (
+                          <Badge variant="muted">Nein</Badge>
+                        )}
+                      </TableCell>
+                      <TableCell className="font-mono text-xs text-muted-foreground">
+                        {draft?.data ? (
+                          <button
+                            onClick={() => setDraftPreview({ key, data: draft.data })}
+                            className="inline-flex items-center gap-1.5 text-left hover:text-foreground transition-colors cursor-pointer"
+                            title="Daten anzeigen"
+                          >
+                            <span className="truncate max-w-xs">
+                              {truncate(JSON.stringify(draft.data), 80)}
+                            </span>
+                            <Eye className="size-3.5 shrink-0" />
+                          </button>
+                        ) : (
+                          '—'
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
       </div>
+
+      <Dialog open={!!draftPreview} onOpenChange={() => setDraftPreview(null)}>
+        <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+          <DialogHeader>
+            <DialogTitle>
+              Entwurf: <span className="font-mono">{draftPreview?.key}</span>
+            </DialogTitle>
+          </DialogHeader>
+          <pre className="overflow-auto rounded-lg bg-dark-50 p-4 text-xs font-mono">
+            {draftPreview?.data ? JSON.stringify(draftPreview.data, null, 2) : '—'}
+          </pre>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Redesign debug main page from raw JSON dump to organized card-based layout
- Extract shared `KV` and `boolBadge` helpers from geolocation/QR scanner debug views
- Add copy-to-clipboard for access token, refresh token, and map center
- Add dialog to inspect full form draft data

close #65

## Problem
The debug dashboard at `/debug/` displayed store state as raw `JSON.stringify()` output, making it hard to read and use during development. Token values could not be
copied, and form draft data was not inspectable.

## Solution
### Structured Card Layout
Replace the JSON dump with five outlined Card sections: Environment & App, Authentication, User (DetailedList), Map Store, and Form Drafts (Table). Uses existing UI primitives from `@green-ecolution/ui`.

### Shared Helpers
Extract the duplicated `KV` component and `boolBadge` helper from `GeolocationDebugView` and `QRScannerDebugView` into `components/debug/KV.tsx` and `components/debug/badgeHelpers.tsx`.

### Copy & Inspect
- Copy buttons on access token, refresh token, and map center coordinates
- Eye icon on form draft preview opens a Dialog with formatted JSON

## Definition of Done
- [x] Code compiles without errors
- [x] All tests pass (`make test`)
- [x] No new linter warnings (`make lint`)
- [ ] Code reviewed by at least 1 person
- [ ] Documentation updated (if applicable)
- [x] Acceptance criteria from issue fulfilled

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

<img width="1280" height="1317" alt="grafik" src="https://github.com/user-attachments/assets/2dc5af12-133a-46fd-b696-0ca57a8b6f50" />
