### PR TITLE
refactor(backend): remove go-geos dependency and disable CGO (GECO-103)

### DIFF
--- a/.github/actions/setup-backend/action.yaml
+++ b/.github/actions/setup-backend/action.yaml
@@ -1,10 +1,5 @@
 name: "Setup Backend"
 description: "Shared setup for backend CI jobs: system deps + Go toolchain"
-inputs:
-  with-cgo-deps:
-    description: "Install geos/proj (needed for CGO builds & tests, not for pure Go jobs)"
-    required: false
-    default: "true"
 runs:
   using: "composite"
   steps:
@@ -12,11 +7,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        if [ "${{ inputs.with-cgo-deps }}" = "true" ]; then
-          sudo apt-get install -y --no-install-recommends just build-essential libgeos-dev libproj-dev
-        else
-          sudo apt-get install -y --no-install-recommends just
-        fi
+        sudo apt-get install -y --no-install-recommends just
     - name: Setup Go
       uses: actions/setup-go@v6
       with:

--- a/.github/workflows/backend-pr.yaml
+++ b/.github/workflows/backend-pr.yaml
@@ -102,8 +102,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-backend
-        with:
-          with-cgo-deps: "false"
       - name: Generate OpenAPI client
         run: just generate-client
       - name: Check generated client is fresh
@@ -128,8 +126,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-backend
-        with:
-          with-cgo-deps: "false"
       - name: Test pkg/client
         working-directory: ./backend/pkg/client
         run: go test ./...
@@ -163,8 +159,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-backend
-        with:
-          with-cgo-deps: "false"
       - name: Test migrations up
         run: just migrate-up
       - name: Test migrations down

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app/build
 
 # install build dependencies
 COPY ./go.mod ./go.sum ./
-RUN apk add --no-cache make git geos-dev build-base proj-dev
+RUN apk add --no-cache git
 RUN go mod download
 
 COPY . .
@@ -25,7 +25,7 @@ ARG APP_GIT_BRANCH="develop"
 ARG APP_GIT_REPOSITORY="https://github.com/green-ecolution/green-ecolution/backend"
 ARG APP_BUILD_TIME="unknown"
 
-RUN CGO_ENABLED=1 go build -o "bin/green-ecolution" \
+RUN CGO_ENABLED=0 go build -o "bin/green-ecolution" \
     -ldflags=" \
       -s -w \
       -X main.version=${APP_VERSION} \
@@ -44,7 +44,7 @@ FROM alpine:3.23 AS runner
 EXPOSE 3000
 
 RUN adduser -D gorunner
-RUN apk add --no-cache geos proj curl
+RUN apk add --no-cache curl
 
 USER gorunner
 WORKDIR /app

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -34,8 +34,6 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
-	github.com/twpayne/go-geos v0.20.3
-	github.com/twpayne/pgx-geos v1.0.1
 	golang.org/x/sync v0.20.0
 )
 
@@ -63,6 +61,7 @@ require (
 	github.com/OpenPeeDeeP/depguard/v2 v2.2.0 // indirect
 	github.com/air-verse/air v1.61.7 // indirect
 	github.com/alecthomas/go-check-sumtype v0.3.1 // indirect
+	github.com/alecthomas/repr v0.5.2 // indirect
 	github.com/alexkohler/nakedret/v2 v2.0.5 // indirect
 	github.com/alexkohler/prealloc v1.0.0 // indirect
 	github.com/alingse/asasalint v0.0.11 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -978,10 +978,6 @@ github.com/tommy-muehle/go-mnd/v2 v2.5.1 h1:NowYhSdyE/1zwK9QCLeRb6USWdoif80Ie+v+
 github.com/tommy-muehle/go-mnd/v2 v2.5.1/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
 github.com/tursodatabase/libsql-client-go v0.0.0-20251219100830-236aa1ff8acc h1:lzi/5fg2EfinRlh3v//YyIhnc4tY7BTqazQGwb1ar+0=
 github.com/tursodatabase/libsql-client-go v0.0.0-20251219100830-236aa1ff8acc/go.mod h1:08inkKyguB6CGGssc/JzhmQWwBgFQBgjlYFjxjRh7nU=
-github.com/twpayne/go-geos v0.20.3 h1:5LbhiQ/YuOht2Udh0GwMVQ7L2UJVrLnmz51IY+a3WH4=
-github.com/twpayne/go-geos v0.20.3/go.mod h1:pclaO38DG71FzG6f8RJd/DOQ9njaZLrMYerBtMChQZ4=
-github.com/twpayne/pgx-geos v1.0.1 h1:RTJ269z1BMZpejm/eJ7F5vpjoRBhlUU4aoqj2G6wDrA=
-github.com/twpayne/pgx-geos v1.0.1/go.mod h1:j/IsZpQFB69eGy34LIY8I5UyeD468jTM8E0dYSQF3FI=
 github.com/ultraware/funlen v0.2.0 h1:gCHmCn+d2/1SemTdYMiKLAHFYxTYz7z9VIDRaTGyLkI=
 github.com/ultraware/funlen v0.2.0/go.mod h1:ZE0q4TsJ8T1SQcjmkhN/w+MceuatI6pBFSxxyteHIJA=
 github.com/ultraware/whitespace v0.2.0 h1:TYowo2m9Nfj1baEQBjuHzvMRbp19i+RCcRYrSWoFa+g=

--- a/backend/internal/storage/_mock/mock_Querier.go
+++ b/backend/internal/storage/_mock/mock_Querier.go
@@ -195,22 +195,24 @@ func (_c *MockQuerier_CalculateGroupedCentroids_Call) RunAndReturn(run func(cont
 }
 
 // CalculateTreesCentroid provides a mock function with given fields: ctx, treeClusterID
-func (_m *MockQuerier) CalculateTreesCentroid(ctx context.Context, treeClusterID *int32) (string, error) {
+func (_m *MockQuerier) CalculateTreesCentroid(ctx context.Context, treeClusterID *int32) (*sqlc.CalculateTreesCentroidRow, error) {
 	ret := _m.Called(ctx, treeClusterID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CalculateTreesCentroid")
 	}
 
-	var r0 string
+	var r0 *sqlc.CalculateTreesCentroidRow
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *int32) (string, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *int32) (*sqlc.CalculateTreesCentroidRow, error)); ok {
 		return rf(ctx, treeClusterID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *int32) string); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *int32) *sqlc.CalculateTreesCentroidRow); ok {
 		r0 = rf(ctx, treeClusterID)
 	} else {
-		r0 = ret.Get(0).(string)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sqlc.CalculateTreesCentroidRow)
+		}
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *int32) error); ok {
@@ -241,12 +243,12 @@ func (_c *MockQuerier_CalculateTreesCentroid_Call) Run(run func(ctx context.Cont
 	return _c
 }
 
-func (_c *MockQuerier_CalculateTreesCentroid_Call) Return(_a0 string, _a1 error) *MockQuerier_CalculateTreesCentroid_Call {
+func (_c *MockQuerier_CalculateTreesCentroid_Call) Return(_a0 *sqlc.CalculateTreesCentroidRow, _a1 error) *MockQuerier_CalculateTreesCentroid_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockQuerier_CalculateTreesCentroid_Call) RunAndReturn(run func(context.Context, *int32) (string, error)) *MockQuerier_CalculateTreesCentroid_Call {
+func (_c *MockQuerier_CalculateTreesCentroid_Call) RunAndReturn(run func(context.Context, *int32) (*sqlc.CalculateTreesCentroidRow, error)) *MockQuerier_CalculateTreesCentroid_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/storage/postgres/_sqlc/models.go
+++ b/backend/internal/storage/postgres/_sqlc/models.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	geos "github.com/twpayne/go-geos"
 )
 
 type DrivingLicense string
@@ -328,7 +327,7 @@ type Region struct {
 	Name      string
 	CreatedAt time.Time
 	UpdatedAt time.Time
-	Geometry  *geos.Geom
+	Geometry  *string
 }
 
 type Sensor struct {
@@ -338,7 +337,7 @@ type Sensor struct {
 	Status                 SensorStatus
 	Latitude               float64
 	Longitude              float64
-	Geometry               *geos.Geom
+	Geometry               *string
 	Provider               *string
 	AdditionalInformations []byte
 }
@@ -363,7 +362,7 @@ type Tree struct {
 	Latitude               float64
 	Longitude              float64
 	WateringStatus         WateringStatus
-	Geometry               *geos.Geom
+	Geometry               *string
 	Description            *string
 	Provider               *string
 	AdditionalInformations []byte
@@ -383,7 +382,7 @@ type TreeCluster struct {
 	SoilCondition          TreeSoilCondition
 	Latitude               *float64
 	Longitude              *float64
-	Geometry               *geos.Geom
+	Geometry               *string
 	RegionID               *int32
 	Name                   string
 	Provider               *string

--- a/backend/internal/storage/postgres/_sqlc/querier.go
+++ b/backend/internal/storage/postgres/_sqlc/querier.go
@@ -14,7 +14,7 @@ type Querier interface {
 	ArchiveTreeCluster(ctx context.Context, id int32) (int32, error)
 	ArchiveVehicle(ctx context.Context, arg *ArchiveVehicleParams) (int32, error)
 	CalculateGroupedCentroids(ctx context.Context, dollar_1 []int32) (string, error)
-	CalculateTreesCentroid(ctx context.Context, treeClusterID *int32) (string, error)
+	CalculateTreesCentroid(ctx context.Context, treeClusterID *int32) (*CalculateTreesCentroidRow, error)
 	CreateRegion(ctx context.Context, arg *CreateRegionParams) (int32, error)
 	CreateSensor(ctx context.Context, arg *CreateSensorParams) (string, error)
 	CreateTree(ctx context.Context, arg *CreateTreeParams) (int32, error)

--- a/backend/internal/storage/postgres/_sqlc/treecluster.sql.go
+++ b/backend/internal/storage/postgres/_sqlc/treecluster.sql.go
@@ -23,14 +23,21 @@ func (q *Queries) ArchiveTreeCluster(ctx context.Context, id int32) (int32, erro
 }
 
 const calculateTreesCentroid = `-- name: CalculateTreesCentroid :one
-SELECT ST_AsText(ST_Centroid(ST_Collect(geometry)))::text AS centroid FROM trees WHERE trees.tree_cluster_id = $1
+SELECT ST_X(ST_Centroid(ST_Collect(geometry)))::float8 AS center_x,
+       ST_Y(ST_Centroid(ST_Collect(geometry)))::float8 AS center_y
+FROM trees WHERE trees.tree_cluster_id = $1
 `
 
-func (q *Queries) CalculateTreesCentroid(ctx context.Context, treeClusterID *int32) (string, error) {
+type CalculateTreesCentroidRow struct {
+	CenterX float64
+	CenterY float64
+}
+
+func (q *Queries) CalculateTreesCentroid(ctx context.Context, treeClusterID *int32) (*CalculateTreesCentroidRow, error) {
 	row := q.db.QueryRow(ctx, calculateTreesCentroid, treeClusterID)
-	var centroid string
-	err := row.Scan(&centroid)
-	return centroid, err
+	var i CalculateTreesCentroidRow
+	err := row.Scan(&i.CenterX, &i.CenterY)
+	return &i, err
 }
 
 const createTreeCluster = `-- name: CreateTreeCluster :one

--- a/backend/internal/storage/postgres/queries/treecluster.sql
+++ b/backend/internal/storage/postgres/queries/treecluster.sql
@@ -82,7 +82,9 @@ WHERE id = $1 RETURNING id;
 DELETE FROM tree_clusters WHERE id = $1 RETURNING id;
 
 -- name: CalculateTreesCentroid :one
-SELECT ST_AsText(ST_Centroid(ST_Collect(geometry)))::text AS centroid FROM trees WHERE trees.tree_cluster_id = $1;
+SELECT ST_X(ST_Centroid(ST_Collect(geometry)))::float8 AS center_x,
+       ST_Y(ST_Centroid(ST_Collect(geometry)))::float8 AS center_y
+FROM trees WHERE trees.tree_cluster_id = $1;
 
 -- name: GetAllLatestSensorDataByTreeClusterID :many
 SELECT sd.*

--- a/backend/internal/storage/postgres/testutils/container.go
+++ b/backend/internal/storage/postgres/testutils/container.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -20,9 +19,6 @@ var (
 
 // SetupPostgres starts a postgres container
 func SetupPostgres(ctx context.Context) *postgres.PostgresContainer {
-	startupTimeout := time.Second * 30
-	pollInterval := time.Microsecond * 100
-
 	postgis, err := postgres.Run(ctx,
 		"postgis/postgis",
 		postgres.WithDatabase(dbName),
@@ -30,12 +26,9 @@ func SetupPostgres(ctx context.Context) *postgres.PostgresContainer {
 		postgres.WithPassword(dbPassword),
 		postgres.WithSQLDriver(dbDriver),
 		testcontainers.WithWaitStrategy(
-			wait.ForSQL("5432/tcp", dbDriver, func(host string, port string) string {
-				return fmt.Sprintf("postgresql://%s:%s@%s:%s/%s", dbUsername, dbPassword, host, port, dbName)
-			}).
-				WithStartupTimeout(startupTimeout).
-				WithPollInterval(pollInterval).
-				WithQuery("SELECT 1"),
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
 		),
 	)
 	if err != nil {

--- a/backend/internal/storage/postgres/testutils/suite.go
+++ b/backend/internal/storage/postgres/testutils/suite.go
@@ -3,6 +3,7 @@ package testutils
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log"
 	"log/slog"
 	"testing"
@@ -10,11 +11,10 @@ import (
 	sqlc "github.com/green-ecolution/green-ecolution/backend/internal/storage/postgres/_sqlc"
 	"github.com/green-ecolution/green-ecolution/backend/internal/storage/postgres/store"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/twpayne/go-geos"
-	pgxgeos "github.com/twpayne/pgx-geos"
 )
 
 type PostgresTestSuite struct {
@@ -89,7 +89,16 @@ func initStore(dbURL string) *store.Store {
 	}
 
 	pgxConfig.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
-		return pgxgeos.Register(ctx, conn, geos.NewContext())
+		var geometryOID uint32
+		if err := conn.QueryRow(ctx, "SELECT 'geometry'::regtype::oid").Scan(&geometryOID); err != nil {
+			return fmt.Errorf("failed to get geometry type OID: %w", err)
+		}
+		conn.TypeMap().RegisterType(&pgtype.Type{
+			Name:  "geometry",
+			OID:   geometryOID,
+			Codec: &pgtype.TextCodec{},
+		})
+		return nil
 	}
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), pgxConfig)

--- a/backend/internal/storage/postgres/treecluster/get.go
+++ b/backend/internal/storage/postgres/treecluster/get.go
@@ -10,7 +10,6 @@ import (
 	"github.com/green-ecolution/green-ecolution/backend/internal/entities"
 	"github.com/green-ecolution/green-ecolution/backend/internal/logger"
 	sqlc "github.com/green-ecolution/green-ecolution/backend/internal/storage/postgres/_sqlc"
-	"github.com/twpayne/go-geos"
 )
 
 func (r *TreeClusterRepository) GetAll(ctx context.Context, filter entities.TreeClusterQuery) ([]*entities.TreeCluster, int64, error) {
@@ -135,24 +134,13 @@ func (r *TreeClusterRepository) GetByIDs(ctx context.Context, ids []int32) ([]*e
 
 func (r *TreeClusterRepository) GetCenterPoint(ctx context.Context, tcID int32) (lat, long float64, err error) {
 	log := logger.GetLogger(ctx)
-	geoStr, err := r.store.CalculateTreesCentroid(ctx, &tcID)
+	row, err := r.store.CalculateTreesCentroid(ctx, &tcID)
 	if err != nil {
 		log.Warn("failed to calculate center point of given cluster", "error", err, "cluster_id", tcID)
 		return 0, 0, err
 	}
 
-	// Parse geoStr to get latitude and longitude
-	g, err := geos.NewGeomFromWKT(geoStr)
-	if err != nil {
-		log.Debug("failed to parse calculated geo string", "error", err, "geo_string", geoStr)
-		return 0, 0, err
-	}
-
-	if g.IsEmpty() {
-		return 0, 0, errors.New("empty geometry")
-	}
-
-	return g.X(), g.Y(), nil
+	return row.CenterX, row.CenterY, nil
 }
 
 func (r *TreeClusterRepository) GetAllLatestSensorDataByClusterID(ctx context.Context, tcID int32) ([]*entities.SensorData, error) {

--- a/backend/main.go
+++ b/backend/main.go
@@ -34,10 +34,9 @@ import (
 	"github.com/green-ecolution/green-ecolution/backend/internal/worker"
 	"github.com/green-ecolution/green-ecolution/backend/internal/worker/subscriber"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/spf13/viper"
-	"github.com/twpayne/go-geos"
-	pgxgeos "github.com/twpayne/pgx-geos"
 )
 
 //go:embed all:frontend
@@ -98,7 +97,16 @@ func postgresRepo(ctx context.Context, cfg *config.Config) (repo *storage.Reposi
 	}
 
 	pgxConfig.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
-		return pgxgeos.Register(ctx, conn, geos.NewContext())
+		var geometryOID uint32
+		if err := conn.QueryRow(ctx, "SELECT 'geometry'::regtype::oid").Scan(&geometryOID); err != nil {
+			return fmt.Errorf("failed to get geometry type OID: %w", err)
+		}
+		conn.TypeMap().RegisterType(&pgtype.Type{
+			Name:  "geometry",
+			OID:   geometryOID,
+			Codec: &pgtype.TextCodec{},
+		})
+		return nil
 	}
 
 	pool, err = pgxpool.NewWithConfig(ctx, pgxConfig)

--- a/backend/sqlc.yaml
+++ b/backend/sqlc.yaml
@@ -45,11 +45,9 @@ sql:
               pointer: true
               type: "Time"
           - db_type: "geometry"
-            go_type: 
-              import: "github.com/twpayne/go-geos"
-              package: "geos"
+            go_type:
+              type: "string"
               pointer: true
-              type: "Geom"
             nullable: true
           - db_type: "uuid"
             go_type:

--- a/flake.nix
+++ b/flake.nix
@@ -117,13 +117,10 @@
           "-X github.com/green-ecolution/backend/internal/storage/local/info.buildTime=${buildDate}"
         ];
 
-        nativeBuildInputs = with pkgs; [proj pkg-config];
-        buildInputs = [pkgs.geos];
-
         doCheck = false;
         excludedPackages = ["pkg/*"];
-        vendorHash = "sha256-EuEwOqxjLNYW8XClah6dGUGxJqOAP9t/76EoqL0lqDU=";
-        env.CGO_ENABLED = 1;
+        vendorHash = "sha256-uQVRzSFILxMhesQucVNXFiKIiBDWzF/teO056vIaAyM=";
+        env.CGO_ENABLED = 0;
 
         postInstall = ''
           if [ -e "$out/bin/backend" ]; then
@@ -161,10 +158,7 @@
           go
           gotools
           golangci-lint
-          geos
-          proj
           gnumake
-          pkg-config
           yq-go
           delve
           # Frontend/Node

--- a/justfile
+++ b/justfile
@@ -73,7 +73,7 @@ _compile-backend:
     @echo "Compiling Go binary..."
     mkdir -p {{ backend_fe_dist }}
     test -f {{ backend_fe_dist }}/index.html || echo "<!-- placeholder for go:embed -->" > {{ backend_fe_dist }}/index.html
-    cd {{ backend_dir }} && CGO_ENABLED=1 go build {{ goflags }} -o ../bin/{{ binary_name }} .
+    cd {{ backend_dir }} && CGO_ENABLED=0 go build {{ goflags }} -o ../bin/{{ binary_name }} .
 
 # Build frontend (pnpm)
 build-frontend:
@@ -98,24 +98,24 @@ build: build-frontend
 # Build for all platforms
 build-all: build-frontend
     @echo "Building backend for all platforms..."
-    cd {{ backend_dir }} && GOARCH=amd64 GOOS=darwin  CGO_ENABLED=1 go build {{ goflags }} -o ../bin/{{ binary_name }}-darwin  .
-    cd {{ backend_dir }} && GOARCH=amd64 GOOS=linux   CGO_ENABLED=1 go build {{ goflags }} -o ../bin/{{ binary_name }}-linux   .
-    cd {{ backend_dir }} && GOARCH=amd64 GOOS=windows CGO_ENABLED=1 go build {{ goflags }} -o ../bin/{{ binary_name }}-windows .
+    cd {{ backend_dir }} && GOARCH=amd64 GOOS=darwin  CGO_ENABLED=0 go build {{ goflags }} -o ../bin/{{ binary_name }}-darwin  .
+    cd {{ backend_dir }} && GOARCH=amd64 GOOS=linux   CGO_ENABLED=0 go build {{ goflags }} -o ../bin/{{ binary_name }}-linux   .
+    cd {{ backend_dir }} && GOARCH=amd64 GOOS=windows CGO_ENABLED=0 go build {{ goflags }} -o ../bin/{{ binary_name }}-windows .
 
 # Build for darwin
 build-darwin:
     @echo "Building backend for darwin..."
-    cd {{ backend_dir }} && GOARCH=amd64 GOOS=darwin CGO_ENABLED=1 go build {{ goflags }} -o ../bin/{{ binary_name }}-darwin .
+    cd {{ backend_dir }} && GOARCH=amd64 GOOS=darwin CGO_ENABLED=0 go build {{ goflags }} -o ../bin/{{ binary_name }}-darwin .
 
 # Build for linux
 build-linux:
     @echo "Building backend for linux..."
-    cd {{ backend_dir }} && GOARCH=amd64 GOOS=linux CGO_ENABLED=1 go build {{ goflags }} -o ../bin/{{ binary_name }}-linux .
+    cd {{ backend_dir }} && GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build {{ goflags }} -o ../bin/{{ binary_name }}-linux .
 
 # Build for windows
 build-windows:
     @echo "Building backend for windows..."
-    cd {{ backend_dir }} && GOARCH=amd64 GOOS=windows CGO_ENABLED=1 go build {{ goflags }} -o ../bin/{{ binary_name }}-windows .
+    cd {{ backend_dir }} && GOARCH=amd64 GOOS=windows CGO_ENABLED=0 go build {{ goflags }} -o ../bin/{{ binary_name }}-windows .
 
 # Run backend binary
 run: build


### PR DESCRIPTION
Replace the only Go-side geometry operation (GetCenterPoint WKT parsing) with direct PostGIS ST_X/ST_Y float returns. Register PostGIS geometry OID with pgtype.TextCodec instead of pgx-geos. Remove geos/proj from Dockerfile, CI, Nix flake, and set CGO_ENABLED=0 everywhere.

close GECO-103
