### PR TITLE
refactor(backend): define TreeCluster as Aggregate Root (GECO-107)

### DIFF
--- a/backend/internal/entities/treecluster.go
+++ b/backend/internal/entities/treecluster.go
@@ -1,6 +1,9 @@
 package entities
 
-import "time"
+import (
+	"slices"
+	"time"
+)
 
 type TreeSoilCondition string
 
@@ -29,6 +32,81 @@ type TreeCluster struct {
 	Name           string
 	Provider       string
 	AdditionalInfo map[string]interface{}
+}
+
+func (tc *TreeCluster) CalculateWateringStatus(sensorData []*SensorData) (WateringStatus, error) {
+	if len(sensorData) == 0 {
+		return WateringStatusUnknown, nil
+	}
+
+	youngest := tc.YoungestTree()
+	if youngest == nil {
+		return WateringStatusUnknown, nil
+	}
+
+	watermarks, err := tc.AverageWatermarks(sensorData)
+	if err != nil {
+		return WateringStatusUnknown, err
+	}
+
+	return youngest.CalculateWateringStatus(watermarks)
+}
+
+func (tc *TreeCluster) YoungestTree() *Tree {
+	sortedTrees := slices.SortedFunc(slices.Values(tc.Trees), func(a, b *Tree) int {
+		return int(a.PlantingYear.Year() - b.PlantingYear.Year())
+	})
+
+	if len(sortedTrees) > 0 {
+		return sortedTrees[0]
+	}
+
+	return nil
+}
+
+func (tc *TreeCluster) AverageWatermarks(sensorData []*SensorData) ([]Watermark, error) {
+	var w30CentibarAvg, w60CentibarAvg, w90CentibarAvg int
+	for _, data := range sensorData {
+		w30, w60, w90, err := checkAndSortWatermarks(data.Data.Watermarks)
+		if err != nil {
+			return nil, ErrSensorDataMalformed
+		}
+
+		w30CentibarAvg += w30.Centibar
+		w60CentibarAvg += w60.Centibar
+		w90CentibarAvg += w90.Centibar
+	}
+
+	return []Watermark{
+		{
+			Centibar: w30CentibarAvg / len(sensorData),
+			Depth:    30,
+		},
+		{
+			Centibar: w60CentibarAvg / len(sensorData),
+			Depth:    60,
+		},
+		{
+			Centibar: w90CentibarAvg / len(sensorData),
+			Depth:    90,
+		},
+	}, nil
+}
+
+func (tc *TreeCluster) NeedsPositionUpdate(prevTree, newTree *Tree) bool {
+	if prevTree.Coordinate != newTree.Coordinate {
+		return true
+	}
+	if prevTree.TreeCluster == nil || newTree.TreeCluster == nil {
+		return prevTree.TreeCluster != newTree.TreeCluster
+	}
+	if prevTree.TreeCluster.ID != newTree.TreeCluster.ID {
+		return true
+	}
+	if prevTree.Sensor != newTree.Sensor {
+		return true
+	}
+	return false
 }
 
 type TreeClusterCreate struct {

--- a/backend/internal/entities/treecluster_test.go
+++ b/backend/internal/entities/treecluster_test.go
@@ -1,0 +1,144 @@
+package entities
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTreeCluster_YoungestTree(t *testing.T) {
+	t.Run("returns youngest tree", func(t *testing.T) {
+		tc := &TreeCluster{
+			Trees: []*Tree{
+				{ID: 1, PlantingYear: MustNewPlantingYear(2020)},
+				{ID: 2, PlantingYear: MustNewPlantingYear(2023)},
+				{ID: 3, PlantingYear: MustNewPlantingYear(2021)},
+			},
+		}
+		youngest := tc.YoungestTree()
+		assert.NotNil(t, youngest)
+		assert.Equal(t, int32(1), youngest.ID)
+	})
+
+	t.Run("returns nil for empty trees", func(t *testing.T) {
+		tc := &TreeCluster{Trees: []*Tree{}}
+		assert.Nil(t, tc.YoungestTree())
+	})
+
+	t.Run("returns nil for nil trees", func(t *testing.T) {
+		tc := &TreeCluster{}
+		assert.Nil(t, tc.YoungestTree())
+	})
+}
+
+func TestTreeCluster_AverageWatermarks(t *testing.T) {
+	t.Run("averages watermarks across sensors", func(t *testing.T) {
+		tc := &TreeCluster{}
+		sensorData := []*SensorData{
+			{Data: &MqttPayload{Watermarks: []Watermark{
+				{Centibar: 20, Depth: 30}, {Centibar: 30, Depth: 60}, {Centibar: 40, Depth: 90},
+			}}},
+			{Data: &MqttPayload{Watermarks: []Watermark{
+				{Centibar: 40, Depth: 30}, {Centibar: 50, Depth: 60}, {Centibar: 60, Depth: 90},
+			}}},
+		}
+
+		wm, err := tc.AverageWatermarks(sensorData)
+		assert.NoError(t, err)
+		assert.Len(t, wm, 3)
+		assert.Equal(t, 30, wm[0].Centibar) // (20+40)/2
+		assert.Equal(t, 40, wm[1].Centibar) // (30+50)/2
+		assert.Equal(t, 50, wm[2].Centibar) // (40+60)/2
+	})
+
+	t.Run("returns error for malformed watermarks", func(t *testing.T) {
+		tc := &TreeCluster{}
+		sensorData := []*SensorData{
+			{Data: &MqttPayload{Watermarks: []Watermark{{Centibar: 10, Depth: 30}}}},
+		}
+
+		_, err := tc.AverageWatermarks(sensorData)
+		assert.ErrorIs(t, err, ErrSensorDataMalformed)
+	})
+}
+
+func TestTreeCluster_CalculateWateringStatus(t *testing.T) {
+	t.Run("calculates status from sensor data", func(t *testing.T) {
+		tc := &TreeCluster{
+			Trees: []*Tree{
+				{ID: 1, PlantingYear: MustNewPlantingYear(int32(time.Now().Year()))},
+			},
+		}
+		sensorData := []*SensorData{
+			{Data: &MqttPayload{Watermarks: []Watermark{
+				{Centibar: 10, Depth: 30}, {Centibar: 10, Depth: 60}, {Centibar: 10, Depth: 90},
+			}}},
+		}
+
+		status, err := tc.CalculateWateringStatus(sensorData)
+		assert.NoError(t, err)
+		assert.Equal(t, WateringStatusGood, status)
+	})
+
+	t.Run("returns unknown for empty sensor data", func(t *testing.T) {
+		tc := &TreeCluster{Trees: []*Tree{
+			{ID: 1, PlantingYear: MustNewPlantingYear(2023)},
+		}}
+
+		status, err := tc.CalculateWateringStatus(nil)
+		assert.NoError(t, err)
+		assert.Equal(t, WateringStatusUnknown, status)
+	})
+
+	t.Run("returns unknown for no trees", func(t *testing.T) {
+		tc := &TreeCluster{Trees: []*Tree{}}
+		sensorData := []*SensorData{
+			{Data: &MqttPayload{Watermarks: []Watermark{
+				{Centibar: 10, Depth: 30}, {Centibar: 10, Depth: 60}, {Centibar: 10, Depth: 90},
+			}}},
+		}
+
+		status, err := tc.CalculateWateringStatus(sensorData)
+		assert.NoError(t, err)
+		assert.Equal(t, WateringStatusUnknown, status)
+	})
+}
+
+func TestTreeCluster_NeedsPositionUpdate(t *testing.T) {
+	coord1 := MustNewCoordinate(54.8, 9.4)
+	coord2 := MustNewCoordinate(54.9, 9.5)
+	tc1 := &TreeCluster{ID: 1}
+	tc2 := &TreeCluster{ID: 2}
+	sensor1 := &Sensor{ID: MustNewSensorID("s-1")}
+
+	t.Run("needs update when coordinate changed", func(t *testing.T) {
+		prev := &Tree{Coordinate: coord1, TreeCluster: tc1}
+		next := &Tree{Coordinate: coord2, TreeCluster: tc1}
+		assert.True(t, tc1.NeedsPositionUpdate(prev, next))
+	})
+
+	t.Run("needs update when cluster changed", func(t *testing.T) {
+		prev := &Tree{Coordinate: coord1, TreeCluster: tc1}
+		next := &Tree{Coordinate: coord1, TreeCluster: tc2}
+		assert.True(t, tc1.NeedsPositionUpdate(prev, next))
+	})
+
+	t.Run("needs update when sensor changed", func(t *testing.T) {
+		prev := &Tree{Coordinate: coord1, TreeCluster: tc1}
+		next := &Tree{Coordinate: coord1, TreeCluster: tc1, Sensor: sensor1}
+		assert.True(t, tc1.NeedsPositionUpdate(prev, next))
+	})
+
+	t.Run("no update needed when nothing changed", func(t *testing.T) {
+		prev := &Tree{Coordinate: coord1, TreeCluster: tc1, Sensor: sensor1}
+		next := &Tree{Coordinate: coord1, TreeCluster: tc1, Sensor: sensor1}
+		assert.False(t, tc1.NeedsPositionUpdate(prev, next))
+	})
+
+	t.Run("needs update when cluster added", func(t *testing.T) {
+		prev := &Tree{Coordinate: coord1}
+		next := &Tree{Coordinate: coord1, TreeCluster: tc1}
+		assert.True(t, tc1.NeedsPositionUpdate(prev, next))
+	})
+}

--- a/backend/internal/service/domain/treecluster/handle_new_sensor_data.go
+++ b/backend/internal/service/domain/treecluster/handle_new_sensor_data.go
@@ -3,33 +3,18 @@ package treecluster
 import (
 	"context"
 	"errors"
-	"slices"
 
 	"github.com/green-ecolution/green-ecolution/backend/internal/entities"
 	"github.com/green-ecolution/green-ecolution/backend/internal/logger"
-	svcUtils "github.com/green-ecolution/green-ecolution/backend/internal/service/domain/utils"
 	"github.com/green-ecolution/green-ecolution/backend/internal/storage"
-	"github.com/green-ecolution/green-ecolution/backend/internal/utils"
 )
 
 // HandleNewSensorData processes new sensor data and updates the watering status of a tree cluster if necessary.
-//
-// The function retrieves the tree associated with the given sensor ID and determines whether it belongs to a tree cluster.
-// If the tree has a linked cluster, the watering status of the entire cluster is calculated based on the latest sensor data.
-// If the calculated watering status differs from the current one, the tree cluster is updated accordingly, and an update event is published.
-//
-// Parameters:
-//   - ctx: The request context, enabling logging and tracing.
-//   - event: Contains the new sensor data, including the sensor ID and measured watermarks.
-//
-// Returns:
-//   - error: Always returns nil, as errors during tree or cluster retrieval are logged but do not interrupt execution.
 func (s *TreeClusterService) HandleNewSensorData(ctx context.Context, event *entities.EventNewSensorData) error {
 	log := logger.GetLogger(ctx)
 	log.Debug("handle event", "event", event.Type(), "service", "TreeClusterService")
 	tree, err := s.treeRepo.GetBySensorID(ctx, event.New.SensorID)
 	if err != nil {
-		// when error, it can be because the sensor has not linked tree or the tree does not exists
 		if errors.Is(err, storage.ErrSensorNotFound) {
 			log.Error("failed to get sensor by id", "sensor_id", event.New.SensorID, "err", err)
 			return nil
@@ -39,11 +24,11 @@ func (s *TreeClusterService) HandleNewSensorData(ctx context.Context, event *ent
 	}
 
 	if tree.TreeCluster == nil {
-		log.Info("this tree will has no linked tree cluster. This event will be ignored", "tree_id", tree.ID, "error", err)
+		log.Info("this tree has no linked tree cluster. This event will be ignored", "tree_id", tree.ID)
 		return nil
 	}
 
-	wateringStatus, err := s.getWateringStatusOfTreeCluster(ctx, tree.TreeCluster.ID)
+	wateringStatus, err := s.getWateringStatusOfTreeCluster(ctx, tree.TreeCluster)
 	if err != nil {
 		log.Error("error while calculating watering status of tree cluster", "error", err)
 		return nil
@@ -66,79 +51,13 @@ func (s *TreeClusterService) HandleNewSensorData(ctx context.Context, event *ent
 	return nil
 }
 
-func (s *TreeClusterService) getWateringStatusOfTreeCluster(ctx context.Context, clusterID int32) (entities.WateringStatus, error) {
+func (s *TreeClusterService) getWateringStatusOfTreeCluster(ctx context.Context, cluster *entities.TreeCluster) (entities.WateringStatus, error) {
 	log := logger.GetLogger(ctx)
-	sensorData, err := s.treeClusterRepo.GetAllLatestSensorDataByClusterID(ctx, clusterID)
+	sensorData, err := s.treeClusterRepo.GetAllLatestSensorDataByClusterID(ctx, cluster.ID)
 	if err != nil {
-		log.Error("failed to get latest sensor data", "cluster_id", clusterID, "err", err)
+		log.Error("failed to get latest sensor data", "cluster_id", cluster.ID, "err", err)
 		return entities.WateringStatusUnknown, errors.New("failed to get latest sensor data")
 	}
 
-	// assertion - if there is no sensor data after receiving the event, the world is ending
-	if len(sensorData) == 0 {
-		log.Error("sensor data is empty")
-		return entities.WateringStatusUnknown, errors.New("sensor data is empty")
-	}
-
-	sensorIDs := utils.Map(sensorData, func(data *entities.SensorData) entities.SensorID {
-		return data.SensorID
-	})
-
-	youngestTree, err := s.getYoungestTree(ctx, sensorIDs)
-	if err != nil {
-		return entities.WateringStatusUnknown, errors.New("failed to get youngest tree")
-	}
-
-	watermarks, err := s.getWatermarkSensorData(ctx, sensorData)
-	if err != nil {
-		return entities.WateringStatusUnknown, errors.New("failed getting watermark sensor data")
-	}
-
-	return svcUtils.CalculateWateringStatus(ctx, youngestTree.PlantingYear.Year(), watermarks), nil
-}
-
-func (s *TreeClusterService) getYoungestTree(ctx context.Context, sensorIDs []entities.SensorID) (*entities.Tree, error) {
-	log := logger.GetLogger(ctx)
-	trees, err := s.treeRepo.GetBySensorIDs(ctx, sensorIDs...)
-	if err != nil {
-		log.Error("failed to get trees by sensor id", "sensor_ids", sensorIDs, "err", err)
-		return nil, errors.New("failed to get trees by sensor id")
-	}
-
-	slices.SortFunc(trees, func(a, b *entities.Tree) int {
-		return int(b.PlantingYear.Year() - a.PlantingYear.Year())
-	})
-
-	return trees[0], nil
-}
-
-func (s *TreeClusterService) getWatermarkSensorData(ctx context.Context, sensorData []*entities.SensorData) ([]entities.Watermark, error) {
-	log := logger.GetLogger(ctx)
-	var w30CentibarAvg, w60CentibarAvg, w90CentibarAvg int
-	for _, data := range sensorData {
-		w30, w60, w90, err := svcUtils.CheckAndSortWatermarks(data.Data.Watermarks)
-		if err != nil {
-			log.Error("sensor data watermarks are malformed", "watermarks", data.Data.Watermarks)
-			return nil, errors.New("sensor data watermarks are malformed")
-		}
-
-		w30CentibarAvg += w30.Centibar
-		w60CentibarAvg += w60.Centibar
-		w90CentibarAvg += w90.Centibar
-	}
-
-	return []entities.Watermark{
-		{
-			Centibar: w30CentibarAvg / len(sensorData),
-			Depth:    30,
-		},
-		{
-			Centibar: w60CentibarAvg / len(sensorData),
-			Depth:    60,
-		},
-		{
-			Centibar: w90CentibarAvg / len(sensorData),
-			Depth:    90,
-		},
-	}, nil
+	return cluster.CalculateWateringStatus(sensorData)
 }

--- a/backend/internal/service/domain/treecluster/handle_new_sensor_data_test.go
+++ b/backend/internal/service/domain/treecluster/handle_new_sensor_data_test.go
@@ -21,7 +21,6 @@ func TestTreeClusterService_HandleNewSensorData(t *testing.T) {
 		eventManager := worker.NewEventManager(entities.EventTypeUpdateTreeCluster)
 		svc := NewTreeClusterService(clusterRepo, treeRepo, regionRepo, eventManager)
 
-		// event
 		_, ch, _ := eventManager.Subscribe(entities.EventTypeUpdateTreeCluster)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -38,8 +37,19 @@ func TestTreeClusterService_HandleNewSensorData(t *testing.T) {
 			},
 		}
 
+		tree1 := &entities.Tree{
+			ID:           2,
+			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 2)),
+		}
+		tree2 := &entities.Tree{
+			ID:           3,
+			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year())),
+		}
+
 		tc := &entities.TreeCluster{
-			ID: 1,
+			ID:             1,
+			WateringStatus: entities.WateringStatusUnknown,
+			Trees:          []*entities.Tree{tree1, tree2},
 		}
 
 		tcNew := &entities.TreeCluster{
@@ -47,34 +57,10 @@ func TestTreeClusterService_HandleNewSensorData(t *testing.T) {
 			WateringStatus: entities.WateringStatusGood,
 		}
 
-		tree := entities.Tree{
+		tree := &entities.Tree{
 			ID:           1,
 			TreeCluster:  tc,
 			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 2)),
-		}
-
-		treeWithSensorID1 := entities.Tree{
-			ID: 2,
-			TreeCluster: &entities.TreeCluster{
-				ID:             1,
-				WateringStatus: entities.WateringStatusUnknown,
-			},
-			Sensor: &entities.Sensor{
-				ID: entities.MustNewSensorID("sensor-1"),
-			},
-			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 2)),
-		}
-
-		treeWithSensorID2 := entities.Tree{
-			ID: 3,
-			TreeCluster: &entities.TreeCluster{
-				ID:             1,
-				WateringStatus: entities.WateringStatusUnknown,
-			},
-			Sensor: &entities.Sensor{
-				ID: entities.MustNewSensorID("sensor-2"),
-			},
-			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 29)), // very old tree
 		}
 
 		allLatestSensorData := []*entities.SensorData{
@@ -102,11 +88,10 @@ func TestTreeClusterService_HandleNewSensorData(t *testing.T) {
 
 		event := entities.NewEventSensorData(&sensorDataEvent)
 
-		treeRepo.EXPECT().GetBySensorID(mock.Anything, entities.MustNewSensorID("sensor-1")).Return(&tree, nil)
+		treeRepo.EXPECT().GetBySensorID(mock.Anything, entities.MustNewSensorID("sensor-1")).Return(tree, nil)
 		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(mock.Anything, int32(1)).Return(allLatestSensorData, nil)
-		treeRepo.EXPECT().GetBySensorIDs(mock.Anything, entities.MustNewSensorID("sensor-1"), entities.MustNewSensorID("sensor-2")).Return([]*entities.Tree{&treeWithSensorID1, &treeWithSensorID2}, nil)
 		clusterRepo.EXPECT().Update(mock.Anything, int32(1), mock.Anything).RunAndReturn(func(ctx context.Context, i int32, f func(*entities.TreeCluster, storage.TreeClusterRepository) (bool, error)) error {
-			cluster := entities.TreeCluster{}
+			cluster := *tc
 			_, err := f(&cluster, clusterRepo)
 			assert.NoError(t, err)
 			assert.Equal(t, entities.WateringStatusGood, cluster.WateringStatus)
@@ -114,10 +99,8 @@ func TestTreeClusterService_HandleNewSensorData(t *testing.T) {
 		})
 		clusterRepo.EXPECT().GetByID(mock.Anything, int32(1)).Return(tcNew, nil)
 
-		// when
 		err := svc.HandleNewSensorData(context.Background(), &event)
 
-		// then
 		assert.NoError(t, err)
 		select {
 		case recievedEvent := <-ch:
@@ -137,7 +120,6 @@ func TestTreeClusterService_HandleNewSensorData(t *testing.T) {
 		eventManager := worker.NewEventManager(entities.EventTypeUpdateTreeCluster)
 		svc := NewTreeClusterService(clusterRepo, treeRepo, regionRepo, eventManager)
 
-		// event
 		_, ch, _ := eventManager.Subscribe(entities.EventTypeUpdateTreeCluster)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -154,37 +136,31 @@ func TestTreeClusterService_HandleNewSensorData(t *testing.T) {
 			},
 		}
 
+		treeInCluster := &entities.Tree{
+			ID:           2,
+			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 1)),
+		}
+
 		tc := &entities.TreeCluster{
-			ID: 1,
+			ID:             1,
+			WateringStatus: entities.WateringStatusUnknown,
+			Trees:          []*entities.Tree{treeInCluster},
 		}
 
-		tcNew := &entities.TreeCluster{
-			ID: 1,
-		}
+		tcNew := &entities.TreeCluster{ID: 1}
 
-		tree := entities.Tree{
+		tree := &entities.Tree{
 			ID:           1,
 			TreeCluster:  tc,
 			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 2)),
 		}
 
-		treeWithSensorID1 := entities.Tree{
-			ID:             2,
-			TreeCluster:    tc,
-			WateringStatus: entities.WateringStatusBad,
-			Sensor: &entities.Sensor{
-				ID: entities.MustNewSensorID("sensor-1"),
-			},
-			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 1)),
-		}
-
 		event := entities.NewEventSensorData(&sensorDataEvent)
 
-		treeRepo.EXPECT().GetBySensorID(mock.Anything, entities.MustNewSensorID("sensor-1")).Return(&tree, nil)
+		treeRepo.EXPECT().GetBySensorID(mock.Anything, entities.MustNewSensorID("sensor-1")).Return(tree, nil)
 		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(mock.Anything, int32(1)).Return([]*entities.SensorData{&sensorDataEvent}, nil)
-		treeRepo.EXPECT().GetBySensorIDs(mock.Anything, entities.MustNewSensorID("sensor-1")).Return([]*entities.Tree{&treeWithSensorID1}, nil)
 		clusterRepo.EXPECT().Update(mock.Anything, int32(1), mock.Anything).RunAndReturn(func(ctx context.Context, i int32, f func(*entities.TreeCluster, storage.TreeClusterRepository) (bool, error)) error {
-			cluster := entities.TreeCluster{}
+			cluster := *tc
 			_, err := f(&cluster, clusterRepo)
 			assert.NoError(t, err)
 			assert.Equal(t, entities.WateringStatusBad, cluster.WateringStatus)
@@ -192,10 +168,8 @@ func TestTreeClusterService_HandleNewSensorData(t *testing.T) {
 		})
 		clusterRepo.EXPECT().GetByID(mock.Anything, int32(1)).Return(tcNew, nil)
 
-		// when
 		err := svc.HandleNewSensorData(context.Background(), &event)
 
-		// then
 		assert.NoError(t, err)
 		select {
 		case recievedEvent := <-ch:
@@ -215,7 +189,6 @@ func TestTreeClusterService_HandleNewSensorData(t *testing.T) {
 		eventManager := worker.NewEventManager(entities.EventTypeUpdateTreeCluster)
 		svc := NewTreeClusterService(clusterRepo, treeRepo, regionRepo, eventManager)
 
-		// event
 		_, ch, _ := eventManager.Subscribe(entities.EventTypeUpdateTreeCluster)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -232,38 +205,30 @@ func TestTreeClusterService_HandleNewSensorData(t *testing.T) {
 			},
 		}
 
+		treeInCluster := &entities.Tree{
+			ID:           2,
+			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 1)),
+		}
+
 		tc := &entities.TreeCluster{
 			ID:             1,
 			WateringStatus: entities.WateringStatusBad,
+			Trees:          []*entities.Tree{treeInCluster},
 		}
 
-		tree := entities.Tree{
-			ID:             1,
-			TreeCluster:    tc,
-			WateringStatus: entities.WateringStatusBad,
-			PlantingYear:   entities.MustNewPlantingYear(int32(time.Now().Year() - 2)),
-		}
-
-		treeWithSensorID1 := entities.Tree{
-			ID:             2,
-			TreeCluster:    tc,
-			WateringStatus: entities.WateringStatusBad,
-			Sensor: &entities.Sensor{
-				ID: entities.MustNewSensorID("sensor-1"),
-			},
-			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 1)),
+		tree := &entities.Tree{
+			ID:           1,
+			TreeCluster:  tc,
+			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 2)),
 		}
 
 		event := entities.NewEventSensorData(&sensorDataEvent)
 
-		treeRepo.EXPECT().GetBySensorID(mock.Anything, entities.MustNewSensorID("sensor-1")).Return(&tree, nil)
+		treeRepo.EXPECT().GetBySensorID(mock.Anything, entities.MustNewSensorID("sensor-1")).Return(tree, nil)
 		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(mock.Anything, int32(1)).Return([]*entities.SensorData{&sensorDataEvent}, nil)
-		treeRepo.EXPECT().GetBySensorIDs(mock.Anything, entities.MustNewSensorID("sensor-1")).Return([]*entities.Tree{&treeWithSensorID1}, nil)
 
-		// when
 		err := svc.HandleNewSensorData(context.Background(), &event)
 
-		// then
 		assert.NoError(t, err)
 		select {
 		case <-ch:
@@ -280,7 +245,6 @@ func TestTreeClusterService_HandleNewSensorData(t *testing.T) {
 		eventManager := worker.NewEventManager(entities.EventTypeUpdateTreeCluster)
 		svc := NewTreeClusterService(clusterRepo, treeRepo, regionRepo, eventManager)
 
-		// event
 		_, ch, _ := eventManager.Subscribe(entities.EventTypeUpdateTreeCluster)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -297,21 +261,18 @@ func TestTreeClusterService_HandleNewSensorData(t *testing.T) {
 			},
 		}
 
-		tree := entities.Tree{
-			ID:             1,
-			TreeCluster:    nil,
-			WateringStatus: entities.WateringStatusBad,
-			PlantingYear:   entities.MustNewPlantingYear(int32(time.Now().Year() - 2)),
+		tree := &entities.Tree{
+			ID:           1,
+			TreeCluster:  nil,
+			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 2)),
 		}
 
 		event := entities.NewEventSensorData(&sensorDataEvent)
 
-		treeRepo.EXPECT().GetBySensorID(mock.Anything, entities.MustNewSensorID("sensor-1")).Return(&tree, nil)
+		treeRepo.EXPECT().GetBySensorID(mock.Anything, entities.MustNewSensorID("sensor-1")).Return(tree, nil)
 
-		// when
 		err := svc.HandleNewSensorData(context.Background(), &event)
 
-		// then
 		assert.NoError(t, err)
 		select {
 		case <-ch:

--- a/backend/internal/service/domain/treecluster/handle_tree_update.go
+++ b/backend/internal/service/domain/treecluster/handle_tree_update.go
@@ -84,7 +84,7 @@ func (s *TreeClusterService) HandleUpdateTree(ctx context.Context, event *entiti
 		return nil
 	}
 
-	if s.isNoUpdateNeeded(event) {
+	if event.Prev.TreeCluster != nil && !event.Prev.TreeCluster.NeedsPositionUpdate(event.Prev, event.New) {
 		return nil
 	}
 
@@ -101,22 +101,15 @@ func (s *TreeClusterService) HandleUpdateTree(ctx context.Context, event *entiti
 	return nil
 }
 
-func (s *TreeClusterService) isNoUpdateNeeded(event *entities.EventUpdateTree) bool {
-	treePosSame := event.Prev.Coordinate == event.New.Coordinate
-	tcSame := event.Prev.TreeCluster != nil && event.New.TreeCluster != nil && event.Prev.TreeCluster.ID == event.New.TreeCluster.ID
-	sensorSame := event.Prev.Sensor == event.New.Sensor
-	return treePosSame && tcSame && sensorSame
-}
-
 func (s *TreeClusterService) handleTreeClusterUpdate(ctx context.Context, tc *entities.TreeCluster, tree *entities.Tree) error {
 	log := logger.GetLogger(ctx)
 	if tc == nil || tree.TreeCluster == nil {
 		return nil
 	}
 
-	wateringStatus, err := s.getWateringStatusOfTreeCluster(ctx, tree.TreeCluster.ID)
+	wateringStatus, err := s.getWateringStatusOfTreeCluster(ctx, tc)
 	if err != nil {
-		log.Error("could not update watering status", "error", err)
+		log.Error("could not calculate watering status", "error", err)
 	}
 
 	updateFn := func(tc *entities.TreeCluster, repo storage.TreeClusterRepository) (bool, error) {
@@ -141,7 +134,7 @@ func (s *TreeClusterService) handleTreeClusterUpdate(ctx context.Context, tc *en
 	}
 
 	if err := s.treeClusterRepo.Update(ctx, tc.ID, updateFn); err == nil {
-		log.Info("successfully updated new tree cluster", "cluster_id", tc.ID)
+		log.Info("successfully updated tree cluster", "cluster_id", tc.ID)
 		return s.publishUpdateEvent(ctx, tc)
 	}
 
@@ -154,7 +147,7 @@ func (s *TreeClusterService) updateWateringStatusOfPrevTreeCluster(ctx context.C
 		return nil
 	}
 
-	wateringStatus, err := s.getWateringStatusOfTreeCluster(ctx, prevTc.ID)
+	wateringStatus, err := s.getWateringStatusOfTreeCluster(ctx, prevTc)
 	if err != nil {
 		log.Error("could not update watering status", "error", err)
 	}

--- a/backend/internal/service/domain/treecluster/handle_tree_update_test.go
+++ b/backend/internal/service/domain/treecluster/handle_tree_update_test.go
@@ -17,7 +17,7 @@ import (
 //nolint:gocyclo // function handles multiple test cases and complex event logic, which requires higher complexity to cover all scenarios.
 func TestTreeClusterService_HandleUpdateTree(t *testing.T) {
 	t.Run("should update tree cluster lat, long, region, watering status and send treecluster update event", func(t *testing.T) {
-		clusterRepo, treeRepo, _, eventManager, svc := setupTest(t)
+		clusterRepo, _, regionRepo, eventManager, svc := setupTest(t)
 
 		// event
 		_, ch, _ := eventManager.Subscribe(entities.EventTypeUpdateTreeCluster)
@@ -27,9 +27,10 @@ func TestTreeClusterService_HandleUpdateTree(t *testing.T) {
 
 		event := entities.NewEventUpdateTree(&prevTree, &updatedTree, nil)
 		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(mock.Anything, int32(1)).Return(allLatestSensorData, nil)
-		treeRepo.EXPECT().GetBySensorIDs(mock.Anything, entities.MustNewSensorID("sensor-1")).Return([]*entities.Tree{&updatedTree}, nil)
+		clusterRepo.EXPECT().GetCenterPoint(mock.Anything, int32(1)).Return(&updatedTcCoord, nil)
+		regionRepo.EXPECT().GetByPoint(mock.Anything, mock.Anything).Return(updatedTc.Region, nil)
 		clusterRepo.EXPECT().Update(mock.Anything, int32(1), mock.Anything).RunAndReturn(func(ctx context.Context, i int32, f func(*entities.TreeCluster, storage.TreeClusterRepository) (bool, error)) error {
-			cluster := entities.TreeCluster{}
+			cluster := prevTc
 			_, err := f(&cluster, clusterRepo)
 			assert.NoError(t, err)
 			assert.Equal(t, entities.WateringStatusGood, cluster.WateringStatus)
@@ -210,9 +211,8 @@ func TestTreeClusterService_HandleUpdateTree(t *testing.T) {
 	})
 
 	t.Run("should update if tree location is equal but tree has changed treecluster", func(t *testing.T) {
-		clusterRepo, _, regionRepo, eventManager, svc := setupTest(t)
+		clusterRepo, _, _, eventManager, svc := setupTest(t)
 
-		// event
 		_, ch, _ := eventManager.Subscribe(entities.EventTypeUpdateTreeCluster)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -226,26 +226,32 @@ func TestTreeClusterService_HandleUpdateTree(t *testing.T) {
 				Name: "Sandberg",
 			},
 			Coordinate: &newTcCoord,
+			Trees: []*entities.Tree{
+				{ID: 1, PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 2))},
+			},
 		}
-		updatedTree.TreeCluster = &newTc
 
-		event := entities.NewEventUpdateTree(&prevTree, &updatedTree, nil)
+		localUpdatedTree := entities.Tree{
+			ID:           1,
+			TreeCluster:  &newTc,
+			Number:       "T001",
+			Coordinate:   entities.MustNewCoordinate(54.811733806341856, 9.482958846410169),
+			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 2)),
+			Sensor:       &entities.Sensor{ID: entities.MustNewSensorID("sensor-1")},
+		}
 
-		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(mock.Anything, int32(2)).Return(nil, storage.ErrSensorNotFound)
+		event := entities.NewEventUpdateTree(&prevTree, &localUpdatedTree, nil)
+
+		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(mock.Anything, int32(1)).Return(allLatestSensorData, nil)
+		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(mock.Anything, int32(2)).Return(allLatestSensorData, nil)
 		clusterRepo.EXPECT().Update(mock.Anything, int32(1), mock.Anything).Return(nil)
 		clusterRepo.EXPECT().Update(mock.Anything, int32(2), mock.Anything).Return(nil)
 		clusterRepo.EXPECT().GetByID(mock.Anything, int32(1)).Return(&prevTc, nil)
 		clusterRepo.EXPECT().GetByID(mock.Anything, int32(2)).Return(&newTc, nil)
 
-		// when
 		err := svc.HandleUpdateTree(context.Background(), &event)
 
-		// then
 		assert.NoError(t, err)
-		clusterRepo.AssertNotCalled(t, "Update")
-		clusterRepo.AssertNotCalled(t, "GetCenterPoint")
-		regionRepo.AssertNotCalled(t, "GetByPoint")
-
 		select {
 		case _, ok := <-ch:
 			assert.True(t, ok)
@@ -341,6 +347,12 @@ var prevTc = entities.TreeCluster{
 		Name: "Sandberg",
 	},
 	Coordinate: &prevTcCoord,
+	Trees: []*entities.Tree{
+		{
+			ID:           1,
+			PlantingYear: entities.MustNewPlantingYear(int32(time.Now().Year() - 2)),
+		},
+	},
 }
 
 var prevTree = entities.Tree{

--- a/backend/internal/service/domain/treecluster/treecluster.go
+++ b/backend/internal/service/domain/treecluster/treecluster.go
@@ -229,11 +229,10 @@ func (s *TreeClusterService) UpdateWateringStatuses(ctx context.Context) error {
 	for _, cluster := range treeClusters {
 		var wateringStatus domain.WateringStatus
 
-		if cluster.Trees == nil || (cluster.Trees != nil && len(cluster.Trees) == 0) {
-			// tree cluster has no trees
+		if len(cluster.Trees) == 0 {
 			wateringStatus = domain.WateringStatusUnknown
 		} else if cluster.LastWatered != nil && cluster.LastWatered.Before(cutoffTime) {
-			wateringStatus, err = s.getWateringStatusOfTreeCluster(ctx, cluster.ID)
+			wateringStatus, err = s.getWateringStatusOfTreeCluster(ctx, cluster)
 			if err != nil {
 				log.Error("failed to get watering status of cluster", "cluster_id", cluster.ID, "error", err)
 				return err
@@ -265,12 +264,7 @@ func (s *TreeClusterService) Ready() bool {
 // otherwise the center point of the tree cluster cannot be set
 func (s *TreeClusterService) updateTreeClusterPosition(ctx context.Context, id int32) error {
 	log := logger.GetLogger(ctx)
-	wateringStatus, err := s.getWateringStatusOfTreeCluster(ctx, id)
-	if err != nil {
-		log.Error("could not update watering status", "error", err)
-	}
-
-	err = s.treeClusterRepo.Update(ctx, id, func(tc *domain.TreeCluster, repo storage.TreeClusterRepository) (bool, error) {
+	err := s.treeClusterRepo.Update(ctx, id, func(tc *domain.TreeCluster, repo storage.TreeClusterRepository) (bool, error) {
 		if len(tc.Trees) != 0 {
 			coord, err := repo.GetCenterPoint(ctx, tc.ID)
 			if err != nil {
@@ -295,7 +289,13 @@ func (s *TreeClusterService) updateTreeClusterPosition(ctx context.Context, id i
 
 			if tc.Coordinate == nil || *tc.Coordinate != *coord {
 				tc.Coordinate = coord
-				tc.WateringStatus = wateringStatus
+
+				wateringStatus, err := s.getWateringStatusOfTreeCluster(ctx, tc)
+				if err != nil {
+					log.Error("could not calculate watering status", "error", err)
+				} else {
+					tc.WateringStatus = wateringStatus
+				}
 
 				log.Info("update tree cluster position due to changed trees inside the tree cluster", "cluster_id", id)
 				log.Debug("detailed updated tree cluster position informations", "cluster_id", id,

--- a/backend/internal/service/domain/treecluster/treecluster_test.go
+++ b/backend/internal/service/domain/treecluster/treecluster_test.go
@@ -161,16 +161,6 @@ func TestTreeClusterService_Create(t *testing.T) {
 		// UpdateWateringStatuses
 		clusterRepo.EXPECT().GetAll(mock.Anything, entities.TreeClusterQuery{}).Return(testClusters, int64(len(testClusters)), nil)
 
-		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(
-			ctx,
-			int32(1),
-		).Return(allLatestSensorData, nil)
-
-		treeRepo.EXPECT().GetBySensorIDs(
-			ctx,
-			entities.MustNewSensorID("sensor-1"),
-		).Return(testTrees, nil)
-
 		clusterRepo.EXPECT().Update(
 			ctx,
 			expectedCluster.ID,
@@ -213,11 +203,6 @@ func TestTreeClusterService_Create(t *testing.T) {
 
 		// UpdateWateringStatuses
 		clusterRepo.EXPECT().GetAll(mock.Anything, entities.TreeClusterQuery{}).Return(testClusters, int64(len(testClusters)), nil)
-
-		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(
-			ctx,
-			int32(2),
-		).Return(nil, storage.ErrSensorNotFound)
 
 		clusterRepo.EXPECT().Update(
 			ctx,
@@ -306,16 +291,6 @@ func TestTreeClusterService_Create(t *testing.T) {
 		// UpdateWateringStatuses
 		clusterRepo.EXPECT().GetAll(mock.Anything, entities.TreeClusterQuery{}).Return(testClusters, int64(len(testClusters)), nil)
 
-		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(
-			ctx,
-			int32(1),
-		).Return(allLatestSensorData, nil)
-
-		treeRepo.EXPECT().GetBySensorIDs(
-			ctx,
-			entities.MustNewSensorID("sensor-1"),
-		).Return(testTrees, nil)
-
 		clusterRepo.EXPECT().Update(
 			ctx,
 			expectedCluster.ID,
@@ -360,16 +335,6 @@ func TestTreeClusterService_Update(t *testing.T) {
 
 		clusterRepo.EXPECT().GetByID(ctx, clusterID).Return(expectedCluster, nil)
 
-		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(
-			ctx,
-			int32(1),
-		).Return(allLatestSensorData, nil)
-
-		treeRepo.EXPECT().GetBySensorIDs(
-			ctx,
-			entities.MustNewSensorID("sensor-1"),
-		).Return(testTrees, nil)
-
 		clusterRepo.EXPECT().Update(
 			ctx,
 			clusterID,
@@ -409,11 +374,6 @@ func TestTreeClusterService_Update(t *testing.T) {
 		).Return(nil, nil)
 
 		clusterRepo.EXPECT().GetByID(ctx, expectedCluster.ID).Return(expectedCluster, nil)
-
-		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(
-			ctx,
-			int32(2),
-		).Return(nil, storage.ErrSensorNotFound)
 
 		clusterRepo.EXPECT().Update(
 			ctx,
@@ -542,16 +502,6 @@ func TestTreeClusterService_EventSystem(t *testing.T) {
 		).Return(nil, nil)
 
 		clusterRepo.EXPECT().GetByID(ctx, expectedCluster.ID).Return(&expectedCluster, nil)
-
-		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(
-			ctx,
-			int32(2),
-		).Return(allLatestSensorData, nil)
-
-		treeRepo.EXPECT().GetBySensorIDs(
-			ctx,
-			entities.MustNewSensorID("sensor-1"),
-		).Return(testTrees, nil)
 
 		clusterRepo.EXPECT().Update(
 			ctx,
@@ -682,7 +632,6 @@ func TestTreeClusterService_UpdateWateringStatuses(t *testing.T) {
 		// when
 		clusterRepo.EXPECT().GetAll(mock.Anything, entities.TreeClusterQuery{}).Return(expectList, int64(len(expectList)), nil)
 		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(mock.Anything, staleCluster.ID).Return(allLatestSensorData, nil)
-		treeRepo.EXPECT().GetBySensorIDs(ctx, entities.MustNewSensorID("sensor-1")).Return(testTrees, nil)
 		clusterRepo.EXPECT().Update(mock.Anything, staleCluster.ID, mock.Anything).Return(nil)
 
 		err := svc.UpdateWateringStatuses(ctx)
@@ -691,7 +640,6 @@ func TestTreeClusterService_UpdateWateringStatuses(t *testing.T) {
 		assert.NoError(t, err)
 		clusterRepo.AssertCalled(t, "GetAll", mock.Anything, entities.TreeClusterQuery{})
 		clusterRepo.AssertCalled(t, "GetAllLatestSensorDataByClusterID", mock.Anything, staleCluster.ID)
-		treeRepo.AssertCalled(t, "GetBySensorIDs", mock.Anything, mock.Anything)
 		clusterRepo.AssertCalled(t, "Update", mock.Anything, staleCluster.ID, mock.Anything)
 		clusterRepo.AssertExpectations(t)
 	})
@@ -755,7 +703,6 @@ func TestTreeClusterService_UpdateWateringStatuses(t *testing.T) {
 		assert.Equal(t, expectedErr, err)
 		clusterRepo.AssertCalled(t, "GetAll", mock.Anything, entities.TreeClusterQuery{})
 		clusterRepo.AssertNotCalled(t, "GetAllLatestSensorDataByClusterID")
-		clusterRepo.AssertNotCalled(t, "GetBySensorIDs")
 		clusterRepo.AssertNotCalled(t, "Update")
 		clusterRepo.AssertExpectations(t)
 	})
@@ -780,7 +727,6 @@ func TestTreeClusterService_UpdateWateringStatuses(t *testing.T) {
 		// when
 		clusterRepo.EXPECT().GetAll(mock.Anything, entities.TreeClusterQuery{}).Return(expectList, int64(len(expectList)), nil)
 		clusterRepo.EXPECT().GetAllLatestSensorDataByClusterID(mock.Anything, staleCluster.ID).Return(allLatestSensorData, nil)
-		treeRepo.EXPECT().GetBySensorIDs(ctx, entities.MustNewSensorID("sensor-1")).Return(testTrees, nil)
 		clusterRepo.EXPECT().Update(mock.Anything, staleCluster.ID, mock.Anything).Return(errors.New("update failed"))
 
 		err := svc.UpdateWateringStatuses(ctx)
@@ -788,7 +734,6 @@ func TestTreeClusterService_UpdateWateringStatuses(t *testing.T) {
 		// then
 		clusterRepo.AssertCalled(t, "GetAll", mock.Anything, entities.TreeClusterQuery{})
 		clusterRepo.AssertCalled(t, "GetAllLatestSensorDataByClusterID", mock.Anything, staleCluster.ID)
-		treeRepo.AssertCalled(t, "GetBySensorIDs", mock.Anything, mock.Anything)
 		clusterRepo.AssertCalled(t, "Update", mock.Anything, staleCluster.ID, mock.Anything)
 		clusterRepo.AssertExpectations(t)
 		assert.NoError(t, err)


### PR DESCRIPTION
Move aggregation logic from `TreeClusterService` into `TreeCluster` entity:

- `CalculateWateringStatus()`: aggregates status from sensor data using youngest tree's age and averaged watermarks across all sensors
- `YoungestTree()`: finds tree with lowest planting year
- `AverageWatermarks()`: averages watermark readings across sensors
- `NeedsPositionUpdate()`: determines if cluster position recalculation is needed based on tree coordinate/cluster/sensor changes

Service now delegates business logic to entity methods, only fetching sensor data from the repository and passing it to the aggregate. Removed `getYoungestTree()`, `getWatermarkSensorData()`, and `isNoUpdateNeeded()` from the service layer.
