### PR TITLE
fix(sensors): rename 'Sensor hinzufügen' to 'Sensor aktivieren' (GECO-135)

### DIFF
--- a/frontend/app/src/routes/_protected/sensors/index.tsx
+++ b/frontend/app/src/routes/_protected/sensors/index.tsx
@@ -4,7 +4,7 @@ import Pagination from '@/components/general/Pagination'
 import SensorList from '@/components/sensor/SensorList'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, useLoaderData } from '@tanstack/react-router'
-import { Plus } from 'lucide-react'
+import { Zap } from 'lucide-react'
 import { z } from 'zod'
 
 export const Route = createFileRoute('/_protected/sensors/')({
@@ -42,8 +42,8 @@ function Sensors() {
         </article>
         <Button asChild size="sm" className="w-full sm:w-auto sm:shrink-0">
           <Link to="/sensors/new">
-            <Plus />
-            Sensor hinzufügen
+            <Zap />
+            Sensor aktivieren
           </Link>
         </Button>
       </div>

--- a/frontend/app/src/routes/_protected/sensors/new/route.tsx
+++ b/frontend/app/src/routes/_protected/sensors/new/route.tsx
@@ -4,7 +4,7 @@ export const Route = createFileRoute('/_protected/sensors/new')({
   component: Outlet,
   loader: () => ({
     crumb: {
-      title: 'Sensor hinzufügen',
+      title: 'Sensor aktivieren',
     },
   }),
 })


### PR DESCRIPTION
The 'add sensor' wording did not match the domain: sensors are pre-prepared and then activated. Rename the button and breadcrumb accordingly and swap the Plus icon for Zap.