### PR TITLE
fix(ci): shorten commit sha in stage version string

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -167,6 +167,12 @@ jobs:
         id: build-time
         run: echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
 
+      - name: Compute short SHA
+        id: short-sha
+        run: |
+          FULL_SHA="${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
+          echo "short=$(echo $FULL_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
+
       - name: Build and push backend
         uses: docker/build-push-action@v7
         with:
@@ -178,7 +184,7 @@ jobs:
           build-args: |
             APP_VERSION=${{ needs.determine-environment.outputs.image-tag }}
             APP_REVISION=${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-            GE_GIT_COMMIT=${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+            GE_GIT_COMMIT=${{ steps.short-sha.outputs.short }}
             GE_GIT_BRANCH=${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
             GE_BUILD_TIME=${{ steps.build-time.outputs.timestamp }}
           cache-from: type=gha,scope=build-backend

--- a/backend-rs/crates/server/src/infra/system_info.rs
+++ b/backend-rs/crates/server/src/infra/system_info.rs
@@ -97,11 +97,17 @@ impl DefaultSystemInfoProvider {
 }
 
 fn build_display_version(raw: &str, commit: &str, kind: BuildKind) -> String {
+    let commit = short_commit_sha(commit);
     match kind {
         BuildKind::Dev => format!("{raw}+dev.{commit}"),
         BuildKind::Stage => format!("{raw}+stage.{commit}"),
         BuildKind::Release => raw.to_string(),
     }
+}
+
+fn short_commit_sha(commit: &str) -> &str {
+    const SHORT_LEN: usize = 7;
+    commit.get(..SHORT_LEN).unwrap_or(commit)
 }
 
 #[async_trait::async_trait]
@@ -179,6 +185,37 @@ mod tests {
             build_display_version("0.1.0", "abc1234", BuildKind::Release),
             "0.1.0"
         );
+    }
+
+    #[test]
+    fn stage_build_truncates_full_length_sha() {
+        assert_eq!(
+            build_display_version(
+                "0.2.0",
+                "58b06957bb2f464c555da47a98c6bf5563312e4f",
+                BuildKind::Stage,
+            ),
+            "0.2.0+stage.58b0695"
+        );
+    }
+
+    #[test]
+    fn dev_build_truncates_full_length_sha() {
+        assert_eq!(
+            build_display_version(
+                "0.2.0",
+                "58b06957bb2f464c555da47a98c6bf5563312e4f",
+                BuildKind::Dev,
+            ),
+            "0.2.0+dev.58b0695"
+        );
+    }
+
+    #[test]
+    fn short_commit_passthrough_when_already_short() {
+        assert_eq!(short_commit_sha("abc1234"), "abc1234");
+        assert_eq!(short_commit_sha("unknown"), "unknown");
+        assert_eq!(short_commit_sha("abc"), "abc");
     }
 
     #[test]


### PR DESCRIPTION
The stage image showed the full 40-character SHA in the version metadata (e.g. `v0.2.0+stage.58b06957bb2f464c555da47a98c6bf5563312e4f`) instead of the expected short form (`v0.2.0+stage.58b0695`).

The build workflow passed `github.sha` verbatim as `GE_GIT_COMMIT`, while the image-tag was already being truncated with `cut -c1-7`. The binary read `GE_GIT_COMMIT` and appended it to the version unchanged.

Fix both layers:
- Pipeline: compute a short SHA and pass it as `GE_GIT_COMMIT`.
- build_display_version: defensively truncate to 7 chars so direct docker builds outside the pipeline still produce a clean version.