### PR TITLE
feat(frontend): show nearest trees after sensor GPS capture (GECO-77)

### DIFF
--- a/frontend/app/src/api/queries.ts
+++ b/frontend/app/src/api/queries.ts
@@ -35,6 +35,7 @@ import {
   ServerInfo,
   ServicesInfo,
   DataStatistics,
+  NearestTreeList,
 } from './backendApi'
 
 /**
@@ -231,4 +232,11 @@ export const plantingYearsQuery = () =>
   queryOptions<number[]>({
     queryKey: ['planting-years'],
     queryFn: () => treeApi.getPlantingYears(),
+  })
+
+export const nearestTreeQuery = (params: { lat: number; lng: number; limit?: number }) =>
+  queryOptions<NearestTreeList>({
+    queryKey: ['trees', 'nearest', params.lat, params.lng, params.limit],
+    queryFn: () =>
+      treeApi.getNearestTrees({ lat: params.lat, lng: params.lng, limit: params.limit }),
   })

--- a/frontend/app/src/components/geolocation/NearestTreeMapPreview.tsx
+++ b/frontend/app/src/components/geolocation/NearestTreeMapPreview.tsx
@@ -1,0 +1,113 @@
+import { SensorMarkerIcon, TreeMarkerIcon } from '@/components/map/markerIcons'
+import ZoomControls from '@/components/map/ZoomControls'
+import { getWateringStatusDetails } from '@/hooks/details/useDetailsForWateringStatus'
+import { type TreeWithDistance, WateringStatus } from '@green-ecolution/backend-client'
+import { cn } from '@green-ecolution/ui'
+import L from 'leaflet'
+import { useMemo } from 'react'
+import { Circle, MapContainer, Marker, TileLayer } from 'react-leaflet'
+
+interface NearestTreeMapPreviewProps {
+  sensorLat: number
+  sensorLng: number
+  sensorAccuracy?: number | null
+  trees: TreeWithDistance[]
+  selectedTreeId: number | null
+  onSelectTree?: (treeId: number) => void
+  className?: string
+}
+
+const NearestTreeMapPreview = ({
+  sensorLat,
+  sensorLng,
+  sensorAccuracy,
+  trees,
+  selectedTreeId,
+  onSelectTree,
+  className,
+}: NearestTreeMapPreviewProps) => {
+  const sensorPos = L.latLng(sensorLat, sensorLng)
+  const radius = sensorAccuracy && sensorAccuracy > 0 ? sensorAccuracy : null
+
+  const bounds = useMemo(() => {
+    const points: L.LatLngExpression[] = [
+      [sensorLat, sensorLng],
+      ...trees.map((t) => [t.tree.latitude, t.tree.longitude] as L.LatLngTuple),
+    ]
+    if (points.length < 2) {
+      return L.latLngBounds([sensorPos, sensorPos]).pad(0.5)
+    }
+    return L.latLngBounds(points).pad(0.3)
+  }, [sensorLat, sensorLng, sensorPos, trees])
+
+  return (
+    <div
+      aria-label="Karte mit Sensor-Position und nahegelegenen Bäumen"
+      className={cn(
+        'relative w-full overflow-hidden rounded-2xl border border-dark-100 shadow-cards',
+        'aspect-[4/3] sm:aspect-[16/10]',
+        className,
+      )}
+    >
+      <MapContainer
+        preferCanvas
+        zoomControl={false}
+        attributionControl={false}
+        dragging={true}
+        touchZoom={true}
+        doubleClickZoom={true}
+        scrollWheelZoom={true}
+        boxZoom={true}
+        keyboard={true}
+        className="z-0 h-full w-full"
+        bounds={bounds}
+        maxZoom={19}
+        minZoom={3}
+      >
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" keepBuffer={2} />
+
+        {radius && (
+          <Circle
+            center={sensorPos}
+            radius={radius}
+            pathOptions={{
+              color: 'oklch(0.62 0.20 145)',
+              fillColor: 'oklch(0.62 0.20 145)',
+              fillOpacity: 0.15,
+              weight: 1.5,
+            }}
+          />
+        )}
+
+        <ZoomControls />
+        <Marker position={sensorPos} icon={SensorMarkerIcon()} />
+
+        {trees.map((entry) => {
+          const { tree } = entry
+          const statusDetails = getWateringStatusDetails(
+            tree.wateringStatus ?? WateringStatus.WateringStatusUnknown,
+          )
+          const isSelected = tree.id === selectedTreeId
+
+          return (
+            <Marker
+              key={tree.id}
+              position={[tree.latitude, tree.longitude]}
+              icon={TreeMarkerIcon(statusDetails.colorHex, isSelected, false)}
+              eventHandlers={{
+                click: () => onSelectTree?.(tree.id),
+              }}
+            />
+          )
+        })}
+      </MapContainer>
+
+      <span className="pointer-events-none absolute bottom-1 right-2 text-[10px] text-dark-600/80 font-mono bg-white/70 px-1 rounded">
+        © OpenStreetMap
+      </span>
+    </div>
+  )
+}
+
+export default NearestTreeMapPreview
+export type { NearestTreeMapPreviewProps }

--- a/frontend/app/src/components/scanner/QRScanResult.tsx
+++ b/frontend/app/src/components/scanner/QRScanResult.tsx
@@ -1,6 +1,14 @@
 import createToast from '@/hooks/createToast'
-import { Button, Card, CardContent, CardFooter, CardHeader, CardTitle } from '@green-ecolution/ui'
-import { ArrowRight, CheckCircle2, Copy, RotateCcw } from 'lucide-react'
+import {
+  Button,
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  CopyableText,
+} from '@green-ecolution/ui'
+import { ArrowRight, CheckCircle2, RotateCcw } from 'lucide-react'
 
 interface QRScanResultProps {
   sensorId: string
@@ -39,25 +47,12 @@ const QRScanResult = ({
         </div>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
-        <div className="flex flex-col gap-2">
-          <span className="text-xs uppercase tracking-widest text-muted-foreground">Sensor-ID</span>
-          <code className="relative flex items-center font-mono text-lg md:text-xl font-semibold break-all bg-dark-50 rounded-lg pl-3 pr-10 py-2 border border-dark-100">
-            <span className="flex-1">{sensorId}</span>
-            <button
-              type="button"
-              onClick={() => {
-                navigator.clipboard
-                  .writeText(sensorId)
-                  .then(() => showToast('Sensor-ID kopiert', 'success'))
-                  .catch(() => showToast('Sensor-ID konnte nicht kopiert werden', 'error'))
-              }}
-              aria-label="Sensor-ID kopieren"
-              className="absolute right-1.5 top-1/2 -translate-y-1/2 p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-dark-100 transition-colors cursor-pointer"
-            >
-              <Copy className="size-4" />
-            </button>
-          </code>
-        </div>
+        <CopyableText
+          value={sensorId}
+          label="Sensor-ID"
+          onCopy={() => showToast('Sensor-ID kopiert', 'success')}
+          onCopyError={() => showToast('Sensor-ID konnte nicht kopiert werden', 'error')}
+        />
         {extra}
       </CardContent>
       <CardFooter className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2">

--- a/frontend/app/src/components/sensor/NearestTreeList.tsx
+++ b/frontend/app/src/components/sensor/NearestTreeList.tsx
@@ -1,0 +1,130 @@
+import { treeClusterIdQuery } from '@/api/queries'
+import { type TreeWithDistance } from '@green-ecolution/backend-client'
+import { Badge, cn } from '@green-ecolution/ui'
+import { useQuery } from '@tanstack/react-query'
+import { Check, MapPin, TreeDeciduous } from 'lucide-react'
+import { useEffect } from 'react'
+
+function formatDistance(meters: number): string {
+  if (meters >= 1000) {
+    return `${new Intl.NumberFormat('de-DE', { maximumFractionDigits: 1 }).format(meters / 1000)} km`
+  }
+  if (meters < 10) {
+    return `${new Intl.NumberFormat('de-DE', { maximumFractionDigits: 1 }).format(meters)} m`
+  }
+  return `${new Intl.NumberFormat('de-DE', { maximumFractionDigits: 0 }).format(meters)} m`
+}
+
+interface NearestTreeListProps {
+  trees: TreeWithDistance[]
+  selectedTreeId: number | null
+  onSelect: (treeId: number) => void
+}
+
+const NearestTreeListItem = ({
+  entry,
+  isSelected,
+  onSelect,
+}: {
+  entry: TreeWithDistance
+  isSelected: boolean
+  onSelect: () => void
+}) => {
+  const { tree, distanceMeters } = entry
+
+  const clusterId = tree.treeClusterId ? String(tree.treeClusterId) : null
+  const { data: clusterRes } = useQuery({
+    ...treeClusterIdQuery(clusterId!),
+    enabled: clusterId !== null,
+  })
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={isSelected}
+      className={cn(
+        'relative w-full text-left rounded-xl border bg-white p-4 shadow-cards',
+        'transition-all duration-200 ease-in-out',
+        'hover:bg-green-dark-50/50',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-dark focus-visible:ring-offset-2',
+        isSelected
+          ? 'border-green-dark ring-2 ring-green-dark/20 bg-green-dark-50/30'
+          : 'border-dark-100',
+      )}
+    >
+      <div className="flex items-start gap-3">
+        {/* Selection indicator */}
+        <div
+          className={cn(
+            'mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border-2 transition-colors',
+            isSelected ? 'border-green-dark bg-green-dark text-white' : 'border-dark-200 bg-white',
+          )}
+        >
+          {isSelected && <Check className="size-3" strokeWidth={3} />}
+        </div>
+
+        {/* Content */}
+        <div className="min-w-0 flex-1">
+          {/* Top row: species + distance */}
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <TreeDeciduous className="size-4 shrink-0 text-green-dark" aria-hidden />
+              <span className="font-semibold text-sm truncate">{tree.species}</span>
+            </div>
+            <Badge variant="green-dark" size="lg" className="shrink-0 tabular-nums font-bold">
+              <MapPin className="mr-1 size-3" aria-hidden />
+              {formatDistance(distanceMeters)}
+            </Badge>
+          </div>
+
+          {/* Details row */}
+          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-dark-800">
+            <span className="font-mono text-xs text-dark-600">{tree.number}</span>
+            <span className="text-dark-200" aria-hidden>
+              |
+            </span>
+            <span className="text-dark-600 text-xs">
+              {tree.treeClusterId ? (clusterRes?.name ?? '…') : 'Nicht zugeordnet'}
+            </span>
+          </div>
+        </div>
+      </div>
+    </button>
+  )
+}
+
+const NearestTreeList = ({ trees, selectedTreeId, onSelect }: NearestTreeListProps) => {
+  useEffect(() => {
+    if (selectedTreeId === null && trees.length > 0) {
+      onSelect(trees[0].tree.id)
+    }
+  }, [trees, selectedTreeId, onSelect])
+
+  return (
+    <section aria-label="Bäume in der Nähe">
+      <div className="flex items-center gap-2 mb-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-dark-600">
+          Bäume in der Nähe
+        </h2>
+        <Badge variant="muted" size="default">
+          {trees.length}
+        </Badge>
+      </div>
+
+      <div className="flex flex-col gap-2" role="radiogroup" aria-label="Baum auswählen">
+        {trees.map((entry) => (
+          <NearestTreeListItem
+            key={entry.tree.id}
+            entry={entry}
+            isSelected={entry.tree.id === selectedTreeId}
+            onSelect={() => onSelect(entry.tree.id)}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default NearestTreeList
+export type { NearestTreeListProps }

--- a/frontend/app/src/components/sensor/SensorGeolocationSummary.tsx
+++ b/frontend/app/src/components/sensor/SensorGeolocationSummary.tsx
@@ -1,9 +1,24 @@
+import { nearestTreeQuery } from '@/api/queries'
 import GeolocationPermissionNotice from '@/components/geolocation/GeolocationPermissionNotice'
 import GPSStatusCard from '@/components/geolocation/GPSStatusCard'
 import LocationMapPreview from '@/components/geolocation/LocationMapPreview'
+import NearestTreeMapPreview from '@/components/geolocation/NearestTreeMapPreview'
+import NearestTreeList from '@/components/sensor/NearestTreeList'
 import type { GeolocationFix, GeolocationStatus } from '@/hooks/useGeolocation'
-import { Card, CardContent, Button, InlineAlert } from '@green-ecolution/ui'
-import { CheckCircle2, Crosshair, Loader2, MapPin, RotateCw } from 'lucide-react'
+import {
+  Button,
+  InlineAlert,
+  Loading,
+  Alert,
+  AlertContent,
+  AlertTitle,
+  AlertDescription,
+  CopyableText,
+  toast,
+} from '@green-ecolution/ui'
+import { useQuery } from '@tanstack/react-query'
+import { CheckCircle2, Crosshair, Loader2, MapPin, RotateCw, TreeDeciduous } from 'lucide-react'
+import { useCallback, useState } from 'react'
 
 interface SensorGeolocationSummaryProps {
   sensorId: string
@@ -12,6 +27,7 @@ interface SensorGeolocationSummaryProps {
   errorMessage: string | null
   onScanAgain: () => void
   onRelocate: () => void
+  onConfirmTree?: (treeId: number) => void
 }
 
 const MapPlaceholder = ({ status }: { status: GeolocationStatus }) => {
@@ -44,9 +60,36 @@ const SensorGeolocationSummary = ({
   errorMessage,
   onScanAgain,
   onRelocate,
+  onConfirmTree,
 }: SensorGeolocationSummaryProps) => {
   const noticeStatus: 'denied' | 'unsupported' | 'error' | null =
     status === 'denied' || status === 'unsupported' || status === 'error' ? status : null
+
+  const [selectedTreeId, setSelectedTreeId] = useState<number | null>(null)
+  const [confirmed, setConfirmed] = useState(false)
+
+  const {
+    data: nearestTrees,
+    isLoading: treesLoading,
+    isError: treesError,
+    refetch: refetchTrees,
+  } = useQuery({
+    ...nearestTreeQuery({
+      lat: position?.latitude ?? 0,
+      lng: position?.longitude ?? 0,
+    }),
+    enabled: !!position,
+  })
+
+  const trees = nearestTrees?.data ?? []
+  const selectedTree = trees.find((t) => t.tree.id === selectedTreeId)
+
+  const handleConfirm = useCallback(() => {
+    if (!selectedTree) return
+    setConfirmed(true)
+    toast.success(`Sensor wird Baum ${selectedTree.tree.number} zugeordnet`)
+    onConfirmTree?.(selectedTree.tree.id)
+  }, [selectedTree, onConfirmTree])
 
   return (
     <div className="mx-auto w-full max-w-3xl pb-[env(safe-area-inset-bottom)]">
@@ -56,26 +99,22 @@ const SensorGeolocationSummary = ({
         <span>Sensor erfasst</span>
       </div>
 
-      <InlineAlert
-        variant="warning"
-        description="Die Speicherung des Sensors ist noch nicht implementiert."
-        className="mb-4 w-full"
-      />
-
       <div className="grid gap-4 md:grid-cols-2 md:gap-6">
         {/* Sensor-ID — spans both columns */}
-        <Card variant="outlined" className="md:col-span-2">
-          <CardContent className="p-5">
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Sensor-ID</p>
-            <p className="mt-1 font-mono text-2xl font-semibold tracking-tight break-all">
-              {sensorId}
-            </p>
-          </CardContent>
-        </Card>
+        <CopyableText value={sensorId} label="Sensor-ID" className="md:col-span-2" />
 
-        {/* Map (anchor) */}
+        {/* Map */}
         <div className="md:col-span-1">
-          {position ? (
+          {position && trees.length > 0 ? (
+            <NearestTreeMapPreview
+              sensorLat={position.latitude}
+              sensorLng={position.longitude}
+              sensorAccuracy={position.accuracy}
+              trees={trees}
+              selectedTreeId={selectedTreeId}
+              onSelectTree={setSelectedTreeId}
+            />
+          ) : position ? (
             <LocationMapPreview
               latitude={position.latitude}
               longitude={position.longitude}
@@ -97,8 +136,54 @@ const SensorGeolocationSummary = ({
           <GPSStatusCard fix={position} title="Erfasster Standort" />
         </div>
 
-        {/* Actions — both secondary until "Sensor speichern" exists. */}
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:col-span-2">
+        {/* Nearest trees */}
+        {position && (
+          <div className="md:col-span-2">
+            {treesLoading && <Loading size="default" label="Bäume in der Nähe werden gesucht…" />}
+
+            {treesError && (
+              <Alert variant="destructive">
+                <AlertContent>
+                  <AlertTitle>Baumsuche fehlgeschlagen</AlertTitle>
+                  <AlertDescription>
+                    Die Suche nach Bäumen in der Nähe ist fehlgeschlagen.
+                  </AlertDescription>
+                </AlertContent>
+                <Button variant="outline" size="sm" onClick={() => void refetchTrees()}>
+                  Erneut versuchen
+                </Button>
+              </Alert>
+            )}
+
+            {!treesLoading && !treesError && trees.length === 0 && (
+              <InlineAlert
+                variant="warning"
+                description="Es wurden keine Bäume in der Nähe gefunden. Überprüfe den Standort oder ordne den Sensor manuell zu."
+              />
+            )}
+
+            {trees.length > 0 && (
+              <NearestTreeList
+                trees={trees}
+                selectedTreeId={selectedTreeId}
+                onSelect={setSelectedTreeId}
+              />
+            )}
+          </div>
+        )}
+
+        {/* Confirmed notice */}
+        {confirmed && (
+          <div className="md:col-span-2">
+            <InlineAlert
+              variant="info"
+              description="Die Verknüpfung wird gespeichert, sobald die Sensor-Synchronisation verfügbar ist."
+            />
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3 md:col-span-2">
           <Button variant="outline" onClick={onScanAgain}>
             <RotateCw className="size-4" />
             Erneut scannen
@@ -107,6 +192,25 @@ const SensorGeolocationSummary = ({
             <MapPin className="size-4" />
             Erneut lokalisieren
           </Button>
+          {trees.length > 0 && (
+            <Button
+              onClick={handleConfirm}
+              disabled={!selectedTreeId || confirmed}
+              variant={confirmed ? 'outline' : 'default'}
+            >
+              {confirmed ? (
+                <>
+                  <CheckCircle2 className="size-4" />
+                  Zugeordnet
+                </>
+              ) : (
+                <>
+                  <TreeDeciduous className="size-4" />
+                  Baum zuordnen
+                </>
+              )}
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/app/src/routes/_protected/sensors/new/index.tsx
+++ b/frontend/app/src/routes/_protected/sensors/new/index.tsx
@@ -4,7 +4,7 @@ import QRScannerView from '@/components/scanner/QRScannerView'
 import SensorGeolocationSummary from '@/components/sensor/SensorGeolocationSummary'
 import useGeolocation, { type GeolocationFix } from '@/hooks/useGeolocation'
 import { createFileRoute } from '@tanstack/react-router'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 export const Route = createFileRoute('/_protected/sensors/new/')({
   component: NewSensor,
@@ -55,6 +55,10 @@ function NewSensor() {
     }
   }
 
+  const handleConfirmTree = useCallback((_treeId: number) => {
+    // Tree assignment stored for future backend linking
+  }, [])
+
   const summaryFix = frozenFix ?? (scannedSensorId ? position : null)
 
   return (
@@ -79,6 +83,7 @@ function NewSensor() {
           errorMessage={errorMessage}
           onScanAgain={handleScanAgain}
           onRelocate={handleRelocate}
+          onConfirmTree={handleConfirmTree}
         />
       ) : (
         <QRScannerView

--- a/frontend/packages/ui/src/components/ui/copyable-text.tsx
+++ b/frontend/packages/ui/src/components/ui/copyable-text.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import { Copy, Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface CopyableTextProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** The text value to display and copy. */
+  value: string
+  /** Optional label rendered above the text. */
+  label?: string
+  /** Callback fired after a successful copy. */
+  onCopy?: () => void
+  /** Callback fired when copying fails. */
+  onCopyError?: () => void
+}
+
+const CopyableText = React.forwardRef<HTMLDivElement, CopyableTextProps>(
+  ({ value, label, onCopy, onCopyError, className, ...props }, ref) => {
+    const [copied, setCopied] = React.useState(false)
+
+    const handleCopy = () => {
+      navigator.clipboard
+        .writeText(value)
+        .then(() => {
+          setCopied(true)
+          onCopy?.()
+          setTimeout(() => setCopied(false), 2000)
+        })
+        .catch(() => {
+          onCopyError?.()
+        })
+    }
+
+    return (
+      <div ref={ref} className={cn('flex flex-col gap-2', className)} {...props}>
+        {label && (
+          <span className="text-xs uppercase tracking-widest text-muted-foreground">{label}</span>
+        )}
+        <code className="relative flex items-center font-mono text-lg md:text-xl font-semibold break-all bg-dark-50 rounded-lg pl-3 pr-10 py-2 border border-dark-100">
+          <span className="flex-1">{value}</span>
+          <button
+            type="button"
+            onClick={handleCopy}
+            aria-label={`${label ?? value} kopieren`}
+            className="absolute right-1.5 top-1/2 -translate-y-1/2 p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-dark-100 transition-colors cursor-pointer"
+          >
+            {copied ? <Check className="size-4 text-green-dark" /> : <Copy className="size-4" />}
+          </button>
+        </code>
+      </div>
+    )
+  },
+)
+CopyableText.displayName = 'CopyableText'
+
+export { CopyableText }

--- a/frontend/packages/ui/src/index.ts
+++ b/frontend/packages/ui/src/index.ts
@@ -103,6 +103,10 @@ export type { ChartConfig } from './components/ui/chart'
 // Checkbox
 export { Checkbox } from './components/ui/checkbox'
 
+// CopyableText
+export { CopyableText } from './components/ui/copyable-text'
+export type { CopyableTextProps } from './components/ui/copyable-text'
+
 // DatePickerField
 export { DatePickerField } from './components/ui/date-picker-field'
 export type { DatePickerFieldProps } from './components/ui/date-picker-field'

--- a/frontend/packages/ui/stories/CopyableText.stories.tsx
+++ b/frontend/packages/ui/stories/CopyableText.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { CopyableText } from '../src/components/ui/copyable-text'
+
+const meta: Meta<typeof CopyableText> = {
+  title: 'UI/CopyableText',
+  component: CopyableText,
+  tags: ['autodocs'],
+  argTypes: {
+    value: { control: 'text' },
+    label: { control: 'text' },
+  },
+  args: {
+    value: 'eui-a84041d55188a64d',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithLabel: Story = {
+  args: {
+    label: 'Sensor-ID',
+    value: 'eui-a84041d55188a64d',
+  },
+}
+
+export const ShortValue: Story = {
+  args: {
+    label: 'Code',
+    value: 'ABC-123',
+  },
+}
+
+export const LongValue: Story = {
+  args: {
+    label: 'API Key',
+    value: 'sk-proj-a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6',
+  },
+}


### PR DESCRIPTION
## Summary
- Show nearest trees automatically after GPS capture in the sensor-add flow
- Field technicians can select a tree from a ranked list or by clicking markers on the map
- Add reusable `CopyableText` UI component with Storybook story

close GECO-77

## Problem
When adding a new sensor, the technician had to manually find and assign the nearest tree. There was no automatic suggestion based on the captured GPS position, making the workflow slow and error-prone in the field.

## Solution
After the QR code scan and GPS capture, the frontend now calls the `GET /v1/tree/nearest` endpoint and displays a ranked list of nearby trees with distance, species, tree number, and cluster membership. The map shows both the sensor position and all nearby tree markers — the selected tree is highlighted. Clicking a marker or list item selects the tree. A confirm button allows the technician to finalize the assignment (backend linking is deferred until sensor sync is implemented).

Additionally, the inline copy-to-clipboard pattern for the sensor ID was extracted into a reusable `CopyableText` component in the UI package.

**New files:**
- `NearestTreeList.tsx` — ranked tree list with distance badges and selection
- `NearestTreeMapPreview.tsx` — interactive map with sensor + tree markers
- `copyable-text.tsx` — reusable UI component with Storybook story

**Modified files:**
- `queries.ts` — added `nearestTreeQuery`
- `SensorGeolocationSummary.tsx` — integrated tree suggestion, map, and confirm flow
- `QRScanResult.tsx` — replaced inline copy pattern with `CopyableText`
- `sensors/new/index.tsx` — wired `onConfirmTree` callback

## Definition of Done
- [x] Code compiles without errors
- [x] All tests pass (`make test`)
- [x] No new linter warnings (`make lint`)
- [ ] Code reviewed by at least 1 person
- [ ] Documentation updated (if applicable)
- [x] Acceptance criteria from issue fulfilled

## Test Plan
- [x] Navigate to `/sensors/new`, scan a QR code, wait for GPS fix
- [x] Verify nearest trees list appears below the map, sorted by distance (closest first)
- [x] Verify each tree shows distance badge, species, number, and cluster name
- [x] Verify closest tree is auto-selected and highlighted on the map
- [x] Click a different tree in the list — map marker updates accordingly
- [x] Click a tree marker on the map — list selection updates accordingly
- [x] Zoom and pan the map using custom zoom controls
- [x] Click "Baum zuordnen" — toast appears, button changes to "Zugeordnet"
- [x] Verify sensor ID is copyable via the copy button (both in QR result and summary)
- [x] Verify empty state when no trees are nearby
- [x] Verify loading state while API fetches
- [x] Verify error state with retry button on API failure
- [x] Test on mobile viewport (responsive layout)

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->
