### PR TITLE
refactor(backend): define Tree as Aggregate Root with business logic (GECO-106)

### DIFF
--- a/backend/internal/entities/tree.go
+++ b/backend/internal/entities/tree.go
@@ -1,7 +1,15 @@
 package entities
 
 import (
+	"errors"
+	"slices"
 	"time"
+)
+
+var (
+	ErrSensorDataMalformed  = errors.New("sensor data must contain exactly 3 entries at depths 30, 60, and 90")
+	ErrTreeBeyondMonitoring = errors.New("tree age exceeds monitored growth period")
+	ErrNoSensorData         = errors.New("tree has no sensor assigned or sensor has no data")
 )
 
 type Tree struct {
@@ -19,6 +27,105 @@ type Tree struct {
 	LastWatered    *time.Time
 	Provider       string
 	AdditionalInfo map[string]interface{}
+}
+
+var mapWateringStatus = map[int]WateringStatus{
+	0: WateringStatusGood,
+	1: WateringStatusModerate,
+	2: WateringStatusBad,
+}
+
+func mapKpaRange(centibar, lower, higher int) int {
+	if centibar < lower {
+		return 0
+	} else if centibar < higher {
+		return 1
+	} else {
+		return 2
+	}
+}
+
+func checkAndSortWatermarks(w []Watermark) (w30, w60, w90 Watermark, err error) {
+	watermarks := slices.SortedFunc(slices.Values(w), func(a, b Watermark) int {
+		return a.Depth - b.Depth
+	})
+
+	if len(watermarks) != 3 || watermarks[0].Depth != 30 || watermarks[1].Depth != 60 || watermarks[2].Depth != 90 {
+		err = ErrSensorDataMalformed
+		return
+	}
+
+	w30, w60, w90 = watermarks[0], watermarks[1], watermarks[2]
+	return
+}
+
+func (t *Tree) CalculateWateringStatus(watermarks []Watermark) (WateringStatus, error) {
+	currentYear := int32(time.Now().Year())
+	treeLifetime := currentYear - t.PlantingYear.Year()
+	w30, w60, w90, err := checkAndSortWatermarks(watermarks)
+	if err != nil {
+		return WateringStatusUnknown, err
+	}
+
+	statusList := make([]int, 3)
+	const (
+		lowerCentibarDefault  = 25
+		higherCentibarDefault = 33
+
+		lowerCentibarYear2Depth30  = 62
+		higherCentibarYear2Depth30 = 81
+
+		lowerCentibarYear3Depth30 = 1585
+		lowerCentibarYear3Depth60 = 80
+		lowerCentibarYear3Depth90 = 80
+		noModerate                = -1
+	)
+
+	switch treeLifetime {
+	case 0, 1:
+		statusList[0] = mapKpaRange(w30.Centibar, lowerCentibarDefault, higherCentibarDefault)
+		statusList[1] = mapKpaRange(w60.Centibar, lowerCentibarDefault, higherCentibarDefault)
+		statusList[2] = mapKpaRange(w90.Centibar, lowerCentibarDefault, higherCentibarDefault)
+	case 2:
+		statusList[0] = mapKpaRange(w30.Centibar, lowerCentibarYear2Depth30, higherCentibarYear2Depth30)
+		statusList[1] = mapKpaRange(w60.Centibar, lowerCentibarDefault, higherCentibarDefault)
+		statusList[2] = mapKpaRange(w90.Centibar, lowerCentibarDefault, higherCentibarDefault)
+	case 3:
+		statusList[0] = mapKpaRange(w30.Centibar, lowerCentibarYear3Depth30, noModerate)
+		statusList[1] = mapKpaRange(w60.Centibar, lowerCentibarYear3Depth60, noModerate)
+		statusList[2] = mapKpaRange(w90.Centibar, lowerCentibarYear3Depth90, noModerate)
+	default:
+		return WateringStatusUnknown, ErrTreeBeyondMonitoring
+	}
+
+	slices.Sort(statusList)
+	return mapWateringStatus[statusList[2]], nil
+}
+
+func (t *Tree) AssignSensor(sensor *Sensor) {
+	t.Sensor = sensor
+}
+
+func (t *Tree) RemoveSensor() {
+	t.Sensor = nil
+	t.WateringStatus = WateringStatusUnknown
+}
+
+func (t *Tree) IsWateringStatusExpired(cutoff time.Time) bool {
+	return t.WateringStatus == WateringStatusJustWatered && t.LastWatered != nil && t.LastWatered.Before(cutoff)
+}
+
+func (t *Tree) RefreshWateringStatus() (WateringStatus, bool, error) {
+	if t.Sensor == nil || t.Sensor.LatestData == nil || t.Sensor.LatestData.Data == nil {
+		return WateringStatusUnknown, false, ErrNoSensorData
+	}
+
+	status, err := t.CalculateWateringStatus(t.Sensor.LatestData.Data.Watermarks)
+	if err != nil {
+		return WateringStatusUnknown, false, err
+	}
+
+	return status, true, nil
 }
 
 type TreeCreate struct {

--- a/backend/internal/entities/tree_test.go
+++ b/backend/internal/entities/tree_test.go
@@ -1,0 +1,175 @@
+package entities
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testTree(plantingYearOffset int32) *Tree {
+	py := MustNewPlantingYear(int32(time.Now().Year()) - plantingYearOffset)
+	return &Tree{
+		ID:             1,
+		PlantingYear:   py,
+		Coordinate:     MustNewCoordinate(54.8, 9.4),
+		WateringStatus: WateringStatusUnknown,
+	}
+}
+
+func watermarks(w30, w60, w90 int) []Watermark {
+	return []Watermark{
+		{Centibar: w30, Depth: 30},
+		{Centibar: w60, Depth: 60},
+		{Centibar: w90, Depth: 90},
+	}
+}
+
+func TestTree_CalculateWateringStatus(t *testing.T) {
+	t.Run("year 0-1: all green", func(t *testing.T) {
+		tree := testTree(0)
+		status, err := tree.CalculateWateringStatus(watermarks(10, 10, 10))
+		assert.NoError(t, err)
+		assert.Equal(t, WateringStatusGood, status)
+	})
+
+	t.Run("year 0-1: worst is moderate", func(t *testing.T) {
+		tree := testTree(1)
+		status, err := tree.CalculateWateringStatus(watermarks(10, 30, 10))
+		assert.NoError(t, err)
+		assert.Equal(t, WateringStatusModerate, status)
+	})
+
+	t.Run("year 0-1: worst is bad", func(t *testing.T) {
+		tree := testTree(0)
+		status, err := tree.CalculateWateringStatus(watermarks(10, 10, 50))
+		assert.NoError(t, err)
+		assert.Equal(t, WateringStatusBad, status)
+	})
+
+	t.Run("year 2: depth 30 uses higher thresholds", func(t *testing.T) {
+		tree := testTree(2)
+		// 30cm: <62 = green, 62-80 = moderate, >80 = bad
+		status, err := tree.CalculateWateringStatus(watermarks(50, 10, 10))
+		assert.NoError(t, err)
+		assert.Equal(t, WateringStatusGood, status)
+
+		status, err = tree.CalculateWateringStatus(watermarks(70, 10, 10))
+		assert.NoError(t, err)
+		assert.Equal(t, WateringStatusModerate, status)
+	})
+
+	t.Run("year 3: no moderate zone", func(t *testing.T) {
+		tree := testTree(3)
+		// depths 60/90: <80 = green, >=80 = bad (no moderate)
+		status, err := tree.CalculateWateringStatus(watermarks(100, 50, 50))
+		assert.NoError(t, err)
+		assert.Equal(t, WateringStatusGood, status)
+
+		status, err = tree.CalculateWateringStatus(watermarks(100, 90, 50))
+		assert.NoError(t, err)
+		assert.Equal(t, WateringStatusBad, status)
+	})
+
+	t.Run("tree beyond monitoring period returns error", func(t *testing.T) {
+		tree := testTree(4)
+		_, err := tree.CalculateWateringStatus(watermarks(10, 10, 10))
+		assert.ErrorIs(t, err, ErrTreeBeyondMonitoring)
+	})
+
+	t.Run("malformed watermarks returns error", func(t *testing.T) {
+		tree := testTree(0)
+		_, err := tree.CalculateWateringStatus([]Watermark{{Centibar: 10, Depth: 30}})
+		assert.ErrorIs(t, err, ErrSensorDataMalformed)
+	})
+
+	t.Run("unsorted watermarks are handled correctly", func(t *testing.T) {
+		tree := testTree(0)
+		wm := []Watermark{
+			{Centibar: 50, Depth: 90},
+			{Centibar: 10, Depth: 30},
+			{Centibar: 10, Depth: 60},
+		}
+		status, err := tree.CalculateWateringStatus(wm)
+		assert.NoError(t, err)
+		assert.Equal(t, WateringStatusBad, status)
+	})
+}
+
+func TestTree_AssignSensor(t *testing.T) {
+	tree := testTree(0)
+	sensor := &Sensor{ID: MustNewSensorID("s-1")}
+
+	tree.AssignSensor(sensor)
+	assert.Equal(t, sensor, tree.Sensor)
+}
+
+func TestTree_RemoveSensor(t *testing.T) {
+	tree := testTree(0)
+	tree.Sensor = &Sensor{ID: MustNewSensorID("s-1")}
+	tree.WateringStatus = WateringStatusGood
+
+	tree.RemoveSensor()
+	assert.Nil(t, tree.Sensor)
+	assert.Equal(t, WateringStatusUnknown, tree.WateringStatus)
+}
+
+func TestTree_IsWateringStatusExpired(t *testing.T) {
+	cutoff := time.Now().Add(-24 * time.Hour)
+
+	t.Run("expired: just watered and older than cutoff", func(t *testing.T) {
+		watered := time.Now().Add(-25 * time.Hour)
+		tree := &Tree{WateringStatus: WateringStatusJustWatered, LastWatered: &watered}
+		assert.True(t, tree.IsWateringStatusExpired(cutoff))
+	})
+
+	t.Run("not expired: just watered but recent", func(t *testing.T) {
+		watered := time.Now().Add(-1 * time.Hour)
+		tree := &Tree{WateringStatus: WateringStatusJustWatered, LastWatered: &watered}
+		assert.False(t, tree.IsWateringStatusExpired(cutoff))
+	})
+
+	t.Run("not expired: different status", func(t *testing.T) {
+		watered := time.Now().Add(-25 * time.Hour)
+		tree := &Tree{WateringStatus: WateringStatusGood, LastWatered: &watered}
+		assert.False(t, tree.IsWateringStatusExpired(cutoff))
+	})
+
+	t.Run("not expired: nil last watered", func(t *testing.T) {
+		tree := &Tree{WateringStatus: WateringStatusJustWatered}
+		assert.False(t, tree.IsWateringStatusExpired(cutoff))
+	})
+}
+
+func TestTree_RefreshWateringStatus(t *testing.T) {
+	t.Run("no sensor returns error", func(t *testing.T) {
+		tree := testTree(0)
+		_, _, err := tree.RefreshWateringStatus()
+		assert.ErrorIs(t, err, ErrNoSensorData)
+	})
+
+	t.Run("sensor without data returns error", func(t *testing.T) {
+		tree := testTree(0)
+		tree.Sensor = &Sensor{ID: MustNewSensorID("s-1")}
+		_, _, err := tree.RefreshWateringStatus()
+		assert.ErrorIs(t, err, ErrNoSensorData)
+	})
+
+	t.Run("recalculates from sensor data", func(t *testing.T) {
+		tree := testTree(0)
+		tree.WateringStatus = WateringStatusUnknown
+		tree.Sensor = &Sensor{
+			ID: MustNewSensorID("s-1"),
+			LatestData: &SensorData{
+				Data: &MqttPayload{
+					Watermarks: watermarks(10, 10, 10),
+				},
+			},
+		}
+
+		status, changed, err := tree.RefreshWateringStatus()
+		assert.NoError(t, err)
+		assert.True(t, changed)
+		assert.Equal(t, WateringStatusGood, status)
+	})
+}

--- a/backend/internal/service/domain/tree/handle_new_sensor_data.go
+++ b/backend/internal/service/domain/tree/handle_new_sensor_data.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/green-ecolution/green-ecolution/backend/internal/entities"
 	"github.com/green-ecolution/green-ecolution/backend/internal/logger"
-	"github.com/green-ecolution/green-ecolution/backend/internal/service/domain/utils"
 	"github.com/green-ecolution/green-ecolution/backend/internal/storage"
 )
 
@@ -29,7 +28,10 @@ func (s *TreeService) HandleNewSensorData(ctx context.Context, event *entities.E
 		return nil
 	}
 
-	status := utils.CalculateWateringStatus(ctx, t.PlantingYear.Year(), event.New.Data.Watermarks)
+	status, err := t.CalculateWateringStatus(event.New.Data.Watermarks)
+	if err != nil {
+		return err
+	}
 
 	if status == t.WateringStatus {
 		log.Debug("sensor status has not changed", "sensor_status", status)

--- a/backend/internal/service/domain/tree/tree.go
+++ b/backend/internal/service/domain/tree/tree.go
@@ -2,6 +2,7 @@ package tree
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"github.com/green-ecolution/green-ecolution/backend/internal/entities"
 	"github.com/green-ecolution/green-ecolution/backend/internal/logger"
 	"github.com/green-ecolution/green-ecolution/backend/internal/service"
-	"github.com/green-ecolution/green-ecolution/backend/internal/service/domain/utils"
 	"github.com/green-ecolution/green-ecolution/backend/internal/storage"
 	"github.com/green-ecolution/green-ecolution/backend/internal/worker"
 )
@@ -154,7 +154,10 @@ func (s *TreeService) Create(ctx context.Context, treeCreate *entities.TreeCreat
 				log.Debug("failed to find previous tree linked to sensor specified from create request", "sensor_id", treeCreate.SensorID)
 			}
 			if sensor.LatestData != nil && sensor.LatestData.Data != nil && len(sensor.LatestData.Data.Watermarks) > 0 {
-				status := utils.CalculateWateringStatus(ctx, treeCreate.PlantingYear.Year(), sensor.LatestData.Data.Watermarks)
+				status, err := tree.CalculateWateringStatus(sensor.LatestData.Data.Watermarks)
+				if err != nil {
+					return false, err
+				}
 				tree.WateringStatus = status
 			}
 		}
@@ -232,12 +235,14 @@ func (s *TreeService) Update(ctx context.Context, id int32, tu *entities.TreeUpd
 				log.Debug("failed to find previous tree linked to sensor specified from update request", "sensor_id", tu.SensorID)
 			}
 			if sensor.LatestData != nil && sensor.LatestData.Data != nil && len(sensor.LatestData.Data.Watermarks) > 0 {
-				status := utils.CalculateWateringStatus(ctx, tu.PlantingYear.Year(), sensor.LatestData.Data.Watermarks)
+				status, err := tree.CalculateWateringStatus(sensor.LatestData.Data.Watermarks)
+				if err != nil {
+					return false, err
+				}
 				tree.WateringStatus = status
 			}
 		} else {
-			tree.Sensor = nil
-			tree.WateringStatus = entities.WateringStatusUnknown
+			tree.RemoveSensor()
 		}
 
 		return true, nil
@@ -263,26 +268,24 @@ func (s *TreeService) UpdateWateringStatuses(ctx context.Context) error {
 
 	cutoffTime := time.Now().Add(-24 * time.Hour) // 1 day ago
 	for _, tree := range trees {
-		// Do nothing if watering status is not »just watered«
-		if tree.WateringStatus != entities.WateringStatusJustWatered {
-			continue
-		}
-
-		if tree.LastWatered.Before(cutoffTime) {
-			wateringStatus := entities.WateringStatusUnknown
-
-			if tree.Sensor != nil {
-				wateringStatus = utils.CalculateWateringStatus(ctx, tree.PlantingYear.Year(), tree.Sensor.LatestData.Data.Watermarks)
+		if tree.IsWateringStatusExpired(cutoffTime) {
+			wateringStatus, hasChanged, err := tree.RefreshWateringStatus()
+			if errors.Is(err, entities.ErrNoSensorData) {
+				continue
 			}
-			_, err = s.treeRepo.Update(ctx, tree.ID, func(tr *entities.Tree, _ storage.TreeRepository) (bool, error) {
-				tr.WateringStatus = wateringStatus
-				return true, nil
-			})
-
 			if err != nil {
-				log.Error("failed to update watering status of tree", "tree_id", tree.ID, "error", err)
-			} else {
-				log.Debug("watering status of tree is updated by scheduler", "tree_id", tree.ID)
+				return err
+			}
+
+			if hasChanged {
+				_, err = s.treeRepo.Update(ctx, tree.ID, func(tr *entities.Tree, _ storage.TreeRepository) (bool, error) {
+					tr.WateringStatus = wateringStatus
+					return true, nil
+				})
+				if err != nil {
+					log.Error("failed to update watering status of tree", "tree_id", tree.ID, "error", err)
+					return err
+				}
 			}
 		}
 	}

--- a/backend/internal/service/domain/tree/tree_test.go
+++ b/backend/internal/service/domain/tree/tree_test.go
@@ -907,10 +907,24 @@ func TestTreeService_UpdateWateringStatuses(t *testing.T) {
 		staleDate := time.Now().Add(-34 * time.Hour)
 		recentDate := time.Now().Add(-2 * time.Hour)
 
+		sensorWithData := &entities.Sensor{
+			ID: entities.MustNewSensorID("sensor-1"),
+			LatestData: &entities.SensorData{
+				Data: &entities.MqttPayload{
+					Watermarks: []entities.Watermark{
+						{Centibar: 10, Depth: 30},
+						{Centibar: 10, Depth: 60},
+						{Centibar: 10, Depth: 90},
+					},
+				},
+			},
+		}
 		staleTree := &entities.Tree{
 			ID:             1,
 			LastWatered:    &staleDate, // Older than 24h
 			WateringStatus: entities.WateringStatusJustWatered,
+			PlantingYear:   entities.MustNewPlantingYear(int32(time.Now().Year())),
+			Sensor:         sensorWithData,
 		}
 		recentTree := &entities.Tree{
 			ID:             2,
@@ -991,10 +1005,24 @@ func TestTreeService_UpdateWateringStatuses(t *testing.T) {
 		svc := tree.NewTreeService(treeRepo, sensorRepo, treeClusterRepo, globalEventManager, testMapCfg)
 
 		staleDate := time.Now().Add(-34 * time.Hour)
+		sensorWithData := &entities.Sensor{
+			ID: entities.MustNewSensorID("sensor-1"),
+			LatestData: &entities.SensorData{
+				Data: &entities.MqttPayload{
+					Watermarks: []entities.Watermark{
+						{Centibar: 10, Depth: 30},
+						{Centibar: 10, Depth: 60},
+						{Centibar: 10, Depth: 90},
+					},
+				},
+			},
+		}
 		staleTree := &entities.Tree{
 			ID:             1,
 			LastWatered:    &staleDate, // Older than 24h
 			WateringStatus: entities.WateringStatusJustWatered,
+			PlantingYear:   entities.MustNewPlantingYear(int32(time.Now().Year())),
+			Sensor:         sensorWithData,
 		}
 		expectList := []*entities.Tree{staleTree}
 
@@ -1008,7 +1036,7 @@ func TestTreeService_UpdateWateringStatuses(t *testing.T) {
 		treeRepo.AssertCalled(t, "GetAll", mock.Anything, entities.TreeQuery{})
 		treeRepo.AssertCalled(t, "Update", mock.Anything, staleTree.ID, mock.Anything)
 		treeRepo.AssertExpectations(t)
-		assert.NoError(t, err)
+		assert.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
Move watering status calculation from `service/domain/utils` into the Tree entity as methods, making Tree a proper Aggregate Root:

- `CalculateWateringStatus()`: watermark-based status from sensor data
- `AssignSensor() / RemoveSensor()`: sensor lifecycle management
- `IsWateringStatusExpired()`: checks if "just watered" has expired
- `RefreshWateringStatus()`: recalculates status from assigned sensor

TreeService now delegates business logic to entity methods and only orchestrates repository access and event publishing.