### PR TITLE
feat: disable routing and plugin features for release

### DIFF
--- a/backend-rs/config/base.yaml
+++ b/backend-rs/config/base.yaml
@@ -23,7 +23,7 @@ mqtt:
   enabled: false
   broker_url: ""
   topic: ""
-  client_id: "green-ecolution-rs"
+  client_id: "green-ecolution"
   keep_alive_secs: 30
 map:
   center: [54.792277136221905, 9.43580607453268]

--- a/backend-rs/config/base.yaml
+++ b/backend-rs/config/base.yaml
@@ -31,3 +31,7 @@ map:
 info:
   update_check_repo: "green-ecolution/green-ecolution"
   repository_url: "https://github.com/green-ecolution/"
+routing:
+  enabled: false
+plugins:
+  enabled: false

--- a/backend-rs/crates/domain/src/info/service.rs
+++ b/backend-rs/crates/domain/src/info/service.rs
@@ -9,6 +9,8 @@ pub enum ServiceName {
     Postgres,
     Keycloak,
     Mqtt,
+    Routing,
+    Plugins,
 }
 
 impl ServiceName {
@@ -17,6 +19,8 @@ impl ServiceName {
             Self::Postgres => "database",
             Self::Keycloak => "auth",
             Self::Mqtt => "mqtt",
+            Self::Routing => "routing",
+            Self::Plugins => "plugins",
         }
     }
 }
@@ -61,6 +65,8 @@ mod tests {
         assert_eq!(ServiceName::Postgres.as_key(), "database");
         assert_eq!(ServiceName::Keycloak.as_key(), "auth");
         assert_eq!(ServiceName::Mqtt.as_key(), "mqtt");
+        assert_eq!(ServiceName::Routing.as_key(), "routing");
+        assert_eq!(ServiceName::Plugins.as_key(), "plugins");
     }
 
     #[test]

--- a/backend-rs/crates/server/src/configuration.rs
+++ b/backend-rs/crates/server/src/configuration.rs
@@ -21,6 +21,10 @@ pub struct Settings {
     pub map: MapSettings,
     #[serde(default)]
     pub info: InfoSettings,
+    #[serde(default)]
+    pub routing: RoutingSettings,
+    #[serde(default)]
+    pub plugins: PluginsSettings,
 }
 
 #[derive(serde::Deserialize, Clone)]
@@ -122,6 +126,18 @@ fn default_client_id() -> String {
 
 fn default_keep_alive_secs() -> u16 {
     30
+}
+
+#[derive(serde::Deserialize, Clone, Default)]
+pub struct RoutingSettings {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+#[derive(serde::Deserialize, Clone, Default)]
+pub struct PluginsSettings {
+    #[serde(default)]
+    pub enabled: bool,
 }
 
 #[derive(serde::Deserialize, Clone)]
@@ -285,6 +301,8 @@ impl Settings {
             mqtt: MqttSettings::default(),
             map: MapSettings::default(),
             info: InfoSettings::default(),
+            routing: RoutingSettings::default(),
+            plugins: PluginsSettings::default(),
         }
     }
 }

--- a/backend-rs/crates/server/src/configuration.rs
+++ b/backend-rs/crates/server/src/configuration.rs
@@ -101,7 +101,7 @@ pub struct MqttSettings {
     /// Broker URL, e.g. `mqtt://localhost:1883` or `mqtts://broker:8883`.
     #[serde(default)]
     pub broker_url: String,
-    /// Stable client identifier — defaults to `green-ecolution-rs`.
+    /// Stable client identifier — defaults to `green-ecolution`.
     #[serde(default = "default_client_id")]
     pub client_id: String,
     /// Topic filter to subscribe to (single string; wildcards `+`/`#` allowed).
@@ -117,7 +117,7 @@ pub struct MqttSettings {
 }
 
 fn default_client_id() -> String {
-    "green-ecolution-rs".to_string()
+    "green-ecolution".to_string()
 }
 
 fn default_keep_alive_secs() -> u16 {

--- a/backend-rs/crates/server/src/http/mod.rs
+++ b/backend-rs/crates/server/src/http/mod.rs
@@ -33,6 +33,12 @@ pub mod health;
 mod tracing;
 pub mod v1;
 
+#[derive(Debug, Clone, Copy)]
+pub struct FeatureFlags {
+    pub routing_enabled: bool,
+    pub plugins_enabled: bool,
+}
+
 pub struct AppState {
     pub region_service: Arc<RegionService>,
     pub tree_service: Arc<TreeService>,
@@ -48,6 +54,7 @@ pub struct AppState {
     pub health_reader: Arc<dyn HealthSnapshotReader>,
     pub statistics_reader: Arc<dyn StatisticsReader>,
     pub token_validator: Arc<TokenValidator>,
+    pub feature_flags: FeatureFlags,
 }
 
 #[derive(OpenApi)]

--- a/backend-rs/crates/server/src/http/v1/error.rs
+++ b/backend-rs/crates/server/src/http/v1/error.rs
@@ -46,6 +46,9 @@ impl IntoResponse for ServiceError {
             e @ (ServiceError::TreeAlreadyHasSensor | ServiceError::AlreadyActivated) => {
                 (StatusCode::CONFLICT, e.to_string()).into_response()
             }
+            e @ ServiceError::FeatureDisabled { .. } => {
+                (StatusCode::SERVICE_UNAVAILABLE, e.to_string()).into_response()
+            }
         }
     }
 }

--- a/backend-rs/crates/server/src/http/v1/plugin.rs
+++ b/backend-rs/crates/server/src/http/v1/plugin.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use axum::{
     Json,
+    body::Bytes,
     extract::{Path, State},
     http::StatusCode,
 };
@@ -29,19 +30,28 @@ pub fn routes() -> OpenApiRouter<Arc<AppState>> {
         .routes(routes!(unregister_plugin))
 }
 
+fn guard(state: &AppState) -> Result<(), ServiceError> {
+    if !state.feature_flags.plugins_enabled {
+        return Err(ServiceError::FeatureDisabled { feature: "plugins" });
+    }
+    Ok(())
+}
+
 #[utoipa::path(get, path = "/plugins", tag = "Plugins",
     operation_id = "listPlugins",
     summary = "List all plugins",
     description = "Returns all registered plugins.",
     responses(
         (status = 200, description = "List of registered plugins", body = PluginListResponse),
+        (status = 503, description = "Plugins feature is disabled"),
         (status = 500, description = "Internal server error"),
     )
 )]
 #[tracing::instrument(level = "info", skip_all)]
 pub async fn list_plugins(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
 ) -> Result<Json<PluginListResponse>, ServiceError> {
+    guard(&state)?;
     todo!()
 }
 
@@ -53,14 +63,16 @@ pub async fn list_plugins(
     responses(
         (status = 201, description = "Plugin registered", body = ClientTokenResponse),
         (status = 400, description = "Invalid input"),
+        (status = 503, description = "Plugins feature is disabled"),
         (status = 500, description = "Internal server error"),
     )
 )]
 #[tracing::instrument(level = "info", skip_all)]
 pub async fn register_plugin(
-    State(_state): State<Arc<AppState>>,
-    Json(_entity): Json<PluginRegisterRequest>,
+    State(state): State<Arc<AppState>>,
+    _body: Bytes,
 ) -> Result<(StatusCode, Json<ClientTokenResponse>), ServiceError> {
+    guard(&state)?;
     todo!()
 }
 
@@ -72,14 +84,16 @@ pub async fn register_plugin(
     responses(
         (status = 200, description = "Plugin found", body = PluginResponse),
         (status = 404, description = "Plugin not found"),
+        (status = 503, description = "Plugins feature is disabled"),
         (status = 500, description = "Internal server error"),
     )
 )]
 #[tracing::instrument(level = "info", skip_all)]
 pub async fn get_plugin(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Path(_slug): Path<String>,
 ) -> Result<Json<PluginResponse>, ServiceError> {
+    guard(&state)?;
     todo!()
 }
 
@@ -91,14 +105,16 @@ pub async fn get_plugin(
     responses(
         (status = 200, description = "Heartbeat received"),
         (status = 404, description = "Plugin not found"),
+        (status = 503, description = "Plugins feature is disabled"),
         (status = 500, description = "Internal server error"),
     )
 )]
 #[tracing::instrument(level = "info", skip_all)]
 pub async fn plugin_heartbeat(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Path(_slug): Path<String>,
 ) -> Result<Json<String>, ServiceError> {
+    guard(&state)?;
     todo!()
 }
 
@@ -111,15 +127,17 @@ pub async fn plugin_heartbeat(
     responses(
         (status = 200, description = "Token refreshed", body = ClientTokenResponse),
         (status = 404, description = "Plugin not found"),
+        (status = 503, description = "Plugins feature is disabled"),
         (status = 500, description = "Internal server error"),
     )
 )]
 #[tracing::instrument(level = "info", skip_all)]
 pub async fn plugin_refresh_token(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Path(_slug): Path<String>,
-    Json(_entity): Json<PluginAuthRequest>,
+    _body: Bytes,
 ) -> Result<Json<ClientTokenResponse>, ServiceError> {
+    guard(&state)?;
     todo!()
 }
 
@@ -131,13 +149,15 @@ pub async fn plugin_refresh_token(
     responses(
         (status = 204, description = "Plugin unregistered"),
         (status = 404, description = "Plugin not found"),
+        (status = 503, description = "Plugins feature is disabled"),
         (status = 500, description = "Internal server error"),
     )
 )]
 #[tracing::instrument(level = "info", skip_all)]
 pub async fn unregister_plugin(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Path(_slug): Path<String>,
 ) -> Result<StatusCode, ServiceError> {
+    guard(&state)?;
     todo!()
 }

--- a/backend-rs/crates/server/src/http/v1/plugin.rs
+++ b/backend-rs/crates/server/src/http/v1/plugin.rs
@@ -70,6 +70,7 @@ pub async fn list_plugins(
 #[tracing::instrument(level = "info", skip_all)]
 pub async fn register_plugin(
     State(state): State<Arc<AppState>>,
+    // Bytes instead of Json<T>: Json would reject invalid/empty bodies with 422 before guard() fires.
     _body: Bytes,
 ) -> Result<(StatusCode, Json<ClientTokenResponse>), ServiceError> {
     guard(&state)?;
@@ -135,6 +136,7 @@ pub async fn plugin_heartbeat(
 pub async fn plugin_refresh_token(
     State(state): State<Arc<AppState>>,
     Path(_slug): Path<String>,
+    // Bytes instead of Json<T>: Json would reject invalid/empty bodies with 422 before guard() fires.
     _body: Bytes,
 ) -> Result<Json<ClientTokenResponse>, ServiceError> {
     guard(&state)?;

--- a/backend-rs/crates/server/src/http/v1/watering_plan.rs
+++ b/backend-rs/crates/server/src/http/v1/watering_plan.rs
@@ -390,14 +390,18 @@ pub async fn delete_watering_plan(
     params(("gpx_name" = String, Path, description = "GPX file name")),
     responses(
         (status = 200, description = "GPX file"),
+        (status = 503, description = "Routing feature is disabled"),
         (status = 500, description = "Internal server error"),
     )
 )]
 #[tracing::instrument(level = "info", skip_all)]
 pub async fn get_gpx_file(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Path(_name): Path<String>,
 ) -> Result<Json<()>, ServiceError> {
+    if !state.feature_flags.routing_enabled {
+        return Err(ServiceError::FeatureDisabled { feature: "routing" });
+    }
     todo!()
 }
 
@@ -407,11 +411,15 @@ pub async fn get_gpx_file(
     description = "Calculates and previews an optimized watering route without creating a plan.",
     responses(
         (status = 200, description = "Route preview"),
+        (status = 503, description = "Routing feature is disabled"),
         (status = 500, description = "Internal server error"),
     )
 )]
 #[tracing::instrument(level = "info", skip_all)]
-pub async fn preview_route(State(_state): State<Arc<AppState>>) -> Result<Json<()>, ServiceError> {
+pub async fn preview_route(State(state): State<Arc<AppState>>) -> Result<Json<()>, ServiceError> {
+    if !state.feature_flags.routing_enabled {
+        return Err(ServiceError::FeatureDisabled { feature: "routing" });
+    }
     todo!()
 }
 

--- a/backend-rs/crates/server/src/infra/health/feature_probe.rs
+++ b/backend-rs/crates/server/src/infra/health/feature_probe.rs
@@ -1,0 +1,47 @@
+//! Static probe that reports a feature flag's enabled state.
+//!
+//! Unlike `PgProbe` / `KeycloakProbe`, no network roundtrip happens —
+//! the probe simply mirrors the configured flag so `/info/services`
+//! lists feature-gated subsystems alongside real services.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+
+use domain::info::{ServiceMessage, ServiceName, ServiceStatus};
+
+use super::probe::HealthProbe;
+
+pub struct FeatureProbe {
+    name: ServiceName,
+    enabled: bool,
+}
+
+impl FeatureProbe {
+    pub fn new(name: ServiceName, enabled: bool) -> Self {
+        Self { name, enabled }
+    }
+}
+
+#[async_trait]
+impl HealthProbe for FeatureProbe {
+    fn name(&self) -> ServiceName {
+        self.name
+    }
+
+    async fn check(&self) -> ServiceStatus {
+        ServiceStatus {
+            name: self.name,
+            enabled: self.enabled,
+            healthy: self.enabled,
+            response_time: Duration::ZERO,
+            last_checked: Utc::now(),
+            message: if self.enabled {
+                ServiceMessage::Connected
+            } else {
+                ServiceMessage::Disabled
+            },
+        }
+    }
+}

--- a/backend-rs/crates/server/src/infra/health/mod.rs
+++ b/backend-rs/crates/server/src/infra/health/mod.rs
@@ -1,3 +1,4 @@
+pub mod feature_probe;
 pub mod keycloak_probe;
 pub mod mqtt_probe;
 pub mod pg_probe;

--- a/backend-rs/crates/server/src/service/mod.rs
+++ b/backend-rs/crates/server/src/service/mod.rs
@@ -25,6 +25,8 @@ pub enum ServiceError {
     TreeAlreadyHasSensor,
     #[error("sensor is already activated")]
     AlreadyActivated,
+    #[error("{feature} feature is disabled")]
+    FeatureDisabled { feature: &'static str },
 }
 
 impl From<ValidationError> for ServiceError {

--- a/backend-rs/crates/server/src/startup.rs
+++ b/backend-rs/crates/server/src/startup.rs
@@ -6,7 +6,7 @@ use tokio::net::TcpListener;
 
 use crate::{
     configuration::{CorsSettings, DatabaseSettings, Settings},
-    http::{AppState, auth::AuthLayer, router},
+    http::{AppState, FeatureFlags, auth::AuthLayer, router},
     infra::{
         self,
         keycloak::{AuthStack, JwksProvider},
@@ -237,6 +237,10 @@ impl Application {
             health_reader,
             statistics_reader,
             token_validator,
+            feature_flags: FeatureFlags {
+                routing_enabled: settings.routing.enabled,
+                plugins_enabled: settings.plugins.enabled,
+            },
         });
 
         // ---- 13. Listener + return ----

--- a/backend-rs/crates/server/src/startup.rs
+++ b/backend-rs/crates/server/src/startup.rs
@@ -193,10 +193,12 @@ impl Application {
             };
 
         // ---- 10. Health probes ----
+        use crate::infra::health::feature_probe::FeatureProbe;
         use crate::infra::health::keycloak_probe::KeycloakProbe;
         use crate::infra::health::mqtt_probe::MqttProbe;
         use crate::infra::health::pg_probe::PgProbe;
         use crate::infra::health::{HealthProbe, spawn as spawn_health};
+        use domain::info::ServiceName;
         let probes: Vec<Arc<dyn HealthProbe>> = vec![
             Arc::new(PgProbe::new(pool.clone())),
             Arc::new(KeycloakProbe::new(
@@ -206,6 +208,14 @@ impl Application {
                 Duration::from_secs(settings.info.health_probe_timeout_secs),
             )),
             Arc::new(MqttProbe::new(settings.mqtt.enabled, mqtt_state.clone())),
+            Arc::new(FeatureProbe::new(
+                ServiceName::Routing,
+                settings.routing.enabled,
+            )),
+            Arc::new(FeatureProbe::new(
+                ServiceName::Plugins,
+                settings.plugins.enabled,
+            )),
         ];
         let (health_coordinator, _health_handle) = spawn_health(
             probes,

--- a/backend-rs/crates/server/test/api/health_probes.rs
+++ b/backend-rs/crates/server/test/api/health_probes.rs
@@ -198,3 +198,25 @@ async fn health_coordinator_aggregates_probes_after_first_tick() {
 
     handle.abort();
 }
+
+#[tokio::test]
+async fn feature_probe_disabled_reports_disabled_message() {
+    use server::infra::health::feature_probe::FeatureProbe;
+    let probe = FeatureProbe::new(ServiceName::Routing, false);
+    let status = probe.check().await;
+    assert_eq!(probe.name(), ServiceName::Routing);
+    assert!(!status.enabled);
+    assert!(!status.healthy);
+    assert_eq!(status.message, ServiceMessage::Disabled);
+}
+
+#[tokio::test]
+async fn feature_probe_enabled_reports_connected() {
+    use server::infra::health::feature_probe::FeatureProbe;
+    let probe = FeatureProbe::new(ServiceName::Plugins, true);
+    let status = probe.check().await;
+    assert_eq!(probe.name(), ServiceName::Plugins);
+    assert!(status.enabled);
+    assert!(status.healthy);
+    assert_eq!(status.message, ServiceMessage::Connected);
+}

--- a/backend-rs/crates/server/test/api/info.rs
+++ b/backend-rs/crates/server/test/api/info.rs
@@ -173,8 +173,14 @@ async fn services_info_lists_routing_and_plugins_disabled_by_default() {
     };
 
     let routing = by_name("routing");
-    assert_eq!(routing.get("enabled").and_then(|v| v.as_bool()), Some(false));
+    assert_eq!(
+        routing.get("enabled").and_then(|v| v.as_bool()),
+        Some(false)
+    );
 
     let plugins = by_name("plugins");
-    assert_eq!(plugins.get("enabled").and_then(|v| v.as_bool()), Some(false));
+    assert_eq!(
+        plugins.get("enabled").and_then(|v| v.as_bool()),
+        Some(false)
+    );
 }

--- a/backend-rs/crates/server/test/api/info.rs
+++ b/backend-rs/crates/server/test/api/info.rs
@@ -151,3 +151,30 @@ async fn get_statistics_returns_counts() {
         );
     }
 }
+
+#[tokio::test]
+async fn services_info_lists_routing_and_plugins_disabled_by_default() {
+    let app = spawn_app().await;
+
+    let response = app.get("/api/v1/info/services").await;
+    assert_eq!(response.status().as_u16(), 200);
+
+    let body: serde_json::Value = response.json().await.expect("json body");
+    let items = body
+        .get("items")
+        .and_then(|v| v.as_array())
+        .expect("items array");
+
+    let by_name = |name: &str| -> &serde_json::Value {
+        items
+            .iter()
+            .find(|i| i.get("name").and_then(|n| n.as_str()) == Some(name))
+            .unwrap_or_else(|| panic!("missing service entry: {name}"))
+    };
+
+    let routing = by_name("routing");
+    assert_eq!(routing.get("enabled").and_then(|v| v.as_bool()), Some(false));
+
+    let plugins = by_name("plugins");
+    assert_eq!(plugins.get("enabled").and_then(|v| v.as_bool()), Some(false));
+}

--- a/backend-rs/crates/server/test/api/main.rs
+++ b/backend-rs/crates/server/test/api/main.rs
@@ -6,6 +6,7 @@ pub mod health;
 pub mod health_probes;
 pub mod helpers;
 pub mod info;
+pub mod plugins;
 pub mod regions;
 pub mod sensor_activate;
 pub mod sensor_create;

--- a/backend-rs/crates/server/test/api/plugins.rs
+++ b/backend-rs/crates/server/test/api/plugins.rs
@@ -1,0 +1,73 @@
+use crate::helpers::spawn_app;
+
+async fn assert_plugins_503(response: reqwest::Response) {
+    assert_eq!(
+        response.status().as_u16(),
+        503,
+        "expected 503 Service Unavailable when plugins disabled"
+    );
+    let body = response.text().await.unwrap_or_default();
+    assert!(
+        body.contains("plugins"),
+        "expected error body to mention plugins, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn list_plugins_returns_503_when_disabled() {
+    let app = spawn_app().await;
+    let response = app.get("/api/v1/plugins").await;
+    assert_plugins_503(response).await;
+}
+
+#[tokio::test]
+async fn register_plugin_returns_503_when_disabled() {
+    let app = spawn_app().await;
+    let response = app
+        .post_json("/api/v1/plugins", &serde_json::json!({}))
+        .await;
+    assert_plugins_503(response).await;
+}
+
+#[tokio::test]
+async fn get_plugin_returns_503_when_disabled() {
+    let app = spawn_app().await;
+    let response = app.get("/api/v1/plugins/my-plugin").await;
+    assert_plugins_503(response).await;
+}
+
+#[tokio::test]
+async fn plugin_heartbeat_returns_503_when_disabled() {
+    let app = spawn_app().await;
+    let response = app
+        .post_json(
+            "/api/v1/plugins/my-plugin/heartbeat",
+            &serde_json::json!({}),
+        )
+        .await;
+    assert_plugins_503(response).await;
+}
+
+#[tokio::test]
+async fn plugin_refresh_token_returns_503_when_disabled() {
+    let app = spawn_app().await;
+    let response = app
+        .post_json(
+            "/api/v1/plugins/my-plugin/token/refresh",
+            &serde_json::json!({}),
+        )
+        .await;
+    assert_plugins_503(response).await;
+}
+
+#[tokio::test]
+async fn unregister_plugin_returns_503_when_disabled() {
+    let app = spawn_app().await;
+    let response = app
+        .post_json(
+            "/api/v1/plugins/my-plugin/unregister",
+            &serde_json::json!({}),
+        )
+        .await;
+    assert_plugins_503(response).await;
+}

--- a/backend-rs/crates/server/test/api/watering_plans.rs
+++ b/backend-rs/crates/server/test/api/watering_plans.rs
@@ -414,3 +414,36 @@ async fn cancel_active_watering_plan_with_note_succeeds() {
     let body: serde_json::Value = cancel_resp.json().await.unwrap();
     assert_eq!(body["status"], "canceled");
 }
+
+#[tokio::test]
+async fn preview_route_returns_503_when_routing_disabled() {
+    let app = spawn_app().await;
+
+    let response = app
+        .post_json(
+            "/api/v1/watering-plans/route/preview",
+            &serde_json::json!({}),
+        )
+        .await;
+
+    assert_eq!(response.status().as_u16(), 503);
+    let body = response.text().await.unwrap_or_default();
+    assert!(
+        body.contains("routing"),
+        "expected error body to mention routing, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn get_gpx_file_returns_503_when_routing_disabled() {
+    let app = spawn_app().await;
+
+    let response = app.get("/api/v1/watering-plans/route/gpx/sample.gpx").await;
+
+    assert_eq!(response.status().as_u16(), 503);
+    let body = response.text().await.unwrap_or_default();
+    assert!(
+        body.contains("routing"),
+        "expected error body to mention routing, got: {body}"
+    );
+}

--- a/frontend/app/src/api/queries.ts
+++ b/frontend/app/src/api/queries.ts
@@ -202,18 +202,6 @@ export const userRoleQuery = (role: string) =>
       }),
   })
 
-// TODO: previewRoute() currently takes no parameters in the generated client.
-// The Rust backend endpoint needs a request body (RouteRequest) to be functional.
-export const routePreviewQuery = (
-  transporterId: string,
-  clusterIds: string[],
-  _trailerId?: string,
-) =>
-  queryOptions({
-    queryKey: ['route', 'preview', `transporter:${transporterId}`, ...clusterIds],
-    queryFn: () => console.log('not implemented'), // () => wateringPlanApi.previewRoute(),
-  })
-
 export const plantingYearsQuery = () =>
   queryOptions<number[]>({
     queryKey: ['planting-years'],

--- a/frontend/app/src/components/map/marker/ShowRoutePreview.tsx
+++ b/frontend/app/src/components/map/marker/ShowRoutePreview.tsx
@@ -1,5 +1,5 @@
-import { routePreviewQuery } from '@/api/queries'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { servicesInfoQuery } from '@/api/queries'
+import { useQuery } from '@tanstack/react-query'
 
 export interface ShowRoutePreview {
   transporterId: string
@@ -7,16 +7,16 @@ export interface ShowRoutePreview {
   selectedClustersIds: string[]
 }
 
-const ShowRoutePreview = ({ transporterId, trailerId, selectedClustersIds }: ShowRoutePreview) => {
-  if (trailerId === '' || trailerId === '-1') {
-    trailerId = undefined
+const ShowRoutePreview = (_props: ShowRoutePreview) => {
+  const { data: services } = useQuery(servicesInfoQuery())
+  const routing = services?.items.find((item) => item.name === 'routing')
+  if (!routing?.enabled) {
+    return null
   }
-  // TODO: previewRoute() currently returns void (stub).
-  // Once the Rust backend implements the route preview endpoint with proper GeoJSON response,
-  // restore the route visualization (markers + GeoJSON layer).
-  useSuspenseQuery(routePreviewQuery(transporterId, selectedClustersIds, trailerId))
 
-  return <>{/* Route preview is not yet implemented in the Rust backend */}</>
+  // TODO: when routing.enabled flips to true, restore the call to
+  // wateringPlanApi.previewRoute() and render the GeoJSON layer.
+  return null
 }
 
 export default ShowRoutePreview

--- a/frontend/app/src/routes/_protected/info.tsx
+++ b/frontend/app/src/routes/_protected/info.tsx
@@ -38,6 +38,7 @@ import {
   Monitor,
   Network,
   Package,
+  Puzzle,
   Radio,
   Server,
   Settings,
@@ -82,6 +83,7 @@ const serviceNameMap: Record<string, string> = {
   s3: 'S3 Speicher',
   routing: 'Routing (Valhalla)',
   vroom: 'Routenoptimierung (Vroom)',
+  plugins: 'Plugin-System',
 }
 
 function getServiceDisplayName(name: string): string {
@@ -514,6 +516,7 @@ const serviceIconMap: Record<string, React.ReactNode> = {
   s3: <HardDrive className="size-4" />,
   routing: <Network className="size-4" />,
   vroom: <Zap className="size-4" />,
+  plugins: <Puzzle className="size-4" />,
 }
 
 function SystemTabContent({

--- a/frontend/app/src/routes/_protected/settings/index.tsx
+++ b/frontend/app/src/routes/_protected/settings/index.tsx
@@ -1,21 +1,41 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { LinkCard, LinkCardTitle, LinkCardDescription, LinkCardFooter } from '@green-ecolution/ui'
+import { useQuery } from '@tanstack/react-query'
+import { servicesInfoQuery } from '@/api/queries'
 
 export const Route = createFileRoute('/_protected/settings/')({
   component: Settings,
 })
 
-const cards = [
+interface SettingsCard {
+  id: number
+  url: string
+  description: string
+  headline: string
+  linkLabel: string
+  featureKey?: string
+}
+
+const allCards: SettingsCard[] = [
   {
     id: 1,
     url: '/settings/plugin',
     description: 'Alle Plugins, die in der Anwendung installiert sind.',
     headline: 'Plugins',
     linkLabel: 'Zu den Plugins',
+    featureKey: 'plugins',
   },
 ]
 
 function Settings() {
+  const { data: services } = useQuery(servicesInfoQuery())
+
+  const cards = allCards.filter((card) => {
+    if (!card.featureKey) return true
+    const entry = services?.items.find((item) => item.name === card.featureKey)
+    return entry?.enabled === true
+  })
+
   return (
     <div className="container mt-6">
       <article className="mb-10 2xl:w-4/5">
@@ -29,19 +49,21 @@ function Settings() {
         </p>
       </article>
 
-      <ul className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
-        {cards.map((card, key) => (
-          <li key={card.id}>
-            <LinkCard variant={key % 2 ? 'dark' : 'light'} asChild>
-              <Link to={card.url} aria-label={card.linkLabel}>
-                <LinkCardTitle>{card.headline}</LinkCardTitle>
-                <LinkCardDescription>{card.description}</LinkCardDescription>
-                <LinkCardFooter>{card.linkLabel}</LinkCardFooter>
-              </Link>
-            </LinkCard>
-          </li>
-        ))}
-      </ul>
+      {cards.length > 0 && (
+        <ul className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+          {cards.map((card, key) => (
+            <li key={card.id}>
+              <LinkCard variant={key % 2 ? 'dark' : 'light'} asChild>
+                <Link to={card.url} aria-label={card.linkLabel}>
+                  <LinkCardTitle>{card.headline}</LinkCardTitle>
+                  <LinkCardDescription>{card.description}</LinkCardDescription>
+                  <LinkCardFooter>{card.linkLabel}</LinkCardFooter>
+                </Link>
+              </LinkCard>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }

--- a/frontend/app/src/routes/_protected/settings/plugin/route.tsx
+++ b/frontend/app/src/routes/_protected/settings/plugin/route.tsx
@@ -1,7 +1,15 @@
-import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { createFileRoute, Outlet, redirect } from '@tanstack/react-router'
+import { servicesInfoQuery } from '@/api/queries'
 
 export const Route = createFileRoute('/_protected/settings/plugin')({
   component: Outlet,
+  beforeLoad: async ({ context }) => {
+    const services = await context.queryClient.ensureQueryData(servicesInfoQuery())
+    const plugins = services.items.find((item) => item.name === 'plugins')
+    if (!plugins?.enabled) {
+      throw redirect({ to: '/settings' })
+    }
+  },
   loader: () => {
     return {
       crumb: {

--- a/frontend/packages/backend-client/api-docs.json
+++ b/frontend/packages/backend-client/api-docs.json
@@ -436,6 +436,9 @@
           },
           "500": {
             "description": "Internal server error"
+          },
+          "503": {
+            "description": "Plugins feature is disabled"
           }
         }
       },
@@ -472,6 +475,9 @@
           },
           "500": {
             "description": "Internal server error"
+          },
+          "503": {
+            "description": "Plugins feature is disabled"
           }
         }
       }
@@ -511,6 +517,9 @@
           },
           "500": {
             "description": "Internal server error"
+          },
+          "503": {
+            "description": "Plugins feature is disabled"
           }
         }
       }
@@ -543,6 +552,9 @@
           },
           "500": {
             "description": "Internal server error"
+          },
+          "503": {
+            "description": "Plugins feature is disabled"
           }
         }
       }
@@ -592,6 +604,9 @@
           },
           "500": {
             "description": "Internal server error"
+          },
+          "503": {
+            "description": "Plugins feature is disabled"
           }
         }
       }
@@ -624,6 +639,9 @@
           },
           "500": {
             "description": "Internal server error"
+          },
+          "503": {
+            "description": "Plugins feature is disabled"
           }
         }
       }
@@ -2249,6 +2267,9 @@
           },
           "500": {
             "description": "Internal server error"
+          },
+          "503": {
+            "description": "Routing feature is disabled"
           }
         }
       }
@@ -2267,6 +2288,9 @@
           },
           "500": {
             "description": "Internal server error"
+          },
+          "503": {
+            "description": "Routing feature is disabled"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Adds runtime config flags `routing.enabled` and `plugins.enabled` (default `false`) — analog to the existing `mqtt.enabled` / `auth.enabled` pattern
- Replaces the panicking `todo!()` stubs in both feature surfaces with feature-flag guards that return **HTTP 503 Service Unavailable** (`ServiceError::FeatureDisabled`)
- Surfaces both flags in `/info/services` via a new `FeatureProbe` so the frontend can react
- Frontend hides the Plugin-Settings card, redirects `/settings/plugin` to `/settings`, and renders the route-preview as `null` when its flag is off

## Problem
The Rust-backend migration left routing (route-optimization for watering plans) and the plugin system as `todo!()` stubs. Any call to these endpoints panics with 500 / connection drop. To release without these features we need a clean way to gate them off, leave the existing code/scaffolding in place, and re-enable later by flipping a config flag plus implementing the handler.

## Solution

### Backend
- `RoutingSettings { enabled: bool }` and `PluginsSettings { enabled: bool }` in `configuration.rs`; both default `false` in `base.yaml`
- New `ServiceError::FeatureDisabled { feature: &'static str }` variant → 503 mapping in `http/v1/error.rs`
- `FeatureFlags { routing_enabled, plugins_enabled }` `Copy` struct on `AppState`, populated in `startup.rs`
- `ServiceName::Routing` and `::Plugins` variants added to the domain enum (portability stays green: `cargo build -p domain --no-default-features` clean)
- New `FeatureProbe` (`infra/health/feature_probe.rs`) implements `HealthProbe` statically — `enabled` mirrors the config, `message` toggles `Connected`/`Disabled`
- All 2 routing handlers and all 6 plugin handlers guard `state.feature_flags.*_enabled` before reaching `todo!()`. Plugin handlers share a small `guard()` helper; the two routing handlers inline for readability
- The two plugin handlers that took `Json<T>` bodies now accept `axum::body::Bytes` so axum's `Json` extractor cannot 422 the request before the guard fires — utoipa `request_body = T` annotations preserved to keep the OpenAPI contract stable

### Frontend
- `settings/index.tsx` filters its cards array based on `servicesInfoQuery` — plugin card disappears when `plugins.enabled === false`
- `settings/plugin/route.tsx` adds a TanStack Router `beforeLoad` that `ensureQueryData(servicesInfoQuery())` and redirects to `/settings` if disabled — covers the entire `/settings/plugin/*` subtree
- `ShowRoutePreview.tsx` reads the snapshot and returns `null` when routing is off
- Dead `routePreviewQuery` (a `console.log('not implemented')` stub) removed from `queries.ts` since the only call site no longer needs it

### Re-enable path
Setting `routing.enabled: true` (or `plugins.enabled: true`) in a config layer + replacing the corresponding `todo!()` with the real implementation is the only required change.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace --locked` (168 passed)
- [x] `cargo build -p domain --no-default-features --locked` (portability)
- [x] Frontend `pnpm run lint` + `pnpm run build` clean
- [x] Integration tests: 6 plugin endpoints + 2 routing endpoints return 503 with `feature is disabled` body
- [x] Integration test: `/info/services` lists `routing` and `plugins` entries with `enabled: false`
- [ ] Manual smoke: `/settings` shows no Plugin-Card; `/settings/plugin` redirects to `/settings`; map watering-plan editor renders without route-preview