### PR TITLE
fix(api): drop duplicate /api segment from client URLs

### DIFF
--- a/backend-rs/crates/server/src/http/health.rs
+++ b/backend-rs/crates/server/src/http/health.rs
@@ -14,7 +14,7 @@ pub fn routes() -> OpenApiRouter<Arc<AppState>> {
     summary = "Liveness probe",
     description = "Lightweight liveness probe for container orchestrators. \
         Returns 200 OK while the HTTP server is responsive; performs no \
-        downstream service checks. Use /api/v1/info/services for a deep \
+        downstream service checks. Use /v1/info/services for a deep \
         services health check.",
     responses(
         (status = 200, description = "Server is alive"),

--- a/backend-rs/crates/server/src/http/mod.rs
+++ b/backend-rs/crates/server/src/http/mod.rs
@@ -87,7 +87,7 @@ pub fn openapi_doc(base_url: &str) -> utoipa::openapi::OpenApi {
         .nest("/api/v1", v1::public_router().merge(v1::protected_router()))
         .split_for_parts();
 
-    api.servers = Some(vec![Server::new(base_url)]);
+    rewrite_paths_for_client(&mut api, base_url);
     api
 }
 
@@ -102,7 +102,7 @@ pub fn router(
         .nest("/api/v1", v1::router(auth_layer))
         .split_for_parts();
 
-    api.servers = Some(vec![Server::new(base_url)]);
+    rewrite_paths_for_client(&mut api, base_url);
 
     let trace_layer = TraceLayer::new_for_http()
         .make_span_with(make_span)
@@ -116,6 +116,20 @@ pub fn router(
         .layer(trace_layer)
         .layer(SetRequestIdLayer::new(REQUEST_ID_HEADER, MakeRequestUuid))
         .with_state(state)
+}
+
+fn rewrite_paths_for_client(api: &mut utoipa::openapi::OpenApi, base_url: &str) {
+    let rewritten: utoipa::openapi::path::PathsMap<_, _> = std::mem::take(&mut api.paths.paths)
+        .into_iter()
+        .map(|(key, item)| {
+            let new_key = key.strip_prefix("/api").map(String::from).unwrap_or(key);
+            (new_key, item)
+        })
+        .collect();
+    api.paths.paths = rewritten;
+
+    let server_url = format!("{}/api", base_url.trim_end_matches('/'));
+    api.servers = Some(vec![Server::new(server_url)]);
 }
 
 fn cors_layer(config: &CorsSettings) -> CorsLayer {

--- a/compose.app.yaml
+++ b/compose.app.yaml
@@ -52,7 +52,7 @@ services:
       # Settings struct exposes those sections.
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.backend.rule=Host(`${APP_HOST:-localhost}`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.backend.rule=Host(`${APP_HOST:-localhost}`) && (PathPrefix(`/api`) || PathPrefix(`/swagger-ui`) || PathPrefix(`/api-docs`))"
       - "traefik.http.routers.backend.entrypoints=${TRAEFIK_ENTRYPOINT:-websecure}"
       - "traefik.http.services.backend.loadbalancer.server.port=3000"
 
@@ -61,7 +61,7 @@ services:
       context: ./frontend
       args:
         - ENV=dev
-        - BASEURL=
+        - BASEURL=/api
         - APP_VERSION=${APP_VERSION:-$(git describe --tags --always --dirty)}
     healthcheck:
       test:

--- a/frontend/app/src/api/backendApi.ts
+++ b/frontend/app/src/api/backendApi.ts
@@ -40,7 +40,7 @@ async function performTokenRefresh(): Promise<void> {
     })
   }
 
-  const res = await fetch(`${basePath}/api/v1/users/token/refresh`, {
+  const res = await fetch(`${basePath}/v1/users/token/refresh`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ refresh_token: refreshToken }),

--- a/frontend/app/src/routes/auth/callback.tsx
+++ b/frontend/app/src/routes/auth/callback.tsx
@@ -20,7 +20,7 @@ export const Route = createFileRoute('/auth/callback')({
     const redirectUrl = `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirect)}`
 
     const response = await fetch(
-      `${basePath}/api/v1/users/login/token?redirect_url=${encodeURIComponent(redirectUrl)}`,
+      `${basePath}/v1/users/login/token?redirect_url=${encodeURIComponent(redirectUrl)}`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/frontend/app/src/routes/login.tsx
+++ b/frontend/app/src/routes/login.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute('/login')({
       redirect_url: redirectUrl,
       code_challenge: challenge,
     })
-    const response = await fetch(`${basePath}/api/v1/users/login?${params.toString()}`)
+    const response = await fetch(`${basePath}/v1/users/login?${params.toString()}`)
     if (!response.ok) {
       throw new Error(`login init failed: ${response.status}`)
     }

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
             '/api-local': {
               target: `http://localhost:3020`,
               changeOrigin: true,
-              rewrite: (path) => path.replace(/^\/api-local/, ''),
+              rewrite: (path) => path.replace(/^\/api-local/, '/api'),
               ws: true,
             },
           }),

--- a/frontend/packages/backend-client/api-docs.json
+++ b/frontend/packages/backend-client/api-docs.json
@@ -15,11 +15,26 @@
   },
   "servers": [
     {
-      "url": "http://127.0.0.1:3020"
+      "url": "http://127.0.0.1:3020/api"
     }
   ],
   "paths": {
-    "/api/v1/clusters": {
+    "/health": {
+      "get": {
+        "tags": [
+          "Info"
+        ],
+        "summary": "Liveness probe",
+        "description": "Lightweight liveness probe for container orchestrators. Returns 200 OK while the HTTP server is responsive; performs no downstream service checks. Use /v1/info/services for a deep services health check.",
+        "operationId": "health",
+        "responses": {
+          "200": {
+            "description": "Server is alive"
+          }
+        }
+      }
+    },
+    "/v1/clusters": {
       "get": {
         "tags": [
           "Tree Clusters"
@@ -106,7 +121,7 @@
         }
       }
     },
-    "/api/v1/clusters/markers": {
+    "/v1/clusters/markers": {
       "get": {
         "tags": [
           "Tree Clusters"
@@ -131,7 +146,7 @@
         }
       }
     },
-    "/api/v1/clusters/{cluster_id}": {
+    "/v1/clusters/{cluster_id}": {
       "get": {
         "tags": [
           "Tree Clusters"
@@ -250,7 +265,7 @@
         }
       }
     },
-    "/api/v1/evaluation": {
+    "/v1/evaluation": {
       "get": {
         "tags": [
           "Evaluation"
@@ -275,7 +290,7 @@
         }
       }
     },
-    "/api/v1/info": {
+    "/v1/info": {
       "get": {
         "tags": [
           "Info"
@@ -300,7 +315,7 @@
         }
       }
     },
-    "/api/v1/info/map": {
+    "/v1/info/map": {
       "get": {
         "tags": [
           "Info"
@@ -325,7 +340,7 @@
         }
       }
     },
-    "/api/v1/info/server": {
+    "/v1/info/server": {
       "get": {
         "tags": [
           "Info"
@@ -350,7 +365,7 @@
         }
       }
     },
-    "/api/v1/info/services": {
+    "/v1/info/services": {
       "get": {
         "tags": [
           "Info"
@@ -375,7 +390,7 @@
         }
       }
     },
-    "/api/v1/info/statistics": {
+    "/v1/info/statistics": {
       "get": {
         "tags": [
           "Info"
@@ -400,7 +415,7 @@
         }
       }
     },
-    "/api/v1/plugins": {
+    "/v1/plugins": {
       "get": {
         "tags": [
           "Plugins"
@@ -461,7 +476,7 @@
         }
       }
     },
-    "/api/v1/plugins/{plugin_slug}": {
+    "/v1/plugins/{plugin_slug}": {
       "get": {
         "tags": [
           "Plugins"
@@ -500,7 +515,7 @@
         }
       }
     },
-    "/api/v1/plugins/{plugin_slug}/heartbeat": {
+    "/v1/plugins/{plugin_slug}/heartbeat": {
       "post": {
         "tags": [
           "Plugins"
@@ -532,7 +547,7 @@
         }
       }
     },
-    "/api/v1/plugins/{plugin_slug}/token/refresh": {
+    "/v1/plugins/{plugin_slug}/token/refresh": {
       "post": {
         "tags": [
           "Plugins"
@@ -581,7 +596,7 @@
         }
       }
     },
-    "/api/v1/plugins/{plugin_slug}/unregister": {
+    "/v1/plugins/{plugin_slug}/unregister": {
       "post": {
         "tags": [
           "Plugins"
@@ -613,7 +628,7 @@
         }
       }
     },
-    "/api/v1/regions": {
+    "/v1/regions": {
       "get": {
         "tags": [
           "Regions"
@@ -667,7 +682,7 @@
         }
       }
     },
-    "/api/v1/regions/{region_id}": {
+    "/v1/regions/{region_id}": {
       "get": {
         "tags": [
           "Regions"
@@ -707,7 +722,7 @@
         }
       }
     },
-    "/api/v1/sensors": {
+    "/v1/sensors": {
       "get": {
         "tags": [
           "Sensors"
@@ -803,7 +818,7 @@
         }
       }
     },
-    "/api/v1/sensors/models": {
+    "/v1/sensors/models": {
       "get": {
         "tags": [
           "Sensors"
@@ -831,7 +846,7 @@
         }
       }
     },
-    "/api/v1/sensors/models/{id}": {
+    "/v1/sensors/models/{id}": {
       "get": {
         "tags": [
           "Sensors"
@@ -870,7 +885,7 @@
         }
       }
     },
-    "/api/v1/sensors/{sensor_id}": {
+    "/v1/sensors/{sensor_id}": {
       "get": {
         "tags": [
           "Sensors"
@@ -939,7 +954,7 @@
         }
       }
     },
-    "/api/v1/sensors/{sensor_id}/activate": {
+    "/v1/sensors/{sensor_id}/activate": {
       "post": {
         "tags": [
           "Sensors"
@@ -991,7 +1006,7 @@
         }
       }
     },
-    "/api/v1/sensors/{sensor_id}/data": {
+    "/v1/sensors/{sensor_id}/data": {
       "get": {
         "tags": [
           "Sensors"
@@ -1030,7 +1045,7 @@
         }
       }
     },
-    "/api/v1/sensors/{sensor_id}/tree": {
+    "/v1/sensors/{sensor_id}/tree": {
       "get": {
         "tags": [
           "Trees"
@@ -1069,7 +1084,7 @@
         }
       }
     },
-    "/api/v1/trees": {
+    "/v1/trees": {
       "get": {
         "tags": [
           "Trees"
@@ -1159,7 +1174,7 @@
         }
       }
     },
-    "/api/v1/trees/markers": {
+    "/v1/trees/markers": {
       "get": {
         "tags": [
           "Trees"
@@ -1239,7 +1254,7 @@
         }
       }
     },
-    "/api/v1/trees/nearest": {
+    "/v1/trees/nearest": {
       "get": {
         "tags": [
           "Trees"
@@ -1305,7 +1320,7 @@
         }
       }
     },
-    "/api/v1/trees/planting-years": {
+    "/v1/trees/planting-years": {
       "get": {
         "tags": [
           "Trees"
@@ -1334,7 +1349,7 @@
         }
       }
     },
-    "/api/v1/trees/{tree_id}": {
+    "/v1/trees/{tree_id}": {
       "get": {
         "tags": [
           "Trees"
@@ -1453,7 +1468,7 @@
         }
       }
     },
-    "/api/v1/users": {
+    "/v1/users": {
       "get": {
         "tags": [
           "Users"
@@ -1552,7 +1567,7 @@
         }
       }
     },
-    "/api/v1/users/login": {
+    "/v1/users/login": {
       "get": {
         "tags": [
           "Users"
@@ -1603,7 +1618,7 @@
         }
       }
     },
-    "/api/v1/users/login/token": {
+    "/v1/users/login/token": {
       "post": {
         "tags": [
           "Users"
@@ -1649,7 +1664,7 @@
         }
       }
     },
-    "/api/v1/users/logout": {
+    "/v1/users/logout": {
       "post": {
         "tags": [
           "Users"
@@ -1677,7 +1692,7 @@
         }
       }
     },
-    "/api/v1/users/role/{role_id}": {
+    "/v1/users/role/{role_id}": {
       "get": {
         "tags": [
           "Users"
@@ -1746,7 +1761,7 @@
         }
       }
     },
-    "/api/v1/users/token/refresh": {
+    "/v1/users/token/refresh": {
       "post": {
         "tags": [
           "Users"
@@ -1781,7 +1796,7 @@
         }
       }
     },
-    "/api/v1/vehicles": {
+    "/v1/vehicles": {
       "get": {
         "tags": [
           "Vehicles"
@@ -1874,7 +1889,7 @@
         }
       }
     },
-    "/api/v1/vehicles/archived": {
+    "/v1/vehicles/archived": {
       "get": {
         "tags": [
           "Vehicles"
@@ -1928,7 +1943,7 @@
         }
       }
     },
-    "/api/v1/vehicles/archived/{vehicle_id}": {
+    "/v1/vehicles/archived/{vehicle_id}": {
       "post": {
         "tags": [
           "Vehicles"
@@ -1961,7 +1976,7 @@
         }
       }
     },
-    "/api/v1/vehicles/plate/{plate}": {
+    "/v1/vehicles/plate/{plate}": {
       "get": {
         "tags": [
           "Vehicles"
@@ -2000,7 +2015,7 @@
         }
       }
     },
-    "/api/v1/vehicles/{vehicle_id}": {
+    "/v1/vehicles/{vehicle_id}": {
       "get": {
         "tags": [
           "Vehicles"
@@ -2119,7 +2134,7 @@
         }
       }
     },
-    "/api/v1/watering-plans": {
+    "/v1/watering-plans": {
       "get": {
         "tags": [
           "Watering Plans"
@@ -2209,7 +2224,7 @@
         }
       }
     },
-    "/api/v1/watering-plans/route/gpx/{gpx_name}": {
+    "/v1/watering-plans/route/gpx/{gpx_name}": {
       "get": {
         "tags": [
           "Watering Plans"
@@ -2238,7 +2253,7 @@
         }
       }
     },
-    "/api/v1/watering-plans/route/preview": {
+    "/v1/watering-plans/route/preview": {
       "post": {
         "tags": [
           "Watering Plans"
@@ -2256,7 +2271,7 @@
         }
       }
     },
-    "/api/v1/watering-plans/{watering_plan_id}": {
+    "/v1/watering-plans/{watering_plan_id}": {
       "get": {
         "tags": [
           "Watering Plans"
@@ -2371,21 +2386,6 @@
           },
           "500": {
             "description": "Internal server error"
-          }
-        }
-      }
-    },
-    "/health": {
-      "get": {
-        "tags": [
-          "Info"
-        ],
-        "summary": "Liveness probe",
-        "description": "Lightweight liveness probe for container orchestrators. Returns 200 OK while the HTTP server is responsive; performs no downstream service checks. Use /api/v1/info/services for a deep services health check.",
-        "operationId": "health",
-        "responses": {
-          "200": {
-            "description": "Server is alive"
           }
         }
       }

--- a/frontend/packages/backend-client/src/apis/EvaluationApi.ts
+++ b/frontend/packages/backend-client/src/apis/EvaluationApi.ts
@@ -37,7 +37,7 @@ export class EvaluationApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/evaluation`;
+        let urlPath = `/v1/evaluation`;
 
         const response = await this.request({
             path: urlPath,

--- a/frontend/packages/backend-client/src/apis/InfoApi.ts
+++ b/frontend/packages/backend-client/src/apis/InfoApi.ts
@@ -49,7 +49,7 @@ export class InfoApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/info`;
+        let urlPath = `/v1/info`;
 
         const response = await this.request({
             path: urlPath,
@@ -80,7 +80,7 @@ export class InfoApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/info/map`;
+        let urlPath = `/v1/info/map`;
 
         const response = await this.request({
             path: urlPath,
@@ -111,7 +111,7 @@ export class InfoApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/info/server`;
+        let urlPath = `/v1/info/server`;
 
         const response = await this.request({
             path: urlPath,
@@ -142,7 +142,7 @@ export class InfoApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/info/services`;
+        let urlPath = `/v1/info/services`;
 
         const response = await this.request({
             path: urlPath,
@@ -173,7 +173,7 @@ export class InfoApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/info/statistics`;
+        let urlPath = `/v1/info/statistics`;
 
         const response = await this.request({
             path: urlPath,
@@ -195,7 +195,7 @@ export class InfoApi extends runtime.BaseAPI {
     }
 
     /**
-     * Lightweight liveness probe for container orchestrators. Returns 200 OK while the HTTP server is responsive; performs no downstream service checks. Use /api/v1/info/services for a deep services health check.
+     * Lightweight liveness probe for container orchestrators. Returns 200 OK while the HTTP server is responsive; performs no downstream service checks. Use /v1/info/services for a deep services health check.
      * Liveness probe
      */
     async healthRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
@@ -217,7 +217,7 @@ export class InfoApi extends runtime.BaseAPI {
     }
 
     /**
-     * Lightweight liveness probe for container orchestrators. Returns 200 OK while the HTTP server is responsive; performs no downstream service checks. Use /api/v1/info/services for a deep services health check.
+     * Lightweight liveness probe for container orchestrators. Returns 200 OK while the HTTP server is responsive; performs no downstream service checks. Use /v1/info/services for a deep services health check.
      * Liveness probe
      */
     async health(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {

--- a/frontend/packages/backend-client/src/apis/PluginsApi.ts
+++ b/frontend/packages/backend-client/src/apis/PluginsApi.ts
@@ -77,7 +77,7 @@ export class PluginsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/plugins/{plugin_slug}`;
+        let urlPath = `/v1/plugins/{plugin_slug}`;
         urlPath = urlPath.replace(`{${"plugin_slug"}}`, encodeURIComponent(String(requestParameters['pluginSlug'])));
 
         const response = await this.request({
@@ -109,7 +109,7 @@ export class PluginsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/plugins`;
+        let urlPath = `/v1/plugins`;
 
         const response = await this.request({
             path: urlPath,
@@ -147,7 +147,7 @@ export class PluginsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/plugins/{plugin_slug}/heartbeat`;
+        let urlPath = `/v1/plugins/{plugin_slug}/heartbeat`;
         urlPath = urlPath.replace(`{${"plugin_slug"}}`, encodeURIComponent(String(requestParameters['pluginSlug'])));
 
         const response = await this.request({
@@ -194,7 +194,7 @@ export class PluginsApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/plugins/{plugin_slug}/token/refresh`;
+        let urlPath = `/v1/plugins/{plugin_slug}/token/refresh`;
         urlPath = urlPath.replace(`{${"plugin_slug"}}`, encodeURIComponent(String(requestParameters['pluginSlug'])));
 
         const response = await this.request({
@@ -236,7 +236,7 @@ export class PluginsApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/plugins`;
+        let urlPath = `/v1/plugins`;
 
         const response = await this.request({
             path: urlPath,
@@ -275,7 +275,7 @@ export class PluginsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/plugins/{plugin_slug}/unregister`;
+        let urlPath = `/v1/plugins/{plugin_slug}/unregister`;
         urlPath = urlPath.replace(`{${"plugin_slug"}}`, encodeURIComponent(String(requestParameters['pluginSlug'])));
 
         const response = await this.request({

--- a/frontend/packages/backend-client/src/apis/RegionsApi.ts
+++ b/frontend/packages/backend-client/src/apis/RegionsApi.ts
@@ -56,7 +56,7 @@ export class RegionsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/regions/{region_id}`;
+        let urlPath = `/v1/regions/{region_id}`;
         urlPath = urlPath.replace(`{${"region_id"}}`, encodeURIComponent(String(requestParameters['regionId'])));
 
         const response = await this.request({
@@ -96,7 +96,7 @@ export class RegionsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/regions`;
+        let urlPath = `/v1/regions`;
 
         const response = await this.request({
             path: urlPath,

--- a/frontend/packages/backend-client/src/apis/SensorsApi.ts
+++ b/frontend/packages/backend-client/src/apis/SensorsApi.ts
@@ -98,7 +98,7 @@ export class SensorsApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/sensors/{sensor_id}/activate`;
+        let urlPath = `/v1/sensors/{sensor_id}/activate`;
         urlPath = urlPath.replace(`{${"sensor_id"}}`, encodeURIComponent(String(requestParameters['sensorId'])));
 
         const response = await this.request({
@@ -140,7 +140,7 @@ export class SensorsApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/sensors`;
+        let urlPath = `/v1/sensors`;
 
         const response = await this.request({
             path: urlPath,
@@ -179,7 +179,7 @@ export class SensorsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/sensors/{sensor_id}`;
+        let urlPath = `/v1/sensors/{sensor_id}`;
         urlPath = urlPath.replace(`{${"sensor_id"}}`, encodeURIComponent(String(requestParameters['sensorId'])));
 
         const response = await this.request({
@@ -217,7 +217,7 @@ export class SensorsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/sensors/{sensor_id}`;
+        let urlPath = `/v1/sensors/{sensor_id}`;
         urlPath = urlPath.replace(`{${"sensor_id"}}`, encodeURIComponent(String(requestParameters['sensorId'])));
 
         const response = await this.request({
@@ -255,7 +255,7 @@ export class SensorsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/sensors/models/{id}`;
+        let urlPath = `/v1/sensors/models/{id}`;
         urlPath = urlPath.replace(`{${"id"}}`, encodeURIComponent(String(requestParameters['id'])));
 
         const response = await this.request({
@@ -293,7 +293,7 @@ export class SensorsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/sensors/{sensor_id}/data`;
+        let urlPath = `/v1/sensors/{sensor_id}/data`;
         urlPath = urlPath.replace(`{${"sensor_id"}}`, encodeURIComponent(String(requestParameters['sensorId'])));
 
         const response = await this.request({
@@ -325,7 +325,7 @@ export class SensorsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/sensors/models`;
+        let urlPath = `/v1/sensors/models`;
 
         const response = await this.request({
             path: urlPath,
@@ -364,7 +364,7 @@ export class SensorsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/sensors`;
+        let urlPath = `/v1/sensors`;
 
         const response = await this.request({
             path: urlPath,

--- a/frontend/packages/backend-client/src/apis/TreeClustersApi.ts
+++ b/frontend/packages/backend-client/src/apis/TreeClustersApi.ts
@@ -80,7 +80,7 @@ export class TreeClustersApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/clusters`;
+        let urlPath = `/v1/clusters`;
 
         const response = await this.request({
             path: urlPath,
@@ -119,7 +119,7 @@ export class TreeClustersApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/clusters/{cluster_id}`;
+        let urlPath = `/v1/clusters/{cluster_id}`;
         urlPath = urlPath.replace(`{${"cluster_id"}}`, encodeURIComponent(String(requestParameters['clusterId'])));
 
         const response = await this.request({
@@ -157,7 +157,7 @@ export class TreeClustersApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/clusters/{cluster_id}`;
+        let urlPath = `/v1/clusters/{cluster_id}`;
         urlPath = urlPath.replace(`{${"cluster_id"}}`, encodeURIComponent(String(requestParameters['clusterId'])));
 
         const response = await this.request({
@@ -189,7 +189,7 @@ export class TreeClustersApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/clusters/markers`;
+        let urlPath = `/v1/clusters/markers`;
 
         const response = await this.request({
             path: urlPath,
@@ -228,7 +228,7 @@ export class TreeClustersApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/clusters`;
+        let urlPath = `/v1/clusters`;
 
         const response = await this.request({
             path: urlPath,
@@ -275,7 +275,7 @@ export class TreeClustersApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/clusters/{cluster_id}`;
+        let urlPath = `/v1/clusters/{cluster_id}`;
         urlPath = urlPath.replace(`{${"cluster_id"}}`, encodeURIComponent(String(requestParameters['clusterId'])));
 
         const response = await this.request({

--- a/frontend/packages/backend-client/src/apis/TreesApi.ts
+++ b/frontend/packages/backend-client/src/apis/TreesApi.ts
@@ -103,7 +103,7 @@ export class TreesApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/trees`;
+        let urlPath = `/v1/trees`;
 
         const response = await this.request({
             path: urlPath,
@@ -142,7 +142,7 @@ export class TreesApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/trees/{tree_id}`;
+        let urlPath = `/v1/trees/{tree_id}`;
         urlPath = urlPath.replace(`{${"tree_id"}}`, encodeURIComponent(String(requestParameters['treeId'])));
 
         const response = await this.request({
@@ -199,7 +199,7 @@ export class TreesApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/trees/nearest`;
+        let urlPath = `/v1/trees/nearest`;
 
         const response = await this.request({
             path: urlPath,
@@ -237,7 +237,7 @@ export class TreesApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/trees/{tree_id}`;
+        let urlPath = `/v1/trees/{tree_id}`;
         urlPath = urlPath.replace(`{${"tree_id"}}`, encodeURIComponent(String(requestParameters['treeId'])));
 
         const response = await this.request({
@@ -276,7 +276,7 @@ export class TreesApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/sensors/{sensor_id}/tree`;
+        let urlPath = `/v1/sensors/{sensor_id}/tree`;
         urlPath = urlPath.replace(`{${"sensor_id"}}`, encodeURIComponent(String(requestParameters['sensorId'])));
 
         const response = await this.request({
@@ -308,7 +308,7 @@ export class TreesApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/trees/planting-years`;
+        let urlPath = `/v1/trees/planting-years`;
 
         const response = await this.request({
             path: urlPath,
@@ -362,7 +362,7 @@ export class TreesApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/trees/markers`;
+        let urlPath = `/v1/trees/markers`;
 
         const response = await this.request({
             path: urlPath,
@@ -401,7 +401,7 @@ export class TreesApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/trees`;
+        let urlPath = `/v1/trees`;
 
         const response = await this.request({
             path: urlPath,
@@ -448,7 +448,7 @@ export class TreesApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/trees/{tree_id}`;
+        let urlPath = `/v1/trees/{tree_id}`;
         urlPath = urlPath.replace(`{${"tree_id"}}`, encodeURIComponent(String(requestParameters['treeId'])));
 
         const response = await this.request({

--- a/frontend/packages/backend-client/src/apis/UsersApi.ts
+++ b/frontend/packages/backend-client/src/apis/UsersApi.ts
@@ -100,7 +100,7 @@ export class UsersApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/users`;
+        let urlPath = `/v1/users`;
 
         const response = await this.request({
             path: urlPath,
@@ -152,7 +152,7 @@ export class UsersApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/users/login/token`;
+        let urlPath = `/v1/users/login/token`;
 
         const response = await this.request({
             path: urlPath,
@@ -192,7 +192,7 @@ export class UsersApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/users`;
+        let urlPath = `/v1/users`;
 
         const response = await this.request({
             path: urlPath,
@@ -238,7 +238,7 @@ export class UsersApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/users/role/{role_id}`;
+        let urlPath = `/v1/users/role/{role_id}`;
         urlPath = urlPath.replace(`{${"role_id"}}`, encodeURIComponent(String(requestParameters['roleId'])));
 
         const response = await this.request({
@@ -278,7 +278,7 @@ export class UsersApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/users/login`;
+        let urlPath = `/v1/users/login`;
 
         const response = await this.request({
             path: urlPath,
@@ -318,7 +318,7 @@ export class UsersApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/users/logout`;
+        let urlPath = `/v1/users/logout`;
 
         const response = await this.request({
             path: urlPath,
@@ -358,7 +358,7 @@ export class UsersApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/users/token/refresh`;
+        let urlPath = `/v1/users/token/refresh`;
 
         const response = await this.request({
             path: urlPath,

--- a/frontend/packages/backend-client/src/apis/VehiclesApi.ts
+++ b/frontend/packages/backend-client/src/apis/VehiclesApi.ts
@@ -88,7 +88,7 @@ export class VehiclesApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/vehicles/archived/{vehicle_id}`;
+        let urlPath = `/v1/vehicles/archived/{vehicle_id}`;
         urlPath = urlPath.replace(`{${"vehicle_id"}}`, encodeURIComponent(String(requestParameters['vehicleId'])));
 
         const response = await this.request({
@@ -128,7 +128,7 @@ export class VehiclesApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/vehicles`;
+        let urlPath = `/v1/vehicles`;
 
         const response = await this.request({
             path: urlPath,
@@ -167,7 +167,7 @@ export class VehiclesApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/vehicles/{vehicle_id}`;
+        let urlPath = `/v1/vehicles/{vehicle_id}`;
         urlPath = urlPath.replace(`{${"vehicle_id"}}`, encodeURIComponent(String(requestParameters['vehicleId'])));
 
         const response = await this.request({
@@ -205,7 +205,7 @@ export class VehiclesApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/vehicles/{vehicle_id}`;
+        let urlPath = `/v1/vehicles/{vehicle_id}`;
         urlPath = urlPath.replace(`{${"vehicle_id"}}`, encodeURIComponent(String(requestParameters['vehicleId'])));
 
         const response = await this.request({
@@ -244,7 +244,7 @@ export class VehiclesApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/vehicles/plate/{plate}`;
+        let urlPath = `/v1/vehicles/plate/{plate}`;
         urlPath = urlPath.replace(`{${"plate"}}`, encodeURIComponent(String(requestParameters['plate'])));
 
         const response = await this.request({
@@ -284,7 +284,7 @@ export class VehiclesApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/vehicles/archived`;
+        let urlPath = `/v1/vehicles/archived`;
 
         const response = await this.request({
             path: urlPath,
@@ -323,7 +323,7 @@ export class VehiclesApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/vehicles`;
+        let urlPath = `/v1/vehicles`;
 
         const response = await this.request({
             path: urlPath,
@@ -370,7 +370,7 @@ export class VehiclesApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/vehicles/{vehicle_id}`;
+        let urlPath = `/v1/vehicles/{vehicle_id}`;
         urlPath = urlPath.replace(`{${"vehicle_id"}}`, encodeURIComponent(String(requestParameters['vehicleId'])));
 
         const response = await this.request({

--- a/frontend/packages/backend-client/src/apis/WateringPlansApi.ts
+++ b/frontend/packages/backend-client/src/apis/WateringPlansApi.ts
@@ -81,7 +81,7 @@ export class WateringPlansApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/watering-plans`;
+        let urlPath = `/v1/watering-plans`;
 
         const response = await this.request({
             path: urlPath,
@@ -120,7 +120,7 @@ export class WateringPlansApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/watering-plans/{watering_plan_id}`;
+        let urlPath = `/v1/watering-plans/{watering_plan_id}`;
         urlPath = urlPath.replace(`{${"watering_plan_id"}}`, encodeURIComponent(String(requestParameters['wateringPlanId'])));
 
         const response = await this.request({
@@ -158,7 +158,7 @@ export class WateringPlansApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/watering-plans/route/gpx/{gpx_name}`;
+        let urlPath = `/v1/watering-plans/route/gpx/{gpx_name}`;
         urlPath = urlPath.replace(`{${"gpx_name"}}`, encodeURIComponent(String(requestParameters['gpxName'])));
 
         const response = await this.request({
@@ -196,7 +196,7 @@ export class WateringPlansApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/watering-plans/{watering_plan_id}`;
+        let urlPath = `/v1/watering-plans/{watering_plan_id}`;
         urlPath = urlPath.replace(`{${"watering_plan_id"}}`, encodeURIComponent(String(requestParameters['wateringPlanId'])));
 
         const response = await this.request({
@@ -236,7 +236,7 @@ export class WateringPlansApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/watering-plans`;
+        let urlPath = `/v1/watering-plans`;
 
         const response = await this.request({
             path: urlPath,
@@ -267,7 +267,7 @@ export class WateringPlansApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/v1/watering-plans/route/preview`;
+        let urlPath = `/v1/watering-plans/route/preview`;
 
         const response = await this.request({
             path: urlPath,
@@ -313,7 +313,7 @@ export class WateringPlansApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
 
-        let urlPath = `/api/v1/watering-plans/{watering_plan_id}`;
+        let urlPath = `/v1/watering-plans/{watering_plan_id}`;
         urlPath = urlPath.replace(`{${"watering_plan_id"}}`, encodeURIComponent(String(requestParameters['wateringPlanId'])));
 
         const response = await this.request({

--- a/frontend/packages/backend-client/src/runtime.ts
+++ b/frontend/packages/backend-client/src/runtime.ts
@@ -13,7 +13,7 @@
  */
 
 
-export const BASE_PATH = "http://127.0.0.1:3020".replace(/\/+$/, "");
+export const BASE_PATH = "http://127.0.0.1:3020/api".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
     basePath?: string; // override base path


### PR DESCRIPTION
Rewrite OpenAPI paths from `/api/v1/...` to `/v1/...` and fold `/api` into the server URL. Vite proxy rewrites `/api-local -> /api` accordingly. Eliminates the `/api-local/api/v1/...` and `/api/api/v1/...` duplications and aligns dev, stage and prod URL shapes.
