### PR TITLE
perf(frontend): reduce unnecessary data fetching on navbar hover

### DIFF
--- a/frontend/app/src/components/layout/Header.tsx
+++ b/frontend/app/src/components/layout/Header.tsx
@@ -11,19 +11,29 @@ function Header() {
   const isStartPage = location.pathname === '/'
   const isLargeScreen = useMediaQuery('(min-width: 1024px)')
 
-  const toggleSidebar = useCallback(
-    (state: boolean) => {
-      setOpen(state)
+  const openSidebar = useCallback(() => {
+    setOpen(true)
+    if (!isLargeScreen) {
+      document.body.classList.add('overflow-y-hidden')
+    }
+  }, [isLargeScreen])
 
-      if (isLargeScreen) return
-      if (state) {
-        document.body.classList.add('overflow-y-hidden')
-      } else {
-        document.body.classList.remove('overflow-y-hidden')
+  const closeSidebar = useCallback(() => {
+    setOpen(false)
+    if (!isLargeScreen) {
+      document.body.classList.remove('overflow-y-hidden')
+    }
+  }, [isLargeScreen])
+
+  const toggleSidebar = useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev
+      if (!isLargeScreen) {
+        document.body.classList.toggle('overflow-y-hidden', next)
       }
-    },
-    [isLargeScreen],
-  )
+      return next
+    })
+  }, [isLargeScreen])
 
   return (
     <header className="relative z-10 bg-white lg:pl-20">
@@ -38,7 +48,7 @@ function Header() {
             aria-haspopup="menu"
             aria-label="Hauptnavigation öffnen"
             className="size-8 rounded-full bg-dark hover:bg-dark-600"
-            onClick={() => toggleSidebar(!open)}
+            onClick={toggleSidebar}
           >
             <AlignJustifyIcon className="!size-5 text-light" />
           </Button>
@@ -47,11 +57,7 @@ function Header() {
         <ProfileButton />
       </div>
 
-      <Navigation
-        isOpen={open}
-        openSidebar={() => toggleSidebar(true)}
-        closeSidebar={() => toggleSidebar(false)}
-      />
+      <Navigation isOpen={open} openSidebar={openSidebar} closeSidebar={closeSidebar} />
     </header>
   )
 }

--- a/frontend/app/src/components/layout/Navigation.tsx
+++ b/frontend/app/src/components/layout/Navigation.tsx
@@ -12,7 +12,6 @@ import {
 } from 'lucide-react'
 import * as React from 'react'
 import { useCallback, useMemo } from 'react'
-import { useShallow } from 'zustand/react/shallow'
 import { LinkProps } from '@tanstack/react-router'
 import NavLink from '../navigation/NavLink'
 import NavHeadline from '../navigation/NavHeadline'
@@ -59,13 +58,6 @@ const publicNavData: NavSectionData[] = [
 const Navigation: React.FC<NavigationProps> = ({ isOpen, openSidebar, closeSidebar }) => {
   const isLargeScreen = useMediaQuery('(min-width: 1024px)')
   const isLoggedIn = useStore((state) => state.isAuthenticated)
-  const mapPosition = useStore(
-    useShallow((state) => ({
-      lat: state.mapCenter[0],
-      lng: state.mapCenter[1],
-      zoom: state.mapZoom,
-    })),
-  )
 
   const handleMouseOver = useCallback(() => {
     if (isLargeScreen) openSidebar()
@@ -90,7 +82,6 @@ const Navigation: React.FC<NavigationProps> = ({ isOpen, openSidebar, closeSideb
             label: 'Karte',
             icon: <Map className="w-5 h-5" />,
             to: '/map',
-            search: { lat: mapPosition.lat, lng: mapPosition.lng, zoom: mapPosition.zoom },
           },
           {
             key: 'nav-green-spaces-clusters',
@@ -173,7 +164,7 @@ const Navigation: React.FC<NavigationProps> = ({ isOpen, openSidebar, closeSideb
         ],
       },
     ],
-    [mapPosition.lat, mapPosition.lng, mapPosition.zoom],
+    [],
   )
 
   const navigationData = isLoggedIn ? protectedNavData : publicNavData

--- a/frontend/app/src/components/layout/Navigation.tsx
+++ b/frontend/app/src/components/layout/Navigation.tsx
@@ -82,6 +82,7 @@ const Navigation: React.FC<NavigationProps> = ({ isOpen, openSidebar, closeSideb
             label: 'Karte',
             icon: <Map className="w-5 h-5" />,
             to: '/map',
+            preload: false,
           },
           {
             key: 'nav-green-spaces-clusters',
@@ -173,9 +174,9 @@ const Navigation: React.FC<NavigationProps> = ({ isOpen, openSidebar, closeSideb
     <nav
       id="main-navigation"
       aria-label="Hauptnavigation"
-      onMouseOut={handleMouseOut}
-      onMouseOver={handleMouseOver}
-      className={`fixed inset-0 z-50 bg-dark w-screen overflow-hidden h-screen transition-all ease-in-out duration-300
+      onMouseLeave={handleMouseOut}
+      onMouseEnter={handleMouseOver}
+      className={`fixed inset-0 z-50 bg-dark w-screen overflow-hidden h-screen ease-in-out duration-300 transition-[width,left,visibility]
         ${isOpen ? 'visible block left-0 lg:w-[17rem] lg:rounded-r-xl' : 'invisible -left-full lg:visible lg:w-[5rem] lg:left-0'}`}
     >
       <div className="relative px-4 py-5 h-full overflow-y-auto no-scrollbar">

--- a/frontend/app/src/main.tsx
+++ b/frontend/app/src/main.tsx
@@ -10,7 +10,15 @@ import NotFound from './components/layout/NotFound'
 import ErrorFallback from './components/layout/ErrorFallback'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+})
 
 const router = createRouter({
   routeTree,
@@ -22,7 +30,7 @@ const router = createRouter({
   ),
   defaultNotFoundComponent: () => <NotFound />,
   defaultPreload: 'intent',
-  defaultPreloadStaleTime: 0,
+  defaultPreloadStaleTime: 30_000,
   scrollRestoration: true,
 })
 


### PR DESCRIPTION
Configure QueryClient with staleTime (60s), disable refetchOnWindowFocus, and increase defaultPreloadStaleTime to 30s to prevent API call storms when hovering navigation items. Remove redundant map position subscription from Navigation component
