### PR TITLE
refactor(frontend): hoist render-time allocations and clean up memoization

### DIFF
--- a/frontend/app/src/components/general/buttons/FilterButton.tsx
+++ b/frontend/app/src/components/general/buttons/FilterButton.tsx
@@ -23,7 +23,7 @@ const FilterButton: React.FC<FilterButtonProps> = ({
       onClick={onClick}
     >
       Filter
-      <span className="flex items-center justify-center w-6 h-6 rounded-full text-sm bg-green-dark/20">
+      <span className="flex items-center justify-center size-6 rounded-full text-sm bg-green-dark/20">
         {activeCount}
       </span>
     </button>

--- a/frontend/app/src/components/general/cards/IntroductionCard.tsx
+++ b/frontend/app/src/components/general/cards/IntroductionCard.tsx
@@ -9,7 +9,7 @@ interface IntroductionCardProps {
 const IntroductionCard: React.FC<IntroductionCardProps> = ({ label, icon: Icon, description }) => {
   return (
     <div className="h-full cursor-pointer bg-white shadow-cards rounded-2xl p-6 border border-dark-50 xl:cursor-default">
-      <figure className="bg-green-light-200 w-12 h-12 rounded-full flex items-center justify-center">
+      <figure className="bg-green-light-200 size-12 rounded-full flex items-center justify-center">
         {Icon && <Icon className="text-green-dark stroke-2" />}
       </figure>
       <h3 className="my-4 font-lato font-semibold text-lg md:my-5">{label}</h3>

--- a/frontend/app/src/components/general/cards/TreeclusterCard.tsx
+++ b/frontend/app/src/components/general/cards/TreeclusterCard.tsx
@@ -26,7 +26,7 @@ const TreeclusterCard: React.FC<TreeclusterCardProps> = ({ treecluster }) => {
         <ListCardTitle>{treecluster.name}</ListCardTitle>
 
         <ListCardMeta>
-          <MapPin className="w-5 h-5" />
+          <MapPin className="size-5" />
           <p>
             <span>{treecluster.address}, </span>
             <br />
@@ -37,7 +37,7 @@ const TreeclusterCard: React.FC<TreeclusterCardProps> = ({ treecluster }) => {
         </ListCardMeta>
 
         <ListCardMeta>
-          <TreeIcon className="w-5 h-5 mt-0.5" />
+          <TreeIcon className="size-5 mt-0.5" />
           <p>
             {treecluster.treeIds ? treecluster.treeIds?.length : 0}
             {treecluster.treeIds?.length === 1 ? ' Baum' : ' Bäume'}

--- a/frontend/app/src/components/general/cards/selected_card/SelectedCardTree.tsx
+++ b/frontend/app/src/components/general/cards/selected_card/SelectedCardTree.tsx
@@ -35,7 +35,7 @@ const SelectedCardTree = ({ onClick, id }: SelectedCardTreeProps) => {
             className="text-dark-600 hover:text-red"
             onClick={() => onClick(id)}
           >
-            <Trash2 className="w-5 h-5" />
+            <Trash2 className="size-5" />
             <span className="sr-only">Baum aus Auswahl löschen</span>
           </Button>
         </ListCardActions>

--- a/frontend/app/src/components/general/cards/selected_card/SelectedCardTreeCluster.tsx
+++ b/frontend/app/src/components/general/cards/selected_card/SelectedCardTreeCluster.tsx
@@ -35,7 +35,7 @@ const SelectedCardCluster = ({ onClick, id }: SelectedCardClusterProps) => {
             className="text-dark-600 hover:text-red"
             onClick={() => onClick(id)}
           >
-            <Trash2 className="w-5 h-5" />
+            <Trash2 className="size-5" />
             <span className="sr-only">Bewässerungsgruppe aus Auswahl löschen</span>
           </Button>
         </ListCardActions>

--- a/frontend/app/src/components/general/filter/Dialog.tsx
+++ b/frontend/app/src/components/general/filter/Dialog.tsx
@@ -1,4 +1,4 @@
-import { Ref, useEffect, useMemo, useState } from 'react'
+import { Ref, useEffect, useState } from 'react'
 import FilterButton from '../buttons/FilterButton'
 import {
   Button,
@@ -95,14 +95,11 @@ const Dialog = ({
     setIsOpen(true)
   }
 
-  const count = useMemo(
-    () =>
-      filters.statusTags.length +
-      filters.regionTags.length +
-      (filters.hasCluster !== undefined ? 1 : 0) +
-      filters.plantingYears.length,
-    [filters],
-  )
+  const count =
+    filters.statusTags.length +
+    filters.regionTags.length +
+    (filters.hasCluster !== undefined ? 1 : 0) +
+    filters.plantingYears.length
 
   useEffect(() => {
     if (!onToggleOpen) return

--- a/frontend/app/src/components/general/filter/Option.tsx
+++ b/frontend/app/src/components/general/filter/Option.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 
 interface OptionProps {
   name: string
@@ -10,18 +10,15 @@ interface OptionProps {
 }
 
 const Option: React.FC<OptionProps> = ({ name, label, value, children, checked, onChange }) => {
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>) => {
-      if (event.key === 'Enter') {
-        event.preventDefault()
-        const syntheticEvent = {
-          target: { name, value: value ?? label, checked: !checked },
-        } as React.ChangeEvent<HTMLInputElement>
-        onChange(syntheticEvent)
-      }
-    },
-    [name, value, label, checked, onChange],
-  )
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      const syntheticEvent = {
+        target: { name, value: value ?? label, checked: !checked },
+      } as React.ChangeEvent<HTMLInputElement>
+      onChange(syntheticEvent)
+    }
+  }
 
   return (
     <label
@@ -35,7 +32,7 @@ const Option: React.FC<OptionProps> = ({ name, label, value, children, checked, 
         value={value ?? label}
         onChange={onChange}
         onKeyDown={handleKeyDown}
-        className="opacity-0 w-0 h-0"
+        className="opacity-0 size-0"
       />
       {children && <div>{children}</div>}
       <span>{label}</span>

--- a/frontend/app/src/components/general/filter/fieldsets/ClusterFieldset.tsx
+++ b/frontend/app/src/components/general/filter/fieldsets/ClusterFieldset.tsx
@@ -1,18 +1,19 @@
 import { useFilter } from '@/context/FilterContext'
 import Option from '../Option'
 
+const treeClusterOptions = [
+  {
+    label: 'Gruppe zugehörig',
+    value: true,
+  },
+  {
+    label: 'Keiner Gruppe zugehörig',
+    value: false,
+  },
+]
+
 const ClusterFieldset = () => {
   const { filters, handleClusterChange } = useFilter()
-  const treeClusterOptions = [
-    {
-      label: 'Gruppe zugehörig',
-      value: true,
-    },
-    {
-      label: 'Keiner Gruppe zugehörig',
-      value: false,
-    },
-  ]
   return (
     <fieldset className="mt-4">
       <legend className="font-lato font-semibold text-dark-600 mb-2">

--- a/frontend/app/src/components/general/filter/fieldsets/PlantingYearFieldset.tsx
+++ b/frontend/app/src/components/general/filter/fieldsets/PlantingYearFieldset.tsx
@@ -1,6 +1,5 @@
 import { useFilter } from '@/context/FilterContext'
 import { Slider } from '@green-ecolution/ui'
-import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { plantingYearsQuery } from '@/api/queries'
 
@@ -8,30 +7,29 @@ const PlantingYearFieldset = () => {
   const { filters, handlePlantingYearRangeChange } = useFilter()
   const { data: availableYears, isLoading } = useQuery(plantingYearsQuery())
 
-  const { minYear, maxYear } = useMemo(() => {
-    if (!availableYears || availableYears.length === 0) {
-      const currentYear = new Date().getFullYear()
-      return { minYear: currentYear - 4, maxYear: currentYear }
-    }
-    return {
-      minYear: Math.min(...availableYears),
-      maxYear: Math.max(...availableYears),
-    }
-  }, [availableYears])
+  const yearBounds =
+    !availableYears || availableYears.length === 0
+      ? (() => {
+          const currentYear = new Date().getFullYear()
+          return { minYear: currentYear - 4, maxYear: currentYear }
+        })()
+      : {
+          minYear: Math.min(...availableYears),
+          maxYear: Math.max(...availableYears),
+        }
+  const { minYear, maxYear } = yearBounds
 
-  const range = useMemo(() => {
-    if (filters.plantingYears.length === 0) {
-      return [minYear, maxYear]
-    }
-    const sortedYears = [...filters.plantingYears].sort((a, b) => a - b)
-    return [sortedYears[0], sortedYears[sortedYears.length - 1]]
-  }, [filters.plantingYears, minYear, maxYear])
+  const sortedYears = filters.plantingYears.toSorted((a, b) => a - b)
+  const range =
+    filters.plantingYears.length === 0
+      ? [minYear, maxYear]
+      : [sortedYears[0], sortedYears[sortedYears.length - 1]]
 
   if (isLoading) {
     return (
       <fieldset className="mt-4">
         <legend className="font-lato font-semibold text-dark-600 mb-2">Pflanzjahr:</legend>
-        <p className="text-sm text-dark-400">Lädt...</p>
+        <p className="text-sm text-dark-400">Lädt…</p>
       </fieldset>
     )
   }

--- a/frontend/app/src/components/general/filter/fieldsets/StatusFieldset.tsx
+++ b/frontend/app/src/components/general/filter/fieldsets/StatusFieldset.tsx
@@ -20,7 +20,7 @@ const StatusFieldset = () => {
           onChange={handleStatusChange}
         >
           <div
-            className="w-4 h-4 rounded-full"
+            className="size-4 rounded-full"
             style={{ backgroundColor: getWateringStatusDetails(statusValue).colorHex }}
           />
         </Option>

--- a/frontend/app/src/components/general/form/FormForVehicle.tsx
+++ b/frontend/app/src/components/general/form/FormForVehicle.tsx
@@ -23,12 +23,12 @@ interface FormForVehicleProps {
   onSubmit: SubmitHandler<VehicleForm>
 }
 
+const translateNum = (e: React.ChangeEvent<HTMLInputElement>) =>
+  (e.target.value = e.target.value.replace(',', '.'))
+
 const FormForVehicle = (props: FormForVehicleProps) => {
   const { register, handleSubmit, control } = useFormContext<VehicleForm>()
   const { isValid, errors } = useFormState({ control })
-
-  const translateNum = (e: React.ChangeEvent<HTMLInputElement>) =>
-    (e.target.value = e.target.value.replace(',', '.'))
 
   return (
     <form

--- a/frontend/app/src/components/general/form/FormForWateringPlan.tsx
+++ b/frontend/app/src/components/general/form/FormForWateringPlan.tsx
@@ -34,6 +34,16 @@ interface FormForWateringPlanProps {
 const startOfToday = new Date()
 startOfToday.setHours(0, 0, 0, 0)
 
+const getDrivingLicensesString = (user: User) => {
+  if (!user.drivingLicenses || user.drivingLicenses.length === 0) {
+    return 'Keinen Führerschein'
+  }
+
+  return user.drivingLicenses
+    .map((drivingLicense: DrivingLicense) => getDrivingLicenseDetails(drivingLicense).label)
+    .join(', ')
+}
+
 const FormForWateringPlan = (props: FormForWateringPlanProps) => {
   const { register, handleSubmit, control } = useFormContext<WateringPlanForm>()
   const { isValid, errors } = useFormState({ control })
@@ -52,16 +62,6 @@ const FormForWateringPlan = (props: FormForWateringPlanProps) => {
     watchedTransporterId,
     watchedTrailerId,
   )
-
-  const getDrivingLicensesString = (user: User) => {
-    if (!user.drivingLicenses || user.drivingLicenses.length === 0) {
-      return 'Keinen Führerschein'
-    }
-
-    return user.drivingLicenses
-      .map((drivingLicense: DrivingLicense) => getDrivingLicenseDetails(drivingLicense).label)
-      .join(', ')
-  }
 
   return (
     <form

--- a/frontend/app/src/components/geolocation/NearestTreeMapPreview.tsx
+++ b/frontend/app/src/components/geolocation/NearestTreeMapPreview.tsx
@@ -5,7 +5,6 @@ import type { TreeWithDistance } from '@/api/backendApi'
 import { WateringStatus } from '@green-ecolution/backend-client'
 import { cn } from '@green-ecolution/ui'
 import L from 'leaflet'
-import { useMemo } from 'react'
 import { Circle, MapContainer, Marker, TileLayer } from 'react-leaflet'
 
 interface NearestTreeMapPreviewProps {
@@ -30,16 +29,14 @@ const NearestTreeMapPreview = ({
   const sensorPos = L.latLng(sensorLat, sensorLng)
   const radius = sensorAccuracy && sensorAccuracy > 0 ? sensorAccuracy : null
 
-  const bounds = useMemo(() => {
-    const points: L.LatLngExpression[] = [
-      [sensorLat, sensorLng],
-      ...trees.map((t) => [t.tree.latitude, t.tree.longitude] as L.LatLngTuple),
-    ]
-    if (points.length < 2) {
-      return L.latLngBounds([sensorPos, sensorPos]).pad(0.5)
-    }
-    return L.latLngBounds(points).pad(0.3)
-  }, [sensorLat, sensorLng, sensorPos, trees])
+  const points: L.LatLngExpression[] = [
+    [sensorLat, sensorLng],
+    ...trees.map((t) => [t.tree.latitude, t.tree.longitude] as L.LatLngTuple),
+  ]
+  const bounds =
+    points.length < 2
+      ? L.latLngBounds([sensorPos, sensorPos]).pad(0.5)
+      : L.latLngBounds(points).pad(0.3)
 
   return (
     <div

--- a/frontend/app/src/components/layout/Breadcrumb.tsx
+++ b/frontend/app/src/components/layout/Breadcrumb.tsx
@@ -9,13 +9,13 @@ import {
   BreadcrumbSeparator,
 } from '@green-ecolution/ui'
 
+const rootBreadcrumb = {
+  title: 'Dashboard',
+  path: '/dashboard',
+}
+
 function Breadcrumb() {
   const breadcrumbs = useBreadcrumbs()
-
-  const rootBreadcrumb = {
-    title: 'Dashboard',
-    path: '/dashboard',
-  }
 
   const isLastItem = (index: number) => index === breadcrumbs.length - 1
 

--- a/frontend/app/src/components/layout/EntityNotFound.tsx
+++ b/frontend/app/src/components/layout/EntityNotFound.tsx
@@ -38,7 +38,7 @@ function EntityNotFound({ entityName, backTo, backLabel }: EntityNotFoundProps) 
           <div className="mt-8">
             <Button asChild variant="outline" className="group gap-2 px-6">
               <Link to={backTo}>
-                <MoveLeft className="w-4 h-4 transition-transform group-hover:-translate-x-1" />
+                <MoveLeft className="size-4 transition-transform group-hover:-translate-x-1" />
                 {backLabel}
               </Link>
             </Button>

--- a/frontend/app/src/components/layout/ErrorFallback.tsx
+++ b/frontend/app/src/components/layout/ErrorFallback.tsx
@@ -1,6 +1,6 @@
 import Lottie from 'lottie-react'
 import cableAnimation from '../../animations/cableAnimation.json'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import ButtonLink from '../general/links/ButtonLink'
 import { MoveRight, RefreshCw } from 'lucide-react'
 import useStore from '@/store/store'
@@ -23,7 +23,7 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({ error, resetErrorBoundary
 
   const isAuthenticated = useStore((state) => state.isAuthenticated)
 
-  const checkResponseErrorMessage = useCallback(async () => {
+  const checkResponseErrorMessage = async () => {
     if (error instanceof ResponseError) {
       const json: unknown = await error.response.clone().json()
       if (isHTTPError(json)) {
@@ -32,7 +32,7 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({ error, resetErrorBoundary
         setErrorMessage('Unbekannter Fehler')
       }
     }
-  }, [error])
+  }
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- async data fetching pattern

--- a/frontend/app/src/components/layout/Footer.tsx
+++ b/frontend/app/src/components/layout/Footer.tsx
@@ -2,6 +2,21 @@ import { useLocation } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 import { infoQuery } from '@/api/queries'
 
+const navItems = [
+  {
+    url: 'mailto:info@green-ecolution.de',
+    label: 'Kontakt',
+  },
+  {
+    url: 'https://green-ecolution.de/impressum',
+    label: 'Impressum',
+  },
+  {
+    url: 'https://green-ecolution.de/datenschutz',
+    label: 'Datenschutz',
+  },
+]
+
 function Footer() {
   const location = useLocation()
   const isMapPage = location.pathname.includes('/map')
@@ -10,21 +25,6 @@ function Footer() {
   const version = appInfo?.version?.startsWith('v')
     ? appInfo.version
     : `v${appInfo?.version ?? 'unkown'}`
-
-  const navItems = [
-    {
-      url: 'mailto:info@green-ecolution.de',
-      label: 'Kontakt',
-    },
-    {
-      url: 'https://green-ecolution.de/impressum',
-      label: 'Impressum',
-    },
-    {
-      url: 'https://green-ecolution.de/datenschutz',
-      label: 'Datenschutz',
-    },
-  ]
 
   return (
     <footer className={`bg-white lg:pl-20 mt-16 ${isMapPage ? 'hidden' : ''}`}>

--- a/frontend/app/src/components/layout/Header.tsx
+++ b/frontend/app/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { AlignJustifyIcon } from 'lucide-react'
-import { useState, useCallback } from 'react'
+import { useState } from 'react'
 import Navigation from './Navigation'
 import Breadcrumb from './Breadcrumb'
 import ProfileButton from './ProfileButton'
@@ -11,21 +11,21 @@ function Header() {
   const isStartPage = location.pathname === '/'
   const isLargeScreen = useMediaQuery('(min-width: 1024px)')
 
-  const openSidebar = useCallback(() => {
+  const openSidebar = () => {
     setOpen(true)
     if (!isLargeScreen) {
       document.body.classList.add('overflow-y-hidden')
     }
-  }, [isLargeScreen])
+  }
 
-  const closeSidebar = useCallback(() => {
+  const closeSidebar = () => {
     setOpen(false)
     if (!isLargeScreen) {
       document.body.classList.remove('overflow-y-hidden')
     }
-  }, [isLargeScreen])
+  }
 
-  const toggleSidebar = useCallback(() => {
+  const toggleSidebar = () => {
     setOpen((prev) => {
       const next = !prev
       if (!isLargeScreen) {
@@ -33,7 +33,7 @@ function Header() {
       }
       return next
     })
-  }, [isLargeScreen])
+  }
 
   return (
     <header className="relative z-10 bg-white lg:pl-20">

--- a/frontend/app/src/components/layout/Navigation.tsx
+++ b/frontend/app/src/components/layout/Navigation.tsx
@@ -11,7 +11,6 @@ import {
   Users,
 } from 'lucide-react'
 import * as React from 'react'
-import { useCallback, useMemo } from 'react'
 import { LinkProps } from '@tanstack/react-router'
 import NavLink from '../navigation/NavLink'
 import NavHeadline from '../navigation/NavHeadline'
@@ -47,8 +46,102 @@ const publicNavData: NavSectionData[] = [
       {
         key: 'nav-login',
         label: 'Anmelden',
-        icon: <LogIn className="w-5 h-5" />,
+        icon: <LogIn className="size-5" />,
         to: '/login',
+        preload: false,
+      },
+    ],
+  },
+]
+
+const protectedNavData: NavSectionData[] = [
+  {
+    id: 1,
+    headline: 'Grünflächen',
+    links: [
+      {
+        key: 'nav-green-spaces-map',
+        label: 'Karte',
+        icon: <Map className="size-5" />,
+        to: '/map',
+        preload: false,
+      },
+      {
+        key: 'nav-green-spaces-clusters',
+        label: 'Bewässerungsgruppen',
+        icon: <FolderClosed className="size-5" />,
+        to: '/treecluster',
+      },
+      {
+        key: 'nav-green-spaces-trees',
+        label: 'Bäume',
+        icon: <Tree className="size-5" />,
+        to: '/trees',
+      },
+    ],
+  },
+  {
+    id: 2,
+    headline: 'Einsatzplanung',
+    links: [
+      {
+        key: 'nav-watering-plans',
+        label: 'Einsätze',
+        icon: <ArrowLeftRight className="size-5" />,
+        to: '/watering-plans',
+      },
+      {
+        key: 'nav-watering-plan-vehicle',
+        label: 'Fahrzeuge',
+        icon: <Car className="size-5" />,
+        to: '/vehicles',
+      },
+      {
+        key: 'nav-more-team',
+        label: 'Mitarbeitende',
+        icon: <Users className="size-5" />,
+        to: '/team',
+      },
+    ],
+  },
+  {
+    id: 3,
+    headline: 'Weiteres',
+    links: [
+      {
+        key: 'nav-more-sensor',
+        label: 'Sensoren',
+        icon: <SensorIcon className="size-5" />,
+        to: '/sensors',
+      },
+      {
+        key: 'nav-more-evaluation',
+        label: 'Auswertung',
+        icon: <PieChart className="size-5" />,
+        to: '/evaluations',
+      },
+      {
+        key: 'nav-more-settings',
+        label: 'Einstellungen',
+        icon: <Settings className="size-5" />,
+        to: '/settings',
+      },
+      // Hide the debug navigation entry in the production build
+      ...(process.env.NODE_ENV !== 'production'
+        ? [
+            {
+              key: 'nav-more-debug',
+              label: 'Debug',
+              icon: <Bug className="size-5" />,
+              to: '/debug',
+            } as NavLinkData,
+          ]
+        : []),
+      {
+        key: 'nav-more-logout',
+        label: 'Ausloggen',
+        icon: <LogOut className="size-5" />,
+        to: '/logout',
         preload: false,
       },
     ],
@@ -59,114 +152,17 @@ const Navigation: React.FC<NavigationProps> = ({ isOpen, openSidebar, closeSideb
   const isLargeScreen = useMediaQuery('(min-width: 1024px)')
   const isLoggedIn = useStore((state) => state.isAuthenticated)
 
-  const handleMouseOver = useCallback(() => {
+  const handleMouseOver = () => {
     if (isLargeScreen) openSidebar()
-  }, [isLargeScreen, openSidebar])
+  }
 
-  const handleMouseOut = useCallback(() => {
+  const handleMouseOut = () => {
     if (isLargeScreen) closeSidebar()
-  }, [isLargeScreen, closeSidebar])
+  }
 
-  const handleNavLinkClick = useCallback(() => {
+  const handleNavLinkClick = () => {
     if (!isLargeScreen) closeSidebar()
-  }, [isLargeScreen, closeSidebar])
-
-  const protectedNavData: NavSectionData[] = useMemo(
-    () => [
-      {
-        id: 1,
-        headline: 'Grünflächen',
-        links: [
-          {
-            key: 'nav-green-spaces-map',
-            label: 'Karte',
-            icon: <Map className="w-5 h-5" />,
-            to: '/map',
-            preload: false,
-          },
-          {
-            key: 'nav-green-spaces-clusters',
-            label: 'Bewässerungsgruppen',
-            icon: <FolderClosed className="w-5 h-5" />,
-            to: '/treecluster',
-          },
-          {
-            key: 'nav-green-spaces-trees',
-            label: 'Bäume',
-            icon: <Tree className="w-5 h-5" />,
-            to: '/trees',
-          },
-        ],
-      },
-      {
-        id: 2,
-        headline: 'Einsatzplanung',
-        links: [
-          {
-            key: 'nav-watering-plans',
-            label: 'Einsätze',
-            icon: <ArrowLeftRight className="w-5 h-5" />,
-            to: '/watering-plans',
-          },
-          {
-            key: 'nav-watering-plan-vehicle',
-            label: 'Fahrzeuge',
-            icon: <Car className="w-5 h-5" />,
-            to: '/vehicles',
-          },
-          {
-            key: 'nav-more-team',
-            label: 'Mitarbeitende',
-            icon: <Users className="w-5 h-5" />,
-            to: '/team',
-          },
-        ],
-      },
-      {
-        id: 3,
-        headline: 'Weiteres',
-        links: [
-          {
-            key: 'nav-more-sensor',
-            label: 'Sensoren',
-            icon: <SensorIcon className="w-5 h-5" />,
-            to: '/sensors',
-          },
-          {
-            key: 'nav-more-evaluation',
-            label: 'Auswertung',
-            icon: <PieChart className="w-5 h-5" />,
-            to: '/evaluations',
-          },
-          {
-            key: 'nav-more-settings',
-            label: 'Einstellungen',
-            icon: <Settings className="w-5 h-5" />,
-            to: '/settings',
-          },
-          // Hide the debug navigation entry in the production build
-          ...(process.env.NODE_ENV !== 'production'
-            ? [
-                {
-                  key: 'nav-more-debug',
-                  label: 'Debug',
-                  icon: <Bug className="w-5 h-5" />,
-                  to: '/debug',
-                } as NavLinkData,
-              ]
-            : []),
-          {
-            key: 'nav-more-logout',
-            label: 'Ausloggen',
-            icon: <LogOut className="w-5 h-5" />,
-            to: '/logout',
-            preload: false,
-          },
-        ],
-      },
-    ],
-    [],
-  )
+  }
 
   const navigationData = isLoggedIn ? protectedNavData : publicNavData
 

--- a/frontend/app/src/components/layout/ProfileButton.tsx
+++ b/frontend/app/src/components/layout/ProfileButton.tsx
@@ -23,7 +23,7 @@ function ProfileButton() {
     <NavLink
       key="nav-your-profile"
       label="Ihr Profil"
-      icon={<Settings className="w-5 h-5" />}
+      icon={<Settings className="size-5" />}
       to="/profile"
       navIsOpen={true}
       closeSidebar={() => toggleOverlay(false)}
@@ -31,7 +31,7 @@ function ProfileButton() {
     <NavLink
       key="nav-logout"
       label="Abmelden"
-      icon={<LogOut className="w-5 h-5" />}
+      icon={<LogOut className="size-5" />}
       to="/logout"
       preload={false}
       navIsOpen={true}
@@ -43,7 +43,7 @@ function ProfileButton() {
     <NavLink
       key="nav-header-login"
       label="Anmelden"
-      icon={<LogIn className="w-5 h-5" />}
+      icon={<LogIn className="size-5" />}
       to="/login"
       preload={false}
       navIsOpen={true}
@@ -66,11 +66,11 @@ function ProfileButton() {
       >
         <Avatar>
           <AvatarFallback variant={isAuthenticated ? 'user' : 'guest'}>
-            {isAuthenticated ? userInitials : <UserRound className="w-5 h-5 stroke-2" />}
+            {isAuthenticated ? userInitials : <UserRound className="size-5 stroke-2" />}
           </AvatarFallback>
         </Avatar>
         <ChevronDown
-          className={`w-5 h-5 text-dark transition-all ease-in-out duration-300 ${open ? 'rotate-180' : ''}`}
+          className={`size-5 text-dark transition-all ease-in-out duration-300 ${open ? 'rotate-180' : ''}`}
         />
       </button>
 

--- a/frontend/app/src/components/map/Map.tsx
+++ b/frontend/app/src/components/map/Map.tsx
@@ -1,5 +1,5 @@
 import { MapContainer, TileLayer } from 'react-leaflet'
-import React, { useMemo } from 'react'
+import React, { useRef } from 'react'
 import useStore from '@/store/store'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { mapInfoQuery } from '@/api/queries'
@@ -18,7 +18,9 @@ const Map = ({ width = '100%', height = 'calc(100dvh - 4.563rem)', children }: M
   const maxZoom = useStore((state) => state.mapMaxZoom)
   const minZoom = useStore((state) => state.mapMinZoom)
 
-  const time = useMemo(() => new Date().getTime(), [])
+  // Stable per-mount timestamp used as MapContainer key to force a fresh instance
+  // when the Map component is remounted. Captured once via useRef.
+  const time = useRef(new Date().getTime()).current
 
   return (
     <MapContainer

--- a/frontend/app/src/components/map/MapButtons.tsx
+++ b/frontend/app/src/components/map/MapButtons.tsx
@@ -40,7 +40,7 @@ const MapButtons = () => {
             className="group flex items-center gap-x-2 !text-green-dark font-medium text-base mb-4"
           >
             Neuen Baum manuell hinzufügen
-            <MoveRight className="w-4 h-4 transition-all ease-in-out duration-300 group-hover:translate-x-1" />
+            <MoveRight className="size-4 transition-all ease-in-out duration-300 group-hover:translate-x-1" />
           </Link>
         </DialogContent>
       </Dialog>

--- a/frontend/app/src/components/map/MapController.tsx
+++ b/frontend/app/src/components/map/MapController.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from '@tanstack/react-router'
 import { useMapEvents } from 'react-leaflet/hooks'
 import useStore from '@/store/store'
-import { useCallback, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 
 const DEBOUNCE_MS = 150
 
@@ -12,23 +12,20 @@ const MapController = () => {
 
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const scheduleUpdate = useCallback(
-    (lat: number, lng: number, zoom: number) => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-      }
-      timeoutRef.current = setTimeout(() => {
-        setCenter([lat, lng])
-        setZoom(zoom)
-        navigate({
-          to: '.',
-          search: (prev) => ({ ...prev, lat, lng, zoom }),
-          replace: true,
-        }).catch((error) => console.error('Navigation failed:', error))
-      }, DEBOUNCE_MS)
-    },
-    [navigate, setCenter, setZoom],
-  )
+  const scheduleUpdate = (lat: number, lng: number, zoom: number) => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+    }
+    timeoutRef.current = setTimeout(() => {
+      setCenter([lat, lng])
+      setZoom(zoom)
+      navigate({
+        to: '.',
+        search: (prev) => ({ ...prev, lat, lng, zoom }),
+        replace: true,
+      }).catch((error) => console.error('Navigation failed:', error))
+    }, DEBOUNCE_MS)
+  }
 
   useEffect(() => {
     return () => {

--- a/frontend/app/src/components/map/MapMarker.tsx
+++ b/frontend/app/src/components/map/MapMarker.tsx
@@ -2,7 +2,7 @@ import defaultIconPng from 'leaflet/dist/images/marker-icon.png'
 import L, { DivIcon, Icon, IconOptions } from 'leaflet'
 import { Marker } from 'react-leaflet'
 import { Marker as LeafletMarker } from 'leaflet'
-import { useMemo, useRef } from 'react'
+import { useRef } from 'react'
 
 const defaultIcon = new Icon({
   iconUrl: defaultIconPng,
@@ -38,23 +38,20 @@ interface DragableMarkerProps {
 
 export const DragableMarker = ({ position, onDrag, onMove }: DragableMarkerProps) => {
   const markerRef = useRef<LeafletMarker>(null)
-  const eventHandlers = useMemo(
-    () => ({
-      move() {
-        const marker = markerRef.current
-        if (marker != null) {
-          onMove?.(marker.getLatLng())
-        }
-      },
-      dragend() {
-        const marker = markerRef.current
-        if (marker != null) {
-          onDrag?.(marker.getLatLng())
-        }
-      },
-    }),
-    [onDrag, onMove],
-  )
+  const eventHandlers = {
+    move() {
+      const marker = markerRef.current
+      if (marker != null) {
+        onMove?.(marker.getLatLng())
+      }
+    },
+    dragend() {
+      const marker = markerRef.current
+      if (marker != null) {
+        onDrag?.(marker.getLatLng())
+      }
+    },
+  }
 
   return (
     <Marker

--- a/frontend/app/src/components/map/MapSelectEntitiesModal.tsx
+++ b/frontend/app/src/components/map/MapSelectEntitiesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, Ref, useCallback, useId } from 'react'
+import React, { useEffect, useState, Ref, useId } from 'react'
 import { Button } from '@green-ecolution/ui'
 import { MoveRight, X } from 'lucide-react'
 import useMapInteractions from '@/hooks/useMapInteractions'
@@ -33,14 +33,11 @@ const MapSelectEntitiesModal = ({
     returnFocusOnDeactivate: true,
   })
 
-  const handleEscapeKey = useCallback(
-    (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && openModal && !isLargeScreen) {
-        setOpenModal(false)
-      }
-    },
-    [openModal, isLargeScreen],
-  )
+  const handleEscapeKey = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && openModal && !isLargeScreen) {
+      setOpenModal(false)
+    }
+  }
 
   useEffect(() => {
     if (isLargeScreen) {

--- a/frontend/app/src/components/map/marker/MarkerList.tsx
+++ b/frontend/app/src/components/map/marker/MarkerList.tsx
@@ -1,5 +1,5 @@
 import L from 'leaflet'
-import { useCallback, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { useMap } from 'react-leaflet'
 
 interface WithLocation {
@@ -38,7 +38,7 @@ const MarkerList = <T extends WithLocation>({
     iconRef.current = icon
   })
 
-  const updateVisibleMarkers = useCallback(() => {
+  const updateVisibleMarkers = () => {
     if (!map) return
 
     const bounds = map.getBounds()
@@ -78,7 +78,7 @@ const MarkerList = <T extends WithLocation>({
         markerMap.set(id, { marker, data: item })
       }
     })
-  }, [map, getId, tooltipContent, tooltipOptions])
+  }
 
   useEffect(() => {
     dataRef.current = data

--- a/frontend/app/src/components/map/marker/WithAllClusters.tsx
+++ b/frontend/app/src/components/map/marker/WithAllClusters.tsx
@@ -4,7 +4,7 @@ import { clusterMarkersQuery } from '@/api/queries'
 import MarkerList from './MarkerList'
 import { ClusterIcon } from '../markerIcons'
 import { getStatusColor } from '../utils'
-import { memo, useCallback, useDeferredValue, useMemo } from 'react'
+import { useDeferredValue } from 'react'
 
 const defaultHighlighted: string[] = []
 const defaultDisabled: string[] = []
@@ -15,50 +15,45 @@ const tooltipOptions = {
   className: 'font-nunito-sans font-semibold',
 }
 
+const getId = (c: ClusterMarkerResponse) => c.id
+const getTooltip = (c: ClusterMarkerResponse) => c.name
+
 export interface WithAllClustersProps {
   onClick?: (cluster: ClusterMarkerResponse) => void
   highlightedClusters?: string[]
   disabledClusters?: string[]
 }
 
-const WithAllClusters = memo(
-  ({
-    onClick,
-    highlightedClusters = defaultHighlighted,
-    disabledClusters = defaultDisabled,
-  }: WithAllClustersProps) => {
-    const { data } = useSuspenseQuery(clusterMarkersQuery())
-    const deferredData = useDeferredValue(data.data)
+const WithAllClusters = ({
+  onClick,
+  highlightedClusters = defaultHighlighted,
+  disabledClusters = defaultDisabled,
+}: WithAllClustersProps) => {
+  const { data } = useSuspenseQuery(clusterMarkersQuery())
+  const deferredData = useDeferredValue(data.data)
 
-    const highlightedSet = useMemo(() => new Set(highlightedClusters), [highlightedClusters])
-    const disabledSet = useMemo(() => new Set(disabledClusters), [disabledClusters])
+  const highlightedSet = new Set(highlightedClusters)
+  const disabledSet = new Set(disabledClusters)
 
-    const getIcon = useCallback(
-      (c: ClusterMarkerResponse) =>
-        ClusterIcon(
-          getStatusColor(c.wateringStatus),
-          highlightedSet.has(c.id),
-          disabledSet.has(c.id),
-          c.treeCount,
-        ),
-      [highlightedSet, disabledSet],
+  const getIcon = (c: ClusterMarkerResponse) =>
+    ClusterIcon(
+      getStatusColor(c.wateringStatus),
+      highlightedSet.has(c.id),
+      disabledSet.has(c.id),
+      c.treeCount,
     )
 
-    const getId = useCallback((c: ClusterMarkerResponse) => c.id, [])
-    const getTooltip = useCallback((c: ClusterMarkerResponse) => c.name, [])
-
-    return (
-      <MarkerList
-        data={deferredData}
-        onClick={onClick}
-        icon={getIcon}
-        getId={getId}
-        tooltipContent={getTooltip}
-        tooltipOptions={tooltipOptions}
-      />
-    )
-  },
-)
+  return (
+    <MarkerList
+      data={deferredData}
+      onClick={onClick}
+      icon={getIcon}
+      getId={getId}
+      tooltipContent={getTooltip}
+      tooltipOptions={tooltipOptions}
+    />
+  )
+}
 
 WithAllClusters.displayName = 'WithAllClusters'
 

--- a/frontend/app/src/components/map/marker/WithAllTrees.tsx
+++ b/frontend/app/src/components/map/marker/WithAllTrees.tsx
@@ -5,7 +5,7 @@ import { useViewportBBox } from '@/hooks/useViewportBBox'
 import { TreeMarkerIcon } from '../markerIcons'
 import MarkerList from './MarkerList'
 import { getStatusColor } from '../utils'
-import { memo, useCallback, useDeferredValue, useMemo } from 'react'
+import { useDeferredValue } from 'react'
 
 const defaultSelectedTrees: string[] = []
 const emptyMarkers: TreeMarkerResponse[] = []
@@ -16,51 +16,50 @@ const tooltipOptions = {
   className: 'font-nunito-sans font-semibold',
 }
 
+const getId = (t: TreeMarkerResponse) => t.id
+const getTooltip = (t: TreeMarkerResponse) => t.number
+
 export interface WithAllTreesProps {
   onClick?: (tree: TreeMarkerResponse) => void
   selectedTrees?: string[]
   hasHighlightedTree?: string
 }
 
-const WithAllTrees = memo(
-  ({ onClick, selectedTrees = defaultSelectedTrees, hasHighlightedTree }: WithAllTreesProps) => {
-    const bbox = useViewportBBox()
-    const { data } = useQuery({
-      ...treeMarkersQuery({ bbox: bbox ?? { swLat: 0, swLng: 0, neLat: 0.0001, neLng: 0.0001 } }),
-      // enabled: bbox !== null prevents firing requests before the map ref is ready
-      enabled: bbox !== null,
-    })
+const WithAllTrees = ({
+  onClick,
+  selectedTrees = defaultSelectedTrees,
+  hasHighlightedTree,
+}: WithAllTreesProps) => {
+  const bbox = useViewportBBox()
+  const { data } = useQuery({
+    ...treeMarkersQuery({ bbox: bbox ?? { swLat: 0, swLng: 0, neLat: 0.0001, neLng: 0.0001 } }),
+    // enabled: bbox !== null prevents firing requests before the map ref is ready
+    enabled: bbox !== null,
+  })
 
-    const deferredData = useDeferredValue(data?.data ?? emptyMarkers)
+  const deferredData = useDeferredValue(data?.data ?? emptyMarkers)
 
-    const selectedSet = useMemo(() => new Set(selectedTrees), [selectedTrees])
+  const selectedSet = new Set(selectedTrees)
 
-    const getIcon = useCallback(
-      (t: TreeMarkerResponse) =>
-        TreeMarkerIcon(
-          getStatusColor(t.wateringStatus),
-          selectedSet.has(t.id),
-          hasHighlightedTree === t.id,
-          false,
-        ),
-      [selectedSet, hasHighlightedTree],
+  const getIcon = (t: TreeMarkerResponse) =>
+    TreeMarkerIcon(
+      getStatusColor(t.wateringStatus),
+      selectedSet.has(t.id),
+      hasHighlightedTree === t.id,
+      false,
     )
 
-    const getId = useCallback((t: TreeMarkerResponse) => t.id, [])
-    const getTooltip = useCallback((t: TreeMarkerResponse) => t.number, [])
-
-    return (
-      <MarkerList
-        data={deferredData}
-        onClick={onClick}
-        icon={getIcon}
-        getId={getId}
-        tooltipContent={getTooltip}
-        tooltipOptions={tooltipOptions}
-      />
-    )
-  },
-)
+  return (
+    <MarkerList
+      data={deferredData}
+      onClick={onClick}
+      icon={getIcon}
+      getId={getId}
+      tooltipContent={getTooltip}
+      tooltipOptions={tooltipOptions}
+    />
+  )
+}
 
 WithAllTrees.displayName = 'WithAllTrees'
 

--- a/frontend/app/src/components/map/marker/WithFilterableClusters.tsx
+++ b/frontend/app/src/components/map/marker/WithFilterableClusters.tsx
@@ -1,5 +1,5 @@
 import type { TreeClusterInList } from '@/api/backendApi'
-import { memo, useCallback, useDeferredValue, useMemo, useState } from 'react'
+import { useDeferredValue, useState } from 'react'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { treeClusterQuery } from '@/api/queries'
 import FilterProvider, { useFilter, Filters } from '@/context/FilterContext'
@@ -28,6 +28,9 @@ const tooltipOptions = {
   className: 'font-nunito-sans font-semibold',
 }
 
+const getId = (c: TreeClusterInList) => c.id
+const getTooltip = (c: TreeClusterInList) => c.name
+
 export interface WithFilterableClustersProps {
   onClick?: (cluster: TreeClusterInList) => void
   highlightedClusters?: string[]
@@ -43,183 +46,162 @@ interface FilterableClustersContentProps extends WithFilterableClustersProps {
   appliedFilters: AppliedFilters
 }
 
-const FilterableClustersContent = memo(
-  ({
-    onClick,
-    highlightedClusters = defaultHighlighted,
-    disabledClusters = defaultDisabled,
-    appliedFilters,
-  }: FilterableClustersContentProps) => {
-    const hasActiveFilter = useMemo(
-      () =>
-        (appliedFilters.wateringStatuses?.length ?? 0) > 0 ||
-        (appliedFilters.regions?.length ?? 0) > 0,
-      [appliedFilters.wateringStatuses, appliedFilters.regions],
+const FilterableClustersContent = ({
+  onClick,
+  highlightedClusters = defaultHighlighted,
+  disabledClusters = defaultDisabled,
+  appliedFilters,
+}: FilterableClustersContentProps) => {
+  const hasActiveFilter =
+    (appliedFilters.wateringStatuses?.length ?? 0) > 0 || (appliedFilters.regions?.length ?? 0) > 0
+
+  // TODO: wateringStatuses and regions filter params are not yet supported in the new API
+  const { data } = useSuspenseQuery(treeClusterQuery(hasActiveFilter ? {} : undefined))
+
+  const filteredData = data.data.filter(
+    (cluster) =>
+      cluster.latitude !== null && cluster.longitude !== null && cluster.treeIds !== undefined,
+  )
+  const deferredData = useDeferredValue(filteredData)
+
+  const highlightedSet = new Set(highlightedClusters)
+  const disabledSet = new Set(disabledClusters)
+
+  const getIcon = (c: TreeClusterInList) =>
+    ClusterIcon(
+      getStatusColor(c.wateringStatus),
+      highlightedSet.has(c.id),
+      disabledSet.has(c.id),
+      c.treeIds?.length ?? 0,
     )
 
-    // TODO: wateringStatuses and regions filter params are not yet supported in the new API
-    const { data } = useSuspenseQuery(treeClusterQuery(hasActiveFilter ? {} : undefined))
-
-    const filteredData = useMemo(
-      () =>
-        data.data.filter(
-          (cluster) =>
-            cluster.latitude !== null &&
-            cluster.longitude !== null &&
-            cluster.treeIds !== undefined,
-        ),
-      [data.data],
-    )
-    const deferredData = useDeferredValue(filteredData)
-
-    const highlightedSet = useMemo(() => new Set(highlightedClusters), [highlightedClusters])
-    const disabledSet = useMemo(() => new Set(disabledClusters), [disabledClusters])
-
-    const getIcon = useCallback(
-      (c: TreeClusterInList) =>
-        ClusterIcon(
-          getStatusColor(c.wateringStatus),
-          highlightedSet.has(c.id),
-          disabledSet.has(c.id),
-          c.treeIds?.length ?? 0,
-        ),
-      [highlightedSet, disabledSet],
-    )
-
-    const getId = useCallback((c: TreeClusterInList) => c.id, [])
-    const getTooltip = useCallback((c: TreeClusterInList) => c.name, [])
-
-    return (
-      <MarkerList
-        data={deferredData}
-        onClick={onClick}
-        icon={getIcon}
-        getId={getId}
-        tooltipContent={getTooltip}
-        tooltipOptions={tooltipOptions}
-      />
-    )
-  },
-)
+  return (
+    <MarkerList
+      data={deferredData}
+      onClick={onClick}
+      icon={getIcon}
+      getId={getId}
+      tooltipContent={getTooltip}
+      tooltipOptions={tooltipOptions}
+    />
+  )
+}
 
 FilterableClustersContent.displayName = 'FilterableClustersContent'
 
-const FilterableClustersInner = memo(
-  ({ onClick, highlightedClusters, disabledClusters }: WithFilterableClustersProps) => {
-    const { enableDragging, disableDragging } = useMapInteractions()
-    const { filters, resetFilters, applyOldStateToTags } = useFilter()
-    const [isOpen, setIsOpen] = useState(false)
-    const [oldValues, setOldValues] = useState<Filters>({
+const FilterableClustersInner = ({
+  onClick,
+  highlightedClusters,
+  disabledClusters,
+}: WithFilterableClustersProps) => {
+  const { enableDragging, disableDragging } = useMapInteractions()
+  const { filters, resetFilters, applyOldStateToTags } = useFilter()
+  const [isOpen, setIsOpen] = useState(false)
+  const [oldValues, setOldValues] = useState<Filters>({
+    statusTags: [],
+    regionTags: [],
+    hasCluster: undefined,
+    plantingYears: [],
+  })
+  const [appliedFilters, setAppliedFilters] = useState<AppliedFilters>({})
+
+  const handleMapInteractions = (isOpen: boolean) => {
+    if (isOpen) {
+      disableDragging()
+    } else {
+      enableDragging()
+    }
+  }
+
+  const handleOpen = () => {
+    setOldValues(filters)
+    setIsOpen(true)
+    handleMapInteractions(true)
+  }
+
+  const handleClose = () => {
+    setIsOpen(false)
+    applyOldStateToTags(oldValues)
+    handleMapInteractions(false)
+  }
+
+  const handleSubmit = () => {
+    setAppliedFilters({
+      wateringStatuses: filters.statusTags.length > 0 ? filters.statusTags : undefined,
+      regions: filters.regionTags.length > 0 ? filters.regionTags : undefined,
+    })
+    setIsOpen(false)
+    handleMapInteractions(false)
+  }
+
+  const handleReset = () => {
+    applyOldStateToTags({
       statusTags: [],
       regionTags: [],
       hasCluster: undefined,
       plantingYears: [],
     })
-    const [appliedFilters, setAppliedFilters] = useState<AppliedFilters>({})
+    resetFilters()
+    setAppliedFilters({})
+    setIsOpen(false)
+    handleMapInteractions(false)
+  }
 
-    const handleMapInteractions = useCallback(
-      (isOpen: boolean) => {
-        if (isOpen) {
-          disableDragging()
-        } else {
-          enableDragging()
-        }
-      },
-      [disableDragging, enableDragging],
-    )
+  const filterCount =
+    (appliedFilters.wateringStatuses?.length ?? 0) + (appliedFilters.regions?.length ?? 0)
 
-    const handleOpen = useCallback(() => {
-      setOldValues(filters)
-      setIsOpen(true)
-      handleMapInteractions(true)
-    }, [filters, handleMapInteractions])
+  return (
+    <>
+      <div className="absolute top-6 left-4 z-[1000]">
+        <div className="font-nunito-sans text-base">
+          <FilterButton
+            activeCount={filterCount}
+            ariaLabel="Bewässerungsgruppen filtern"
+            isOnMap
+            onClick={() => (isOpen ? handleClose() : handleOpen())}
+          />
 
-    const handleClose = useCallback(() => {
-      setIsOpen(false)
-      applyOldStateToTags(oldValues)
-      handleMapInteractions(false)
-    }, [applyOldStateToTags, oldValues, handleMapInteractions])
+          <DialogRoot open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+            <DialogContent className="max-h-[80dvh] overflow-y-auto">
+              <DialogHeader>
+                <DialogTitle>Bewässerungsgruppen filtern</DialogTitle>
+              </DialogHeader>
+              <StatusFieldset />
+              <RegionFieldset />
 
-    const handleSubmit = useCallback(() => {
-      setAppliedFilters({
-        wateringStatuses: filters.statusTags.length > 0 ? filters.statusTags : undefined,
-        regions: filters.regionTags.length > 0 ? filters.regionTags : undefined,
-      })
-      setIsOpen(false)
-      handleMapInteractions(false)
-    }, [filters, handleMapInteractions])
-
-    const handleReset = useCallback(() => {
-      applyOldStateToTags({
-        statusTags: [],
-        regionTags: [],
-        hasCluster: undefined,
-        plantingYears: [],
-      })
-      resetFilters()
-      setAppliedFilters({})
-      setIsOpen(false)
-      handleMapInteractions(false)
-    }, [applyOldStateToTags, resetFilters, handleMapInteractions])
-
-    const filterCount = useMemo(
-      () => (appliedFilters.wateringStatuses?.length ?? 0) + (appliedFilters.regions?.length ?? 0),
-      [appliedFilters],
-    )
-
-    return (
-      <>
-        <div className="absolute top-6 left-4 z-[1000]">
-          <div className="font-nunito-sans text-base">
-            <FilterButton
-              activeCount={filterCount}
-              ariaLabel="Bewässerungsgruppen filtern"
-              isOnMap
-              onClick={() => (isOpen ? handleClose() : handleOpen())}
-            />
-
-            <DialogRoot open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-              <DialogContent className="max-h-[80dvh] overflow-y-auto">
-                <DialogHeader>
-                  <DialogTitle>Bewässerungsgruppen filtern</DialogTitle>
-                </DialogHeader>
-                <StatusFieldset />
-                <RegionFieldset />
-
-                <div className="flex flex-wrap gap-5 mt-6">
-                  <Button type="button" onClick={handleSubmit}>
-                    Anwenden
-                    <MoveRight className="icon-arrow-animate" />
-                  </Button>
-                  <Button variant="outline" onClick={handleReset}>
-                    Zurücksetzen
-                    <X />
-                  </Button>
-                </div>
-              </DialogContent>
-            </DialogRoot>
-          </div>
+              <div className="flex flex-wrap gap-5 mt-6">
+                <Button type="button" onClick={handleSubmit}>
+                  Anwenden
+                  <MoveRight className="icon-arrow-animate" />
+                </Button>
+                <Button variant="outline" onClick={handleReset}>
+                  Zurücksetzen
+                  <X />
+                </Button>
+              </div>
+            </DialogContent>
+          </DialogRoot>
         </div>
-        <FilterableClustersContent
-          onClick={onClick}
-          highlightedClusters={highlightedClusters}
-          disabledClusters={disabledClusters}
-          appliedFilters={appliedFilters}
-        />
-      </>
-    )
-  },
-)
+      </div>
+      <FilterableClustersContent
+        onClick={onClick}
+        highlightedClusters={highlightedClusters}
+        disabledClusters={disabledClusters}
+        appliedFilters={appliedFilters}
+      />
+    </>
+  )
+}
 
 FilterableClustersInner.displayName = 'FilterableClustersInner'
 
-const WithFilterableClusters = memo((props: WithFilterableClustersProps) => {
+const WithFilterableClusters = (props: WithFilterableClustersProps) => {
   return (
     <FilterProvider>
       <FilterableClustersInner {...props} />
     </FilterProvider>
   )
-})
+}
 
 WithFilterableClusters.displayName = 'WithFilterableClusters'
 

--- a/frontend/app/src/components/map/marker/WithFilterableTrees.tsx
+++ b/frontend/app/src/components/map/marker/WithFilterableTrees.tsx
@@ -1,5 +1,5 @@
 import type { WateringStatus, TreeMarkerResponse } from '@/api/backendApi'
-import { memo, useCallback, useMemo, useState } from 'react'
+import { useState } from 'react'
 import FilterProvider, { useFilter, Filters } from '@/context/FilterContext'
 import FilterButton from '@/components/general/buttons/FilterButton'
 import StatusFieldset from '@/components/general/filter/fieldsets/StatusFieldset'
@@ -33,163 +33,159 @@ interface FilterableTreesContentProps extends WithFilterableTreesProps {
   appliedFilters: AppliedFilters
 }
 
-const FilterableTreesContent = memo(
-  ({ onClick, selectedTrees, hasHighlightedTree, appliedFilters }: FilterableTreesContentProps) => {
-    const hasActiveFilter = useMemo(
-      () =>
-        (appliedFilters.wateringStatuses?.length ?? 0) > 0 ||
-        appliedFilters.hasCluster !== undefined ||
-        (appliedFilters.plantingYears?.length ?? 0) > 0,
-      [appliedFilters.wateringStatuses, appliedFilters.hasCluster, appliedFilters.plantingYears],
-    )
+const FilterableTreesContent = ({
+  onClick,
+  selectedTrees,
+  hasHighlightedTree,
+  appliedFilters,
+}: FilterableTreesContentProps) => {
+  const hasActiveFilter =
+    (appliedFilters.wateringStatuses?.length ?? 0) > 0 ||
+    appliedFilters.hasCluster !== undefined ||
+    (appliedFilters.plantingYears?.length ?? 0) > 0
 
-    if (hasActiveFilter) {
-      return (
-        <WithFilterdTrees
-          onClick={onClick}
-          selectedTrees={selectedTrees}
-          hasHighlightedTree={hasHighlightedTree}
-          hasCluster={appliedFilters.hasCluster}
-          plantingYears={appliedFilters.plantingYears}
-          wateringStatuses={appliedFilters.wateringStatuses}
-        />
-      )
-    }
-
+  if (hasActiveFilter) {
     return (
-      <WithAllTrees
+      <WithFilterdTrees
         onClick={onClick}
         selectedTrees={selectedTrees}
         hasHighlightedTree={hasHighlightedTree}
+        hasCluster={appliedFilters.hasCluster}
+        plantingYears={appliedFilters.plantingYears}
+        wateringStatuses={appliedFilters.wateringStatuses}
       />
     )
-  },
-)
+  }
+
+  return (
+    <WithAllTrees
+      onClick={onClick}
+      selectedTrees={selectedTrees}
+      hasHighlightedTree={hasHighlightedTree}
+    />
+  )
+}
 
 FilterableTreesContent.displayName = 'FilterableTreesContent'
 
-const FilterableTreesInner = memo(
-  ({ onClick, selectedTrees, hasHighlightedTree }: WithFilterableTreesProps) => {
-    const { enableDragging, disableDragging } = useMapInteractions()
-    const { filters, resetFilters, applyOldStateToTags } = useFilter()
-    const [isOpen, setIsOpen] = useState(false)
-    const [oldValues, setOldValues] = useState<Filters>({
+const FilterableTreesInner = ({
+  onClick,
+  selectedTrees,
+  hasHighlightedTree,
+}: WithFilterableTreesProps) => {
+  const { enableDragging, disableDragging } = useMapInteractions()
+  const { filters, resetFilters, applyOldStateToTags } = useFilter()
+  const [isOpen, setIsOpen] = useState(false)
+  const [oldValues, setOldValues] = useState<Filters>({
+    statusTags: [],
+    regionTags: [],
+    hasCluster: undefined,
+    plantingYears: [],
+  })
+  const [appliedFilters, setAppliedFilters] = useState<AppliedFilters>({})
+
+  const handleMapInteractions = (isOpen: boolean) => {
+    if (isOpen) {
+      disableDragging()
+    } else {
+      enableDragging()
+    }
+  }
+
+  const handleOpen = () => {
+    setOldValues(filters)
+    setIsOpen(true)
+    handleMapInteractions(true)
+  }
+
+  const handleClose = () => {
+    setIsOpen(false)
+    applyOldStateToTags(oldValues)
+    handleMapInteractions(false)
+  }
+
+  const handleSubmit = () => {
+    setAppliedFilters({
+      wateringStatuses:
+        filters.statusTags.length > 0 ? (filters.statusTags as WateringStatus[]) : undefined,
+      hasCluster: filters.hasCluster,
+      plantingYears: filters.plantingYears.length > 0 ? filters.plantingYears : undefined,
+    })
+    setIsOpen(false)
+    handleMapInteractions(false)
+  }
+
+  const handleReset = () => {
+    applyOldStateToTags({
       statusTags: [],
       regionTags: [],
       hasCluster: undefined,
       plantingYears: [],
     })
-    const [appliedFilters, setAppliedFilters] = useState<AppliedFilters>({})
+    resetFilters()
+    setAppliedFilters({})
+    setIsOpen(false)
+    handleMapInteractions(false)
+  }
 
-    const handleMapInteractions = useCallback(
-      (isOpen: boolean) => {
-        if (isOpen) {
-          disableDragging()
-        } else {
-          enableDragging()
-        }
-      },
-      [disableDragging, enableDragging],
-    )
+  const filterCount =
+    (appliedFilters.wateringStatuses?.length ?? 0) +
+    (appliedFilters.hasCluster !== undefined ? 1 : 0) +
+    (appliedFilters.plantingYears?.length ?? 0)
 
-    const handleOpen = useCallback(() => {
-      setOldValues(filters)
-      setIsOpen(true)
-      handleMapInteractions(true)
-    }, [filters, handleMapInteractions])
+  return (
+    <>
+      <div className="absolute top-6 left-4 z-[1000]">
+        <div className="font-nunito-sans text-base">
+          <FilterButton
+            activeCount={filterCount}
+            ariaLabel="Bäume filtern"
+            isOnMap
+            onClick={() => (isOpen ? handleClose() : handleOpen())}
+          />
 
-    const handleClose = useCallback(() => {
-      setIsOpen(false)
-      applyOldStateToTags(oldValues)
-      handleMapInteractions(false)
-    }, [applyOldStateToTags, oldValues, handleMapInteractions])
+          <DialogRoot open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+            <DialogContent className="max-h-[80dvh] overflow-y-auto">
+              <DialogHeader>
+                <DialogTitle>Bäume filtern</DialogTitle>
+              </DialogHeader>
+              <StatusFieldset />
+              <ClusterFieldset />
+              <PlantingYearFieldset />
 
-    const handleSubmit = useCallback(() => {
-      setAppliedFilters({
-        wateringStatuses:
-          filters.statusTags.length > 0 ? (filters.statusTags as WateringStatus[]) : undefined,
-        hasCluster: filters.hasCluster,
-        plantingYears: filters.plantingYears.length > 0 ? filters.plantingYears : undefined,
-      })
-      setIsOpen(false)
-      handleMapInteractions(false)
-    }, [filters, handleMapInteractions])
-
-    const handleReset = useCallback(() => {
-      applyOldStateToTags({
-        statusTags: [],
-        regionTags: [],
-        hasCluster: undefined,
-        plantingYears: [],
-      })
-      resetFilters()
-      setAppliedFilters({})
-      setIsOpen(false)
-      handleMapInteractions(false)
-    }, [applyOldStateToTags, resetFilters, handleMapInteractions])
-
-    const filterCount = useMemo(
-      () =>
-        (appliedFilters.wateringStatuses?.length ?? 0) +
-        (appliedFilters.hasCluster !== undefined ? 1 : 0) +
-        (appliedFilters.plantingYears?.length ?? 0),
-      [appliedFilters],
-    )
-
-    return (
-      <>
-        <div className="absolute top-6 left-4 z-[1000]">
-          <div className="font-nunito-sans text-base">
-            <FilterButton
-              activeCount={filterCount}
-              ariaLabel="Bäume filtern"
-              isOnMap
-              onClick={() => (isOpen ? handleClose() : handleOpen())}
-            />
-
-            <DialogRoot open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-              <DialogContent className="max-h-[80dvh] overflow-y-auto">
-                <DialogHeader>
-                  <DialogTitle>Bäume filtern</DialogTitle>
-                </DialogHeader>
-                <StatusFieldset />
-                <ClusterFieldset />
-                <PlantingYearFieldset />
-
-                <div className="flex flex-wrap gap-5 mt-6">
-                  <Button type="button" onClick={handleSubmit}>
-                    Anwenden
-                    <MoveRight className="icon-arrow-animate" />
-                  </Button>
-                  <Button variant="outline" onClick={handleReset}>
-                    Zurücksetzen
-                    <X />
-                  </Button>
-                </div>
-              </DialogContent>
-            </DialogRoot>
-          </div>
+              <div className="flex flex-wrap gap-5 mt-6">
+                <Button type="button" onClick={handleSubmit}>
+                  Anwenden
+                  <MoveRight className="icon-arrow-animate" />
+                </Button>
+                <Button variant="outline" onClick={handleReset}>
+                  Zurücksetzen
+                  <X />
+                </Button>
+              </div>
+            </DialogContent>
+          </DialogRoot>
         </div>
-        <FilterableTreesContent
-          onClick={onClick}
-          selectedTrees={selectedTrees}
-          hasHighlightedTree={hasHighlightedTree}
-          appliedFilters={appliedFilters}
-        />
-      </>
-    )
-  },
-)
+      </div>
+      <FilterableTreesContent
+        onClick={onClick}
+        selectedTrees={selectedTrees}
+        hasHighlightedTree={hasHighlightedTree}
+        appliedFilters={appliedFilters}
+      />
+    </>
+  )
+}
 
 FilterableTreesInner.displayName = 'FilterableTreesInner'
 
-const WithFilterableTrees = memo((props: WithFilterableTreesProps) => {
+const WithFilterableTrees = (props: WithFilterableTreesProps) => {
   return (
     <FilterProvider>
       <FilterableTreesInner {...props} />
     </FilterProvider>
   )
-})
+}
 
 WithFilterableTrees.displayName = 'WithFilterableTrees'
 

--- a/frontend/app/src/components/map/marker/WithFilterdTrees.tsx
+++ b/frontend/app/src/components/map/marker/WithFilterdTrees.tsx
@@ -5,7 +5,7 @@ import { useViewportBBox } from '@/hooks/useViewportBBox'
 import { TreeMarkerIcon } from '../markerIcons'
 import MarkerList from './MarkerList'
 import { getStatusColor } from '../utils'
-import { memo, useCallback, useDeferredValue, useMemo } from 'react'
+import { useDeferredValue } from 'react'
 
 const defaultSelectedTrees: string[] = []
 const emptyMarkers: TreeMarkerResponse[] = []
@@ -16,6 +16,9 @@ const tooltipOptions = {
   className: 'font-nunito-sans font-semibold',
 }
 
+const getId = (t: TreeMarkerResponse) => t.id
+const getTooltip = (t: TreeMarkerResponse) => t.number
+
 export interface WithFilterdTreesProps {
   onClick?: (tree: TreeMarkerResponse) => void
   selectedTrees?: string[]
@@ -25,55 +28,47 @@ export interface WithFilterdTreesProps {
   wateringStatuses?: WateringStatus[]
 }
 
-const WithFilterdTrees = memo(
-  ({
-    onClick,
-    selectedTrees = defaultSelectedTrees,
-    hasHighlightedTree,
-    hasCluster,
-    plantingYears,
-    wateringStatuses,
-  }: WithFilterdTreesProps) => {
-    const bbox = useViewportBBox()
-    const { data } = useQuery({
-      ...treeMarkersQuery({
-        bbox: bbox ?? { swLat: 0, swLng: 0, neLat: 0.0001, neLng: 0.0001 },
-        hasCluster,
-        plantingYears,
-        wateringStatuses,
-      }),
-      enabled: bbox !== null,
-    })
-    const deferredData = useDeferredValue(data?.data ?? emptyMarkers)
+const WithFilterdTrees = ({
+  onClick,
+  selectedTrees = defaultSelectedTrees,
+  hasHighlightedTree,
+  hasCluster,
+  plantingYears,
+  wateringStatuses,
+}: WithFilterdTreesProps) => {
+  const bbox = useViewportBBox()
+  const { data } = useQuery({
+    ...treeMarkersQuery({
+      bbox: bbox ?? { swLat: 0, swLng: 0, neLat: 0.0001, neLng: 0.0001 },
+      hasCluster,
+      plantingYears,
+      wateringStatuses,
+    }),
+    enabled: bbox !== null,
+  })
+  const deferredData = useDeferredValue(data?.data ?? emptyMarkers)
 
-    const selectedSet = useMemo(() => new Set(selectedTrees), [selectedTrees])
+  const selectedSet = new Set(selectedTrees)
 
-    const getIcon = useCallback(
-      (t: TreeMarkerResponse) =>
-        TreeMarkerIcon(
-          getStatusColor(t.wateringStatus),
-          selectedSet.has(t.id),
-          hasHighlightedTree === t.id,
-          false,
-        ),
-      [selectedSet, hasHighlightedTree],
+  const getIcon = (t: TreeMarkerResponse) =>
+    TreeMarkerIcon(
+      getStatusColor(t.wateringStatus),
+      selectedSet.has(t.id),
+      hasHighlightedTree === t.id,
+      false,
     )
 
-    const getId = useCallback((t: TreeMarkerResponse) => t.id, [])
-    const getTooltip = useCallback((t: TreeMarkerResponse) => t.number, [])
-
-    return (
-      <MarkerList
-        data={deferredData}
-        onClick={onClick}
-        icon={getIcon}
-        getId={getId}
-        tooltipContent={getTooltip}
-        tooltipOptions={tooltipOptions}
-      />
-    )
-  },
-)
+  return (
+    <MarkerList
+      data={deferredData}
+      onClick={onClick}
+      icon={getIcon}
+      getId={getId}
+      tooltipContent={getTooltip}
+      tooltipOptions={tooltipOptions}
+    />
+  )
+}
 
 WithFilterdTrees.displayName = 'WithFilterdTrees'
 

--- a/frontend/app/src/components/map/markerSvgCache.tsx
+++ b/frontend/app/src/components/map/markerSvgCache.tsx
@@ -4,16 +4,12 @@ import TreeIcon from '../icons/Tree'
 import SensorIcon from '../icons/Sensor'
 
 export const SVG_CACHE = {
-  tree: renderToStaticMarkup(
-    <TreeIcon className="text-white w-[1.125rem] h-[1.125rem]" strokeWidth={3} />,
-  ),
-  check: renderToStaticMarkup(
-    <Check className="text-white w-[1.125rem] h-[1.125rem]" strokeWidth={3} />,
-  ),
+  tree: renderToStaticMarkup(<TreeIcon className="text-white size-[1.125rem]" strokeWidth={3} />),
+  check: renderToStaticMarkup(<Check className="text-white size-[1.125rem]" strokeWidth={3} />),
   sensor: renderToStaticMarkup(
-    <SensorIcon className="text-white w-[1.125rem] h-[1.125rem]" strokeWidth={3} />,
+    <SensorIcon className="text-white size-[1.125rem]" strokeWidth={3} />,
   ),
   paintBucket: renderToStaticMarkup(
-    <PaintBucket className="text-white w-[1.125rem] h-[1.125rem]" strokeWidth={3} />,
+    <PaintBucket className="text-white size-[1.125rem]" strokeWidth={3} />,
   ),
 }

--- a/frontend/app/src/components/sensor/detail/SensorLorawanConfigSection.tsx
+++ b/frontend/app/src/components/sensor/detail/SensorLorawanConfigSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Alert,
   AlertContent,
@@ -107,23 +107,19 @@ const SensorLorawanConfigSection = ({ sensor }: SensorLorawanConfigSectionProps)
   const [expanded, setExpanded] = useState(false)
   const [query, setQuery] = useState('')
 
-  const entries = useMemo(() => {
-    if (!config) return []
-    return Object.entries(config).sort(([a], [b]) => a.localeCompare(b))
-  }, [config])
+  const entries = !config ? [] : Object.entries(config).sort(([a], [b]) => a.localeCompare(b))
 
-  const hasSecrets = useMemo(() => entries.some(([k]) => isSensitiveConfigKey(k)), [entries])
+  const hasSecrets = entries.some(([k]) => isSensitiveConfigKey(k))
 
-  const filtered = useMemo(() => {
-    if (!query.trim()) return entries
-    const q = query.toLowerCase()
-    return entries.filter(
-      ([k, v]) =>
-        k.toLowerCase().includes(q) ||
-        // Don't expose sensitive values via filter matches.
-        (!isSensitiveConfigKey(k) && stringifyValue(v).toLowerCase().includes(q)),
-    )
-  }, [entries, query])
+  const q = query.toLowerCase()
+  const filtered = !query.trim()
+    ? entries
+    : entries.filter(
+        ([k, v]) =>
+          k.toLowerCase().includes(q) ||
+          // Don't expose sensitive values via filter matches.
+          (!isSensitiveConfigKey(k) && stringifyValue(v).toLowerCase().includes(q)),
+      )
 
   if (!config || entries.length === 0) return null
 

--- a/frontend/app/src/components/startpage/IntroductionSlider.tsx
+++ b/frontend/app/src/components/startpage/IntroductionSlider.tsx
@@ -5,61 +5,61 @@ import SensorIcon from '../icons/Sensor'
 import TreeIcon from '../icons/Tree'
 import { i18nTranslated } from '../../lib/sliderTranslations'
 
+const facts = [
+  {
+    id: 1,
+    label: 'Entwicklung einer Sensorlösung',
+    icon: SensorIcon,
+    description:
+      'Daten zur Bodenfeuchte werden mithilfe von in unterschiedlicher Tiefe platzierten Sensoren geliefert.',
+  },
+  {
+    id: 2,
+    label: 'Auswertung der Messdaten',
+    icon: PieChart,
+    description:
+      'Auswertung der durch Sensoren übermittelten Daten für eine bedarfsgerechte Bewässerung von Bäumen.',
+  },
+  {
+    id: 3,
+    label: 'Augenmerk auf Jungbäume',
+    icon: TreeIcon,
+    description:
+      'Jungbäume sind besonders hitzeanfällig und daher äußerst schutzbedürftig. Aus diesem Grund werden Bäume in deren ersten drei Standjahren überwacht.',
+  },
+  {
+    id: 4,
+    label: 'Monitoring mehrerer Standorte',
+    icon: MapPin,
+    description:
+      'Unter Verwendung des LoRaWan-Netzes können verschiedene Standorte überwacht und weitere einfach eingebunden werden.',
+  },
+  {
+    id: 5,
+    label: 'Vereinfachte Einsatzplanung',
+    icon: Car,
+    description:
+      'Einsatzfahrten zur Bewässerung können digital und schnell geplant werden. Dabei können Informationen wie die Mitarbeitenden sowie genutzte Fahrzeuge und deren Wasserkapazität hinterlegt werden.',
+  },
+  {
+    id: 6,
+    label: 'Dynamische Routenplanung',
+    icon: Route,
+    description:
+      'Dynamische Berechnung von Bewässerungsrouten mithilfe von Open-Source Software (Valhalla & Vroom).',
+  },
+]
+
+const breakpoints = {
+  640: {
+    perPage: 2,
+  },
+  1024: {
+    destroy: true,
+  },
+}
+
 const IntroductionSlider = () => {
-  const facts = [
-    {
-      id: 1,
-      label: 'Entwicklung einer Sensorlösung',
-      icon: SensorIcon,
-      description:
-        'Daten zur Bodenfeuchte werden mithilfe von in unterschiedlicher Tiefe platzierten Sensoren geliefert.',
-    },
-    {
-      id: 2,
-      label: 'Auswertung der Messdaten',
-      icon: PieChart,
-      description:
-        'Auswertung der durch Sensoren übermittelten Daten für eine bedarfsgerechte Bewässerung von Bäumen.',
-    },
-    {
-      id: 3,
-      label: 'Augenmerk auf Jungbäume',
-      icon: TreeIcon,
-      description:
-        'Jungbäume sind besonders hitzeanfällig und daher äußerst schutzbedürftig. Aus diesem Grund werden Bäume in deren ersten drei Standjahren überwacht.',
-    },
-    {
-      id: 4,
-      label: 'Monitoring mehrerer Standorte',
-      icon: MapPin,
-      description:
-        'Unter Verwendung des LoRaWan-Netzes können verschiedene Standorte überwacht und weitere einfach eingebunden werden.',
-    },
-    {
-      id: 5,
-      label: 'Vereinfachte Einsatzplanung',
-      icon: Car,
-      description:
-        'Einsatzfahrten zur Bewässerung können digital und schnell geplant werden. Dabei können Informationen wie die Mitarbeitenden sowie genutzte Fahrzeuge und deren Wasserkapazität hinterlegt werden.',
-    },
-    {
-      id: 6,
-      label: 'Dynamische Routenplanung',
-      icon: Route,
-      description:
-        'Dynamische Berechnung von Bewässerungsrouten mithilfe von Open-Source Software (Valhalla & Vroom).',
-    },
-  ]
-
-  const breakpoints = {
-    640: {
-      perPage: 2,
-    },
-    1024: {
-      destroy: true,
-    },
-  }
-
   return (
     <section className="container my-20 lg:my-28">
       <div className="rounded-xl bg-green-dark-100 p-6 md:p-10 lg:pb-6">

--- a/frontend/app/src/components/startpage/KeyFacts.tsx
+++ b/frontend/app/src/components/startpage/KeyFacts.tsx
@@ -1,21 +1,22 @@
 import { BadgeCheck } from 'lucide-react'
 
+const numbers = [
+  'Monitoring des Bewässerungszustands',
+  'Gruppierung von Bäumen anhand von Standortbedingungen',
+  'Interpretation der Messwerte der Sensordaten in ein Ampelsystem',
+  'Vereinfachte & Digitalisierte Einsatzplanung',
+  'Dynamische Routenplanung von Bewässerungsfahrten',
+  'Langzeitauswertung von Daten',
+]
+
 const KeyFacts = () => {
-  const numbers = [
-    'Monitoring des Bewässerungszustands',
-    'Gruppierung von Bäumen anhand von Standortbedingungen',
-    'Interpretation der Messwerte der Sensordaten in ein Ampelsystem',
-    'Vereinfachte & Digitalisierte Einsatzplanung',
-    'Dynamische Routenplanung von Bewässerungsfahrten',
-    'Langzeitauswertung von Daten',
-  ]
   return (
     <section className="container mt-20 lg:mt-28">
       <h2 className="font-semibold text-dark-800 mb-6">Wobei genau hilft Ihnen Green Ecolution?</h2>
       <ul className="grid grid-cols-1 gap-y-4 md:grid-cols-2 md:gap-x-10">
         {numbers.map((number) => (
           <li key={number} className="flex items-center gap-x-4">
-            <BadgeCheck className="text-green-light w-8 h-8 shrink-0" />
+            <BadgeCheck className="text-green-light size-8 shrink-0" />
             <p className="font-semibold text-lg">{number}</p>
           </li>
         ))}

--- a/frontend/app/src/components/startpage/QuickLinks.tsx
+++ b/frontend/app/src/components/startpage/QuickLinks.tsx
@@ -1,32 +1,31 @@
 import { Link } from '@tanstack/react-router'
 import { LinkCard, LinkCardTitle, LinkCardDescription, LinkCardFooter } from '@green-ecolution/ui'
 
-const QuickLinks = () => {
-  const cards = [
-    {
-      id: 1,
-      url: '/map',
-      description: 'Alle Bewässerungsgruppen & Bäume auf der Karte anzeigen lassen',
-      headline: 'Karte inkl. Verortung aller Bäume',
-      linkLabel: 'Zur Karte',
-    },
-    {
-      id: 2,
-      url: '/sensors',
-      description: 'Zeigt alle verbauten Sensoren inkl. Akkustand, Messwerte, …',
-      headline: 'Liste aller verbauten Sensoren',
-      linkLabel: 'Zu den Sensoren',
-    },
-    {
-      id: 3,
-      url: '/watering-plans',
-      description:
-        'Listenansicht, aller Einsatzpläne, die geplant, abgeschlossen, aktiv etc. sind.',
-      headline: 'Auflistung der Einsatzpläne & Routenplanung',
-      linkLabel: 'Zu den Einsatzplänen',
-    },
-  ]
+const cards = [
+  {
+    id: 1,
+    url: '/map',
+    description: 'Alle Bewässerungsgruppen & Bäume auf der Karte anzeigen lassen',
+    headline: 'Karte inkl. Verortung aller Bäume',
+    linkLabel: 'Zur Karte',
+  },
+  {
+    id: 2,
+    url: '/sensors',
+    description: 'Zeigt alle verbauten Sensoren inkl. Akkustand, Messwerte, …',
+    headline: 'Liste aller verbauten Sensoren',
+    linkLabel: 'Zu den Sensoren',
+  },
+  {
+    id: 3,
+    url: '/watering-plans',
+    description: 'Listenansicht, aller Einsatzpläne, die geplant, abgeschlossen, aktiv etc. sind.',
+    headline: 'Auflistung der Einsatzpläne & Routenplanung',
+    linkLabel: 'Zu den Einsatzplänen',
+  },
+]
 
+const QuickLinks = () => {
   return (
     <section className="container border-t border-t-dark-100 pt-10 mt-20 lg:pt-28 lg:mt-28">
       <article className="text-center max-w-screen-lg mx-auto">

--- a/frontend/app/src/components/tree/TabWateringStatus.tsx
+++ b/frontend/app/src/components/tree/TabWateringStatus.tsx
@@ -88,7 +88,7 @@ const TabWateringStatus: React.FC<TabWateringStatusProps> = ({ tree }) => {
 
           <div className="lg:grid lg:grid-cols-[auto_15rem] lg:items-end lg:gap-x-10 xl:gap-x-20 xl:grid-cols-[auto_20rem]">
             <div aria-hidden="true" className="mb-10 lg:mb-0 lg:w-60 lg:col-start-2 xl:w-80">
-              <TreeDeciduous className="w-11 h-11 mx-auto mb-4" />
+              <TreeDeciduous className="size-11 mx-auto mb-4" />
               <ul className="flex flex-col gap-y-3">
                 {((tree?.sensor.latestData.data as SensorPayload)?.watermarks ?? []).map(
                   (watermark: Watermark) => (

--- a/frontend/app/src/components/tree/TreeDashboard.tsx
+++ b/frontend/app/src/components/tree/TreeDashboard.tsx
@@ -92,19 +92,19 @@ const TreeDashboard = ({ tree, treeCluster }: TreeDashboardProps) => {
         <Tabs defaultValue="watering" className="mt-10">
           <TabsList>
             <TabsTrigger value="watering">
-              <TreeIcon className="w-5 h-5" />
+              <TreeIcon className="size-5" />
               <span className="hidden group-data-[state=active]:block lg:block">
                 Bewässerungsdaten
               </span>
             </TabsTrigger>
             <TabsTrigger value="general">
-              <File className="w-5 h-5" />
+              <File className="size-5" />
               <span className="hidden group-data-[state=active]:block lg:block">
                 Allgemeine Daten
               </span>
             </TabsTrigger>
             <TabsTrigger value="sensor">
-              <SensorIcon className="w-5 h-5" />
+              <SensorIcon className="size-5" />
               <span className="hidden group-data-[state=active]:block lg:block">Sensordaten</span>
             </TabsTrigger>
           </TabsList>

--- a/frontend/app/src/components/watering-plan/WateringPlanDashboard.tsx
+++ b/frontend/app/src/components/watering-plan/WateringPlanDashboard.tsx
@@ -127,20 +127,20 @@ const WateringPlanDashboard = ({ wateringPlan }: WateringPlanDashboardProps) => 
       <Tabs defaultValue="general" className="mt-10">
         <TabsList>
           <TabsTrigger value="general">
-            <File className="w-5 h-5" />
+            <File className="size-5" />
             <span className="hidden group-data-[state=active]:block lg:block">
               Allgemeine Daten
             </span>
           </TabsTrigger>
           <TabsTrigger value="clusters">
-            <FolderClosed className="w-5 h-5" />
+            <FolderClosed className="size-5" />
             <span className="hidden group-data-[state=active]:block lg:block">
               Bewässerungsgruppen
             </span>
           </TabsTrigger>
           {wateringPlan.distance > 0 && (
             <TabsTrigger value="route">
-              <Route className="w-5 h-5" />
+              <Route className="size-5" />
               <span className="hidden group-data-[state=active]:block lg:block">Route</span>
             </TabsTrigger>
           )}

--- a/frontend/app/src/components/watering-plan/WateringPlanStatusUpdate.tsx
+++ b/frontend/app/src/components/watering-plan/WateringPlanStatusUpdate.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
 import BackLink from '../general/links/BackLink'
 import { WateringPlanStatus } from '@green-ecolution/backend-client'
 import type { WateringPlan, WateringPlanUpdate } from '@/api/backendApi'
@@ -81,58 +81,55 @@ const WateringPlanStatusUpdate = ({ wateringPlanId }: WateringPlanStatusUpdatePr
   const date = format(new Date(loadedData.date), 'dd.MM.yyyy')
   const statusDetails = getWateringPlanStatusDetails(loadedData.status)
 
-  const formByStatus = useCallback(
-    (status: WateringPlanStatus) => {
-      const onSubmitFinished: SubmitHandler<WateringPlanFinishedForm> = (data) => {
-        mutate({
-          ...loadedData,
-          status: WateringPlanStatus.Finished,
-          evaluation: data.evaluation,
-          transporterId: loadedData.transporter.id,
-          treeClusterIds: loadedData.treeclusters.map((cluster) => cluster.id),
-        })
-      }
+  const formByStatus = (status: WateringPlanStatus) => {
+    const onSubmitFinished: SubmitHandler<WateringPlanFinishedForm> = (data) => {
+      mutate({
+        ...loadedData,
+        status: WateringPlanStatus.Finished,
+        evaluation: data.evaluation,
+        transporterId: loadedData.transporter.id,
+        treeClusterIds: loadedData.treeclusters.map((cluster) => cluster.id),
+      })
+    }
 
-      const onSubmitCancel: SubmitHandler<WateringPlanCancelForm> = (data) => {
-        mutate({
-          ...loadedData,
-          status: WateringPlanStatus.Canceled,
-          cancellationNote: data.cancellationNote,
-          transporterId: loadedData.transporter.id,
-          treeClusterIds: loadedData.treeclusters.map((cluster) => cluster.id),
-        })
-      }
+    const onSubmitCancel: SubmitHandler<WateringPlanCancelForm> = (data) => {
+      mutate({
+        ...loadedData,
+        status: WateringPlanStatus.Canceled,
+        cancellationNote: data.cancellationNote,
+        transporterId: loadedData.transporter.id,
+        treeClusterIds: loadedData.treeclusters.map((cluster) => cluster.id),
+      })
+    }
 
-      const onSubmitOtherStatus = (status: WateringPlanStatus) => {
-        mutate({
-          ...loadedData,
-          status,
-          transporterId: loadedData.transporter.id,
-          treeClusterIds: loadedData.treeclusters.map((cluster) => cluster.id),
-        })
-      }
-      switch (status) {
-        case 'canceled':
-          return <CancelWateringPlan onSubmit={onSubmitCancel} />
-        case 'finished':
-          return (
-            <FinishedWateringPlan
-              onSubmit={onSubmitFinished}
-              wateringPlanId={wateringPlanId}
-              loadedData={loadedData}
-            />
-          )
-        default:
-          return (
-            <Button onClick={() => onSubmitOtherStatus(status)} type="submit" className="mt-10">
-              Speichern
-              <MoveRight className="icon-arrow-animate" />
-            </Button>
-          )
-      }
-    },
-    [loadedData, wateringPlanId, mutate],
-  )
+    const onSubmitOtherStatus = (status: WateringPlanStatus) => {
+      mutate({
+        ...loadedData,
+        status,
+        transporterId: loadedData.transporter.id,
+        treeClusterIds: loadedData.treeclusters.map((cluster) => cluster.id),
+      })
+    }
+    switch (status) {
+      case 'canceled':
+        return <CancelWateringPlan onSubmit={onSubmitCancel} />
+      case 'finished':
+        return (
+          <FinishedWateringPlan
+            onSubmit={onSubmitFinished}
+            wateringPlanId={wateringPlanId}
+            loadedData={loadedData}
+          />
+        )
+      default:
+        return (
+          <Button onClick={() => onSubmitOtherStatus(status)} type="submit" className="mt-10">
+            Speichern
+            <MoveRight className="icon-arrow-animate" />
+          </Button>
+        )
+    }
+  }
 
   return (
     <>

--- a/frontend/app/src/context/FilterContext.tsx
+++ b/frontend/app/src/context/FilterContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, ReactNode, use, useMemo } from 'react'
+import React, { createContext, useState, ReactNode, use } from 'react'
 
 export interface Filters {
   statusTags: string[]
@@ -92,19 +92,16 @@ const FilterProvider: React.FC<FilterProviderProps> = ({
     setPlantingYears([])
   }
 
-  const context = useMemo(
-    () => ({
-      filters: { statusTags, regionTags, hasCluster, plantingYears },
-      handleStatusChange,
-      handleRegionChange,
-      handleClusterChange,
-      handlePlantingYearChange,
-      handlePlantingYearRangeChange,
-      resetFilters,
-      applyOldStateToTags,
-    }),
-    [hasCluster, plantingYears, regionTags, statusTags],
-  )
+  const context = {
+    filters: { statusTags, regionTags, hasCluster, plantingYears },
+    handleStatusChange,
+    handleRegionChange,
+    handleClusterChange,
+    handlePlantingYearChange,
+    handlePlantingYearRangeChange,
+    resetFilters,
+    applyOldStateToTags,
+  }
 
   return <FilterContext value={context}>{children}</FilterContext>
 }

--- a/frontend/app/src/hooks/form/useEntityForm.ts
+++ b/frontend/app/src/hooks/form/useEntityForm.ts
@@ -4,7 +4,6 @@ import { useNavigate } from '@tanstack/react-router'
 import { DefaultValues, FieldValues, Resolver, useForm } from 'react-hook-form'
 import { useFormNavigationBlocker } from './useFormNavigationBlocker'
 import { useFormDraft } from '@/store/form/useFormDraft'
-import { useCallback } from 'react'
 import { FormType, MutationType } from '@/store/form/formDraftSlice'
 
 export interface EntityFormConfig<TForm extends FieldValues, TCreate, TUpdate, TEntity> {
@@ -53,12 +52,12 @@ export function useEntityForm<
     resolver: config.resolver,
   })
 
-  const saveDraft = useCallback(() => {
+  const saveDraft = () => {
     const data = form.getValues()
     if (data && Object.keys(data).length > 0) {
       draft.setData(data)
     }
-  }, [form, draft])
+  }
 
   const navigationBlocker = useFormNavigationBlocker({
     isDirty: form.formState.isDirty || draft.hasChanges,

--- a/frontend/app/src/hooks/form/useFormNavigationBlocker.ts
+++ b/frontend/app/src/hooks/form/useFormNavigationBlocker.ts
@@ -1,5 +1,5 @@
 import { useBlocker } from '@tanstack/react-router'
-import { useCallback, useRef } from 'react'
+import { useRef } from 'react'
 
 export interface UseFormNavigationBlockerOptions {
   isDirty: boolean
@@ -45,18 +45,18 @@ export const useFormNavigationBlocker = ({
     withResolver: true,
   })
 
-  const allowNavigation = useCallback(() => {
+  const allowNavigation = () => {
     allowNavigationRef.current = true
-  }, [])
+  }
 
-  const closeModal = useCallback(() => {
+  const closeModal = () => {
     reset?.()
-  }, [reset])
+  }
 
-  const confirmLeave = useCallback(() => {
+  const confirmLeave = () => {
     onLeave?.()
     proceed?.()
-  }, [onLeave, proceed])
+  }
 
   return {
     isModalOpen: status === 'blocked',

--- a/frontend/app/src/hooks/useFocusTrap.ts
+++ b/frontend/app/src/hooks/useFocusTrap.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, RefObject, useCallback } from 'react'
+import { useEffect, useRef, RefObject } from 'react'
 
 const FOCUSABLE_SELECTOR = [
   'a[href]',
@@ -21,12 +21,12 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(
   const containerRef = useRef<T | null>(null)
   const previousActiveElement = useRef<HTMLElement | null>(null)
 
-  const getFocusableElements = useCallback((): HTMLElement[] => {
+  const getFocusableElements = (): HTMLElement[] => {
     if (!containerRef.current) return []
     return Array.from(
       containerRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
     ).filter((el) => el.offsetParent !== null)
-  }, [])
+  }
 
   useEffect(() => {
     if (!enabled) return

--- a/frontend/app/src/hooks/useGeolocation.ts
+++ b/frontend/app/src/hooks/useGeolocation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export type GeolocationStatus =
   | 'idle'
@@ -91,14 +91,14 @@ const useGeolocation = ({
   const [history, setHistory] = useState<GeolocationFix[]>([])
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  const clearWatch = useCallback(() => {
+  const clearWatch = () => {
     if (watchIdRef.current !== null && navigator.geolocation) {
       navigator.geolocation.clearWatch(watchIdRef.current)
     }
     watchIdRef.current = null
-  }, [])
+  }
 
-  const settlePending = useCallback((fix: GeolocationFix | null, error?: unknown) => {
+  const settlePending = (fix: GeolocationFix | null, error?: unknown) => {
     if (error && pendingRejectRef.current) {
       pendingRejectRef.current(error)
     } else if (pendingResolveRef.current) {
@@ -106,47 +106,41 @@ const useGeolocation = ({
     }
     pendingResolveRef.current = null
     pendingRejectRef.current = null
-  }, [])
+  }
 
-  const handleSuccess = useCallback(
-    (raw: GeolocationPosition) => {
-      const fix = toFix(raw)
-      setPosition(fix)
-      setStatus('watching')
-      // A successful fix implicitly clears a stale transient error.
-      setErrorMessage(null)
-      if (trackHistory) {
-        setHistory((prev) => [fix, ...prev].slice(0, 200))
-      }
-      if (!locatedRef.current) {
-        locatedRef.current = true
-        onLocatedRef.current?.(fix)
-        settlePending(fix)
-      }
-    },
-    [trackHistory, settlePending],
-  )
+  const handleSuccess = (raw: GeolocationPosition) => {
+    const fix = toFix(raw)
+    setPosition(fix)
+    setStatus('watching')
+    // A successful fix implicitly clears a stale transient error.
+    setErrorMessage(null)
+    if (trackHistory) {
+      setHistory((prev) => [fix, ...prev].slice(0, 200))
+    }
+    if (!locatedRef.current) {
+      locatedRef.current = true
+      onLocatedRef.current?.(fix)
+      settlePending(fix)
+    }
+  }
 
-  const handleError = useCallback(
-    (err: GeolocationPositionError) => {
-      setErrorMessage(err.message || null)
-      if (err.code === err.PERMISSION_DENIED) {
-        setStatus('denied')
-        clearWatch()
-        settlePending(null, err)
-        return
-      }
-      // POSITION_UNAVAILABLE / TIMEOUT — keep watching, surface as error state
-      // only when we have no fix yet; otherwise stay in 'watching' with last value.
-      if (!locatedRef.current) {
-        setStatus('error')
-        settlePending(null, err)
-      }
-    },
-    [clearWatch, settlePending],
-  )
+  const handleError = (err: GeolocationPositionError) => {
+    setErrorMessage(err.message || null)
+    if (err.code === err.PERMISSION_DENIED) {
+      setStatus('denied')
+      clearWatch()
+      settlePending(null, err)
+      return
+    }
+    // POSITION_UNAVAILABLE / TIMEOUT — keep watching, surface as error state
+    // only when we have no fix yet; otherwise stay in 'watching' with last value.
+    if (!locatedRef.current) {
+      setStatus('error')
+      settlePending(null, err)
+    }
+  }
 
-  const start = useCallback((): Promise<GeolocationFix | null> => {
+  const start = (): Promise<GeolocationFix | null> => {
     // Already watching — return a no-op promise resolving to the last fix.
     if (watchIdRef.current !== null) {
       return Promise.resolve(position)
@@ -210,14 +204,14 @@ const useGeolocation = ({
 
       void run()
     })
-  }, [handleSuccess, handleError, settlePending, position])
+  }
 
-  const stop = useCallback(() => {
+  const stop = () => {
     clearWatch()
     setStatus('idle')
-  }, [clearWatch])
+  }
 
-  const reset = useCallback(() => {
+  const reset = () => {
     clearWatch()
     locatedRef.current = false
     settlePending(null)
@@ -225,9 +219,9 @@ const useGeolocation = ({
     setHistory([])
     setErrorMessage(null)
     setStatus('idle')
-  }, [clearWatch, settlePending])
+  }
 
-  const relocate = useCallback((): Promise<GeolocationFix | null> => {
+  const relocate = (): Promise<GeolocationFix | null> => {
     clearWatch()
     locatedRef.current = false
     settlePending(null)
@@ -235,7 +229,7 @@ const useGeolocation = ({
     // Keep the stale `position` visible until the next fix arrives — feels
     // smoother than flashing an empty state.
     return start()
-  }, [clearWatch, settlePending, start])
+  }
 
   // autoStart on mount; options are captured via optionsRef so this runs once.
   useEffect(() => {

--- a/frontend/app/src/hooks/usePWAInstall.ts
+++ b/frontend/app/src/hooks/usePWAInstall.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 interface BeforeInstallPromptEvent extends Event {
   readonly platforms: readonly string[]
@@ -49,6 +49,18 @@ const detectPlatform = (): PWAPlatform => {
   return 'desktop'
 }
 
+const promptInstall = async () => {
+  if (!deferredPrompt) return
+  const evt = deferredPrompt
+  try {
+    await evt.prompt()
+    await evt.userChoice
+  } finally {
+    deferredPrompt = null
+    notify()
+  }
+}
+
 export interface UsePWAInstallReturn {
   /** True when the app runs as an installed PWA (standalone display mode) */
   isStandalone: boolean
@@ -86,19 +98,7 @@ const usePWAInstall = (): UsePWAInstallReturn => {
     }
   }, [])
 
-  const platform = useMemo(detectPlatform, [])
-
-  const promptInstall = useCallback(async () => {
-    if (!deferredPrompt) return
-    const evt = deferredPrompt
-    try {
-      await evt.prompt()
-      await evt.userChoice
-    } finally {
-      deferredPrompt = null
-      notify()
-    }
-  }, [])
+  const platform = detectPlatform()
 
   return { isStandalone, platform, canPromptInstall, promptInstall }
 }

--- a/frontend/app/src/hooks/useQRScanner.ts
+++ b/frontend/app/src/hooks/useQRScanner.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { BarcodeDetector as BarcodeDetectorType } from 'barcode-detector/pure'
 
 export type ScannerStatus =
@@ -49,7 +49,7 @@ const useQRScanner = ({ onScan }: UseQRScannerOptions = {}): UseQRScannerReturn 
   const [scannedData, setScannedData] = useState<string | null>(null)
 
   // Release camera + cancel any pending frame callbacks.
-  const releaseStream = useCallback(() => {
+  const releaseStream = () => {
     cancelledRef.current = true
     streamRef.current?.getTracks().forEach((track) => {
       track.stop()
@@ -58,9 +58,9 @@ const useQRScanner = ({ onScan }: UseQRScannerOptions = {}): UseQRScannerReturn 
     if (videoRef.current) {
       videoRef.current.srcObject = null
     }
-  }, [])
+  }
 
-  const startScanning = useCallback(async (): Promise<void> => {
+  const startScanning = async (): Promise<void> => {
     if (!videoRef.current) return
     if (startingRef.current || streamRef.current) return
     startingRef.current = true
@@ -177,17 +177,17 @@ const useQRScanner = ({ onScan }: UseQRScannerOptions = {}): UseQRScannerReturn 
     }
 
     scheduleNext()
-  }, [releaseStream])
+  }
 
-  const stopScanning = useCallback(() => {
+  const stopScanning = () => {
     releaseStream()
     setStatus('idle')
-  }, [releaseStream])
+  }
 
-  const resetScan = useCallback(() => {
+  const resetScan = () => {
     setScannedData(null)
     setStatus('idle')
-  }, [])
+  }
 
   // Always release the camera on unmount
   useEffect(() => {

--- a/frontend/app/src/routes/_protected/dashboard.tsx
+++ b/frontend/app/src/routes/_protected/dashboard.tsx
@@ -6,53 +6,53 @@ export const Route = createFileRoute('/_protected/dashboard')({
   component: Dashboard,
 })
 
+const cards = [
+  {
+    id: 1,
+    url: '/map',
+    description: 'Alle Bäume in Flensburg im Zuständigkeitsbereich des TBZ.',
+    headline: 'Karte',
+    linkLabel: 'Zur Karte',
+  },
+  {
+    id: 2,
+    url: '/treecluster',
+    description: 'Listenansicht aller gruppierten Bäume, die mit Sensoren ausgestattet sind.',
+    headline: 'Auflistung der Bewässerungsgruppen',
+    linkLabel: 'Zu den Bewässerungsgruppen',
+  },
+  {
+    id: 3,
+    url: '/sensors',
+    description: 'Zeigt alle verbauten Sensoren in Flensburg inkl. Akkustand, Standort,…',
+    headline: 'Liste aller verbauten Sensoren',
+    linkLabel: 'Zu den Sensoren',
+  },
+  {
+    id: 4,
+    url: '/watering-plans',
+    description: 'Planung eines neuen Einsatzes zur Bewässerung von Baumgruppen',
+    headline: 'Einsatzplanung',
+    linkLabel: 'Zur Einsatzplanung',
+  },
+  {
+    id: 5,
+    url: '/settings',
+    description: 'Hier können Sie Einstellungen vornehmen, da Sie Administrator sind.',
+    headline: 'Einstellungen',
+    linkLabel: 'Zu den Einstellungen',
+  },
+  {
+    id: 6,
+    url: '/profile',
+    description: 'Hier können persönliche Informationen hinterlegt und angepasst werden.',
+    headline: 'Eigenes Profil',
+    linkLabel: 'Zum Profil',
+  },
+]
+
 function Dashboard() {
   const user = useUserStore()
-
-  const cards = [
-    {
-      id: 1,
-      url: '/map',
-      description: 'Alle Bäume in Flensburg im Zuständigkeitsbereich des TBZ.',
-      headline: 'Karte',
-      linkLabel: 'Zur Karte',
-    },
-    {
-      id: 2,
-      url: '/treecluster',
-      description: 'Listenansicht aller gruppierten Bäume, die mit Sensoren ausgestattet sind.',
-      headline: 'Auflistung der Bewässerungsgruppen',
-      linkLabel: 'Zu den Bewässerungsgruppen',
-    },
-    {
-      id: 3,
-      url: '/sensors',
-      description: 'Zeigt alle verbauten Sensoren in Flensburg inkl. Akkustand, Standort,…',
-      headline: 'Liste aller verbauten Sensoren',
-      linkLabel: 'Zu den Sensoren',
-    },
-    {
-      id: 4,
-      url: '/watering-plans',
-      description: 'Planung eines neuen Einsatzes zur Bewässerung von Baumgruppen',
-      headline: 'Einsatzplanung',
-      linkLabel: 'Zur Einsatzplanung',
-    },
-    {
-      id: 5,
-      url: '/settings',
-      description: 'Hier können Sie Einstellungen vornehmen, da Sie Administrator sind.',
-      headline: 'Einstellungen',
-      linkLabel: 'Zu den Einstellungen',
-    },
-    {
-      id: 6,
-      url: '/profile',
-      description: 'Hier können persönliche Informationen hinterlegt und angepasst werden.',
-      headline: 'Eigenes Profil',
-      linkLabel: 'Zum Profil',
-    },
-  ]
 
   return (
     <div className="container mt-6">

--- a/frontend/app/src/routes/_protected/info.tsx
+++ b/frontend/app/src/routes/_protected/info.tsx
@@ -792,16 +792,16 @@ interface SoftwareTabContentProps {
   }
 }
 
-function SoftwareTabContent({ data }: SoftwareTabContentProps) {
-  const copyToClipboard = async (text: string) => {
-    try {
-      await navigator.clipboard.writeText(text)
-      toast.success('In Zwischenablage kopiert')
-    } catch {
-      toast.error('Kopieren fehlgeschlagen')
-    }
+const copyToClipboard = async (text: string) => {
+  try {
+    await navigator.clipboard.writeText(text)
+    toast.success('In Zwischenablage kopiert')
+  } catch {
+    toast.error('Kopieren fehlgeschlagen')
   }
+}
 
+function SoftwareTabContent({ data }: SoftwareTabContentProps) {
   const buildDate = new Date(data.buildTime)
   const env = getBuildEnv(data.versionInfo)
   const visual = envVisuals[env]

--- a/frontend/app/src/routes/_protected/map/index.tsx
+++ b/frontend/app/src/routes/_protected/map/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, useLoaderData, useNavigate } from '@tanstack/react-router'
 import MapButtons from '@/components/map/MapButtons'
 import type { ClusterMarkerResponse, Tree, TreeCluster, TreeMarkerResponse } from '@/api/backendApi'
-import { useCallback, useMemo, useRef } from 'react'
+import { useRef } from 'react'
 import Dialog from '@/components/general/filter/Dialog'
 import StatusFieldset from '@/components/general/filter/fieldsets/StatusFieldset'
 import FilterProvider from '@/context/FilterContext'
@@ -25,40 +25,28 @@ function MapView() {
   const { enableDragging, disableDragging } = useMapInteractions()
   const dialogRef = useRef<HTMLDivElement>(null)
 
-  const hasActiveFilter = useMemo(
-    () => search.hasCluster !== undefined || search.plantingYears !== undefined,
-    [search.hasCluster, search.plantingYears],
-  )
+  const hasActiveFilter = search.hasCluster !== undefined || search.plantingYears !== undefined
 
-  const handleTreeClick = useCallback(
-    (tree: TreeMarkerResponse | Tree) => {
-      navigate({ to: `/trees/$treeId`, params: { treeId: tree.id.toString() } }).catch((error) =>
-        console.error('Navigation failed:', error),
-      )
-    },
-    [navigate],
-  )
+  const handleTreeClick = (tree: TreeMarkerResponse | Tree) => {
+    navigate({ to: `/trees/$treeId`, params: { treeId: tree.id.toString() } }).catch((error) =>
+      console.error('Navigation failed:', error),
+    )
+  }
 
-  const handleClusterClick = useCallback(
-    (cluster: ClusterMarkerResponse | TreeCluster) => {
-      navigate({
-        to: `/treecluster/$treeclusterId`,
-        params: { treeclusterId: cluster.id.toString() },
-      }).catch((error) => console.error('Navigation failed:', error))
-    },
-    [navigate],
-  )
+  const handleClusterClick = (cluster: ClusterMarkerResponse | TreeCluster) => {
+    navigate({
+      to: `/treecluster/$treeclusterId`,
+      params: { treeclusterId: cluster.id.toString() },
+    }).catch((error) => console.error('Navigation failed:', error))
+  }
 
-  const handleMapInteractions = useCallback(
-    (isOpen: boolean) => {
-      if (isOpen) {
-        disableDragging()
-      } else {
-        enableDragging()
-      }
-    },
-    [disableDragging, enableDragging],
-  )
+  const handleMapInteractions = (isOpen: boolean) => {
+    if (isOpen) {
+      disableDragging()
+    } else {
+      enableDragging()
+    }
+  }
 
   return (
     <>

--- a/frontend/app/src/routes/_protected/map/sensor/select/tree/index.tsx
+++ b/frontend/app/src/routes/_protected/map/sensor/select/tree/index.tsx
@@ -8,7 +8,7 @@ import createToast from '@/hooks/createToast'
 import { Tree, TreeMarkerResponse, TreeUpdateRequest } from '@/api/backendApi'
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
 
 export const Route = createFileRoute('/_protected/map/sensor/select/tree/')({
   component: LinkTreeToSensor,
@@ -51,12 +51,12 @@ function LinkTreeToSensor() {
       .catch(console.log)
   }
 
-  const handleNavigateBack = useCallback(() => {
+  const handleNavigateBack = () => {
     return navigate({
       to: `/sensors/$sensorId`,
       params: { sensorId: sensorId?.toString() ?? '' },
     })
-  }, [navigate, sensorId])
+  }
 
   const handleSave = async () => {
     setErrorMessage(null)

--- a/frontend/app/src/routes/_protected/map/tree/edit/index.tsx
+++ b/frontend/app/src/routes/_protected/map/tree/edit/index.tsx
@@ -16,7 +16,7 @@ import { TreeForm } from '@/schema/treeSchema'
 import { useMapStore } from '@/store/store'
 import { createFileRoute, useNavigate, useBlocker } from '@tanstack/react-router'
 import { LatLng } from 'leaflet'
-import { useCallback, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { z } from 'zod'
 
 const editTreeParams = z.object({
@@ -65,12 +65,12 @@ function EditTree() {
     withResolver: true,
   })
 
-  const handleConfirmLeave = useCallback(() => {
+  const handleConfirmLeave = () => {
     draft.clear()
     proceed?.()
-  }, [proceed, draft])
+  }
 
-  const handleNavigateBack = useCallback(() => {
+  const handleNavigateBack = () => {
     allowNavigationRef.current = true
     switch (formType) {
       case 'create':
@@ -93,7 +93,7 @@ function EditTree() {
           search: { lat: treeLatLng.lat, lng: treeLatLng.lng, zoom },
         })
     }
-  }, [formType, navigate, treeLatLng.lat, treeLatLng.lng, treeId, zoom])
+  }
 
   const handleSave = () => {
     const originalLat = draft.data?.latitude ?? treeLat

--- a/frontend/app/src/routes/_protected/map/treecluster/select/tree/index.tsx
+++ b/frontend/app/src/routes/_protected/map/treecluster/select/tree/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate, useBlocker } from '@tanstack/react-router'
 import { Tree, TreeMarkerResponse } from '@/api/backendApi'
-import { useCallback, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import SelectedCard from '@/components/general/cards/SelectedCard'
 import WithFilterableTrees from '@/components/map/marker/WithFilterableTrees'
 import MapSelectEntitiesModal from '@/components/map/MapSelectEntitiesModal'
@@ -59,12 +59,12 @@ function SelectTrees() {
     withResolver: true,
   })
 
-  const handleConfirmLeave = useCallback(() => {
+  const handleConfirmLeave = () => {
     draft.clear()
     proceed?.()
-  }, [proceed, draft])
+  }
 
-  const handleNavigateBack = useCallback(() => {
+  const handleNavigateBack = () => {
     allowNavigationRef.current = true
     switch (formType) {
       case 'create':
@@ -77,7 +77,7 @@ function SelectTrees() {
           params: { treeclusterId: clusterId?.toString() ?? '' },
         })
     }
-  }, [navigate, formType, clusterId])
+  }
 
   const handleSave = () => {
     if (treeIds.length === 0) {

--- a/frontend/app/src/routes/_protected/map/watering-plan/select/cluster/index.tsx
+++ b/frontend/app/src/routes/_protected/map/watering-plan/select/cluster/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate, useBlocker } from '@tanstack/react-router'
 import { TreeClusterInList } from '@/api/backendApi'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import {
   AlertDialog,
   AlertDialogContent,
@@ -67,10 +67,10 @@ function SelectCluster() {
     withResolver: true,
   })
 
-  const handleConfirmLeave = useCallback(() => {
+  const handleConfirmLeave = () => {
     draft.clear()
     proceed?.()
-  }, [proceed, draft])
+  }
 
   const { data: clusters } = useSuspenseQuery(treeClusterQuery())
   const { data: transporter } = useQuery({
@@ -82,7 +82,7 @@ function SelectCluster() {
     enabled: !!trailerId && trailerId !== '-1',
   })
 
-  const handleNavigateBack = useCallback(() => {
+  const handleNavigateBack = () => {
     allowNavigationRef.current = true
     switch (formType) {
       case 'update':
@@ -95,7 +95,7 @@ function SelectCluster() {
           to: '/watering-plans/new',
         })
     }
-  }, [navigate, formType, wateringPlanId])
+  }
 
   const handleSave = () => {
     if (clusterIds.length === 0) {
@@ -151,24 +151,20 @@ function SelectCluster() {
       .map((cluster) => cluster.id)
   }, [transporter, trailer, clusters.data])
 
-  const { showNotice, notice } = useMemo(() => {
-    const errors = []
+  const errors = []
 
-    if (!transporterId || transporterId === '-1') {
-      errors.push('Um eine Route generieren zu können, muss ein Fahrzeug ausgewählt werden.')
-    }
+  if (!transporterId || transporterId === '-1') {
+    errors.push('Um eine Route generieren zu können, muss ein Fahrzeug ausgewählt werden.')
+  }
 
-    if (disabledClusters.length > 0) {
-      errors.push(
-        'Ausgegraute Bewässerungsgruppen sind ausgeschlossen, da das Fahrzeug nicht genügend Wasserkapazität hat.',
-      )
-    }
+  if (disabledClusters.length > 0) {
+    errors.push(
+      'Ausgegraute Bewässerungsgruppen sind ausgeschlossen, da das Fahrzeug nicht genügend Wasserkapazität hat.',
+    )
+  }
 
-    return {
-      showNotice: errors.length > 0,
-      notice: errors,
-    }
-  }, [transporterId, disabledClusters])
+  const showNotice = errors.length > 0
+  const notice = errors
 
   return (
     <>

--- a/frontend/app/src/routes/_protected/sensors/new/index.tsx
+++ b/frontend/app/src/routes/_protected/sensors/new/index.tsx
@@ -14,7 +14,7 @@ import {
 import useGeolocation from '@/hooks/useGeolocation'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useCallback, useEffect, useReducer } from 'react'
+import { useEffect, useReducer } from 'react'
 
 export const Route = createFileRoute('/_protected/sensors/new/')({
   component: NewSensor,
@@ -92,40 +92,37 @@ function NewSensor() {
     onError: (err) => dispatch({ type: 'submissionError', message: mapActivateError(err) }),
   })
 
-  const handleRelocate = useCallback(async () => {
+  const handleRelocate = async () => {
     dispatch({ type: 'gpsCleared' })
     const next = await relocate().catch(() => null)
     if (next) {
       dispatch({ type: 'gpsFrozen', fix: next })
       stop()
     }
-  }, [relocate, stop])
+  }
 
-  const handleStepClick = useCallback(
-    (target: WizardStep) => dispatch({ type: 'goToStep', step: target }),
-    [],
-  )
+  const handleStepClick = (target: WizardStep) => dispatch({ type: 'goToStep', step: target })
 
-  const handleBack = useCallback(() => {
+  const handleBack = () => {
     if (state.step > 1) {
       dispatch({ type: 'goToStep', step: (state.step - 1) as WizardStep })
     }
-  }, [state.step])
+  }
 
-  const handleNext = useCallback(() => {
+  const handleNext = () => {
     if (state.step < 3) {
       dispatch({ type: 'goToStep', step: (state.step + 1) as WizardStep })
     }
-  }, [state.step])
+  }
 
-  const handleResetForNext = useCallback(() => {
+  const handleResetForNext = () => {
     dispatch({ type: 'resetForNextSensor' })
     void relocate()
-  }, [relocate])
+  }
 
-  const handleBackToOverview = useCallback(() => {
+  const handleBackToOverview = () => {
     void navigate({ to: '/sensors', search: { page: 1 } })
-  }, [navigate])
+  }
 
   if (state.submission === 'success') {
     return (

--- a/frontend/app/src/routes/_protected/settings/plugin/index.tsx
+++ b/frontend/app/src/routes/_protected/settings/plugin/index.tsx
@@ -23,7 +23,7 @@ function PluginView() {
         </p>
       </article>
 
-      <Suspense fallback={<div>Laden von Plugins...</div>}>
+      <Suspense fallback={<div>Laden von Plugins…</div>}>
         <PluginList />
       </Suspense>
     </div>

--- a/frontend/app/src/routes/_protected/trees/_formular/new/index.tsx
+++ b/frontend/app/src/routes/_protected/trees/_formular/new/index.tsx
@@ -5,7 +5,6 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useMapStore } from '@/store/store'
 import { sensorQuery, treeClusterQuery } from '@/api/queries'
 import { useTreeForm } from '@/hooks/form/useTreeForm'
-import { useCallback } from 'react'
 import { z } from 'zod'
 import { useTreeDraft } from '@/store/form/useFormDraft'
 import { FormProvider } from 'react-hook-form'
@@ -78,7 +77,7 @@ function NewTree() {
     })
   }
 
-  const handleOnChangeLocation = useCallback(() => {
+  const handleOnChangeLocation = () => {
     saveDraft()
     navigate({
       to: '/map/tree/edit',
@@ -91,7 +90,7 @@ function NewTree() {
         zoom: mapZoom,
       },
     }).catch((error) => console.error('Navigation failed:', error))
-  }, [form, mapZoom, navigate, saveDraft])
+  }
 
   return (
     <div className="container mt-6">

--- a/frontend/app/src/store/form/useFormDraft.ts
+++ b/frontend/app/src/store/form/useFormDraft.ts
@@ -1,4 +1,3 @@
-import { useCallback, useMemo } from 'react'
 import useStore from '@/store/store'
 import { FormDraftKey, FormDraftState, FormType, MutationType } from './formDraftSlice'
 
@@ -11,25 +10,19 @@ export function useFormDraft<T>(formType: FormType, mutationType: MutationType) 
   const markFormDraftChanged = useStore((state) => state.markFormDraftChanged)
   const clearFormDraft = useStore((state) => state.clearFormDraft)
 
-  const setData = useCallback((data: T) => setFormDraft(key, data), [key, setFormDraft])
-  const updateData = useCallback(
-    (updater: (prev: T | null) => T) => updateFormDraft(key, updater),
-    [key, updateFormDraft],
-  )
-  const markChanged = useCallback(() => markFormDraftChanged(key), [key, markFormDraftChanged])
-  const clear = useCallback(() => clearFormDraft(key), [key, clearFormDraft])
+  const setData = (data: T) => setFormDraft(key, data)
+  const updateData = (updater: (prev: T | null) => T) => updateFormDraft(key, updater)
+  const markChanged = () => markFormDraftChanged(key)
+  const clear = () => clearFormDraft(key)
 
-  return useMemo(
-    () => ({
-      data: (draft?.data ?? null) as T | null,
-      hasChanges: draft?.hasChanges ?? false,
-      setData,
-      updateData,
-      markChanged,
-      clear,
-    }),
-    [draft?.data, draft?.hasChanges, setData, updateData, markChanged, clear],
-  )
+  return {
+    data: (draft?.data ?? null) as T | null,
+    hasChanges: draft?.hasChanges ?? false,
+    setData,
+    updateData,
+    markChanged,
+    clear,
+  }
 }
 
 export const useTreeDraft = <T>(mutationType: MutationType) => useFormDraft<T>('tree', mutationType)

--- a/frontend/app/tsconfig.app.json
+++ b/frontend/app/tsconfig.app.json
@@ -3,7 +3,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "ES2023.Array", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     /* Bundler mode */

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,8 @@
     "build-storybook": "pnpm --filter @green-ecolution/ui build-storybook"
   },
   "devDependencies": {
-    "prettier": "^3.8.3"
+    "prettier": "^3.8.3",
+    "react-doctor": "^0.2.16"
   },
   "packageManager": "pnpm@10.20.0"
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
+      react-doctor:
+        specifier: ^0.2.16
+        version: 0.2.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@10.0.3(jiti@2.7.0))
 
   app:
     dependencies:
@@ -104,10 +107,10 @@ importers:
         version: 10.0.1(eslint@10.0.3(jiti@2.7.0))
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 4.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/router-plugin':
         specifier: 1.168.11
-        version: 1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -131,10 +134,10 @@ importers:
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-basic-ssl':
         specifier: ^2.3.0
-        version: 2.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 2.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitejs/plugin-react':
         specifier: ^5.1.4
-        version: 5.2.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 5.2.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.7
         version: 4.1.7(vitest@4.1.7)
@@ -179,19 +182,19 @@ importers:
         version: 8.57.0(eslint@10.0.3(jiti@2.7.0))(typescript@5.9.3)
       vite:
         specifier: ^7.3.1
-        version: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+        version: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-plugin-pwa:
         specifier: ^1.3.0
-        version: 1.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.1)
+        version: 1.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.1)
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(rollup@2.80.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 1.6.0(rollup@2.80.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
-        version: 3.6.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 3.6.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       workbox-window:
         specifier: ^7.4.1
         version: 7.4.1
@@ -222,7 +225,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugin-interface:
     devDependencies:
@@ -243,7 +246,7 @@ importers:
         version: 8.60.0(eslint@10.0.3(jiti@2.7.0))(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^5.1.4
-        version: 5.2.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 5.2.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       eslint:
         specifier: ^10.0.3
         version: 10.0.3(jiti@2.7.0)
@@ -267,10 +270,10 @@ importers:
         version: 8.57.0(eslint@10.0.3(jiti@2.7.0))(typescript@5.9.3)
       vite:
         specifier: ^7.3.1
-        version: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+        version: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^4.5.3
-        version: 4.5.4(@types/node@25.9.1)(rollup@4.57.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 4.5.4(@types/node@25.9.1)(rollup@4.57.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/ui:
     dependencies:
@@ -340,19 +343,19 @@ importers:
         version: 10.0.1(eslint@10.0.3(jiti@2.7.0))
       '@storybook/addon-a11y':
         specifier: ^10.4.1
-        version: 10.4.1(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 10.4.1(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@storybook/addon-docs':
         specifier: ^10.4.1
-        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@storybook/react':
         specifier: ^10.4.1
-        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^10.4.1
-        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.27.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.27.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 4.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -370,7 +373,7 @@ importers:
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-react':
         specifier: ^5.1.4
-        version: 5.2.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 5.2.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.7
         version: 4.1.7(vitest@4.1.7)
@@ -397,7 +400,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       storybook:
         specifier: ^10.4.1
-        version: 10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -409,13 +412,13 @@ importers:
         version: 8.57.0(eslint@10.0.3(jiti@2.7.0))(typescript@5.9.3)
       vite:
         specifier: ^7.3.1
-        version: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+        version: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@25.9.1)(rollup@4.57.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 4.5.4(@types/node@25.9.1)(rollup@4.57.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -1103,8 +1106,20 @@ packages:
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
+  '@effect/platform-node-shared@4.0.0-beta.70':
+    resolution: {integrity: sha512-3VXuL63IDmq13We+ApRKn2JW3Rb9g5gj1YEmfb8u2b73norur1VsIJ/pRE4qjShevg19dQYi2JsLawSZ6gApug==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-beta.70
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
@@ -1384,6 +1399,9 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+
   '@inquirer/ansi@2.0.6':
     resolution: {integrity: sha512-I/INw4sHGlVZ/afZOckpLiDP9SmbMl1g/GCqeHjLw1Afw/0PlRs2tRFgTGWmdI0hoNuWZn3y2iHNmG1vyECyQQ==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
@@ -1486,6 +1504,36 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
@@ -1534,6 +1582,18 @@ packages:
       '@nestjs/websockets':
         optional: true
 
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
   '@nuxt/opencollective@0.4.1':
     resolution: {integrity: sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==}
     engines: {node: ^14.18.0 || >=16.10.0, npm: '>=5.10.0'}
@@ -1561,8 +1621,50 @@ packages:
     engines: {node: '>=20.19.0'}
     hasBin: true
 
+  '@opentelemetry/api-logs@0.214.0':
+    resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.214.0':
+    resolution: {integrity: sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
+
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
     resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm-eabi@0.132.0':
+    resolution: {integrity: sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
@@ -1573,8 +1675,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@oxc-parser/binding-android-arm64@0.132.0':
+    resolution: {integrity: sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@oxc-parser/binding-darwin-arm64@0.127.0':
     resolution: {integrity: sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-arm64@0.132.0':
+    resolution: {integrity: sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -1585,8 +1699,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@oxc-parser/binding-darwin-x64@0.132.0':
+    resolution: {integrity: sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@oxc-parser/binding-freebsd-x64@0.127.0':
     resolution: {integrity: sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-freebsd-x64@0.132.0':
+    resolution: {integrity: sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -1597,8 +1723,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
+    resolution: {integrity: sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
     resolution: {integrity: sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
+    resolution: {integrity: sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -1609,8 +1747,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
+    resolution: {integrity: sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
+    resolution: {integrity: sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1621,8 +1771,20 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
+    resolution: {integrity: sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
+    resolution: {integrity: sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -1633,8 +1795,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
+    resolution: {integrity: sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
+    resolution: {integrity: sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -1645,8 +1819,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
+    resolution: {integrity: sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-musl@0.132.0':
+    resolution: {integrity: sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1657,13 +1843,30 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@oxc-parser/binding-openharmony-arm64@0.132.0':
+    resolution: {integrity: sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@oxc-parser/binding-wasm32-wasi@0.127.0':
     resolution: {integrity: sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
+  '@oxc-parser/binding-wasm32-wasi@0.132.0':
+    resolution: {integrity: sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
     resolution: {integrity: sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
+    resolution: {integrity: sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -1674,14 +1877,29 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
+    resolution: {integrity: sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxc-parser/binding-win32-x64-msvc@0.127.0':
     resolution: {integrity: sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
+  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
+    resolution: {integrity: sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@oxc-project/types@0.132.0':
+    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
@@ -1780,6 +1998,120 @@ packages:
 
   '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
     resolution: {integrity: sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.68.0':
+    resolution: {integrity: sha512-wEdsIspexXLLMCPAEOcCuFLMt6aE3AzTuA/nQKLPRnoJ+EQTturmGheDkhHuuVHx0GbutjQ3JKmEn+Gz6Ag28Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.68.0':
+    resolution: {integrity: sha512-6aZRNNXQTsYtgaus8HTb9nuCcsrQTlKXGnktwvwW0n/SooRWNxNb3925grDkC63aEYZuCIyOVLV16IdYIoC2aQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.68.0':
+    resolution: {integrity: sha512-lVTbsE3kO4bLpZELgjRZuAJc8kP98wb83yMXWH8gaPaFZ+cM2IDeZto4ByoUAYj0Mxv2rvw+A1ssZequSepVSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.68.0':
+    resolution: {integrity: sha512-nCmw2XrmQskjBUh/sfP5yKs93V68LijQgjd1cuuZ/q4SCARngLYs60/qqyzuMsg8QQ9KArDI98hxs/RDGE4KRQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.68.0':
+    resolution: {integrity: sha512-TI4ovQJliYE9V6e06cEv+qEI9uj7Ao65fmif4er4HD+aouyYyh0P31q2jh3KtqsOHHcQqv2PZ61TjJFLpBDGWQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.68.0':
+    resolution: {integrity: sha512-LcNnEi9g71Cmry5ZpLbKT+oVv+/zYG3hYVAbBBB5X85nOQZSk8l92CnDkxJMcxUg0NCnMCOFZuaVDlMyv4tYJw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.68.0':
+    resolution: {integrity: sha512-OovHahL3FX4UaK+hgSf11llUx2vszqjSdQQ61Ck9InOEI/ptZoC4XSQJurITqItVvd53JSlmkLMeaNjM1PoQew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.68.0':
+    resolution: {integrity: sha512-YbzTglnHLzzi9zv5or8Ztz5fykAoZE8W9iM42/bOrF4HBSB6rJTqdLQWuoP76EHQw9DuKl76K1QmFlG29sPJXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-musl@1.68.0':
+    resolution: {integrity: sha512-qVKtCZNic+OoNnOr/hCQAu22HSQzflI7Fsq/Blzkw02SnLuv163k3kfmrVpZjSBlUHgsRKj6WgQiw30d3SX02Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.68.0':
+    resolution: {integrity: sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.68.0':
+    resolution: {integrity: sha512-6C4MPuwewyDavA7sxM14wzgRi5GGL68HPIxRCdVyS75U4MDbpFVYzKO9WNR6KLKTMPq2pcz3THwo1sK2uiqngw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-musl@1.68.0':
+    resolution: {integrity: sha512-bnZooVeHAcvA+dH0EDLgx+7HY/DRi6e0hFszg3P+OBatuUjV6EvfIyNIzWOusmqAVh4L6r21GGTZtiKE4iqM4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-s390x-gnu@1.68.0':
+    resolution: {integrity: sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-gnu@1.68.0':
+    resolution: {integrity: sha512-zc9lEnfV/HreDTY6gdMlZe+irkwHSxQ4/B1pS9GyK7RVaA5LxhoZY/w6/o2vIwLLEYiXQ5ujGxOM1ZazeFAAIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-musl@1.68.0':
+    resolution: {integrity: sha512-Dl5QEX0TCo/40Cdh1o1JdPS//+YiWqjC+Hrrya5OQmStZZr4svAFtdlqcpCrU9yq2Mo3vRVyO9B3h0dzD8s36Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-openharmony-arm64@1.68.0':
+    resolution: {integrity: sha512-/qy6dOvi4S3/LeXq0l5BT5pRKPYA7oj3uKwJOAZOr5HRLL+HK6jdBynvWuXIA2wwfE01RzNYmbBdM7vwYx00sA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.68.0':
+    resolution: {integrity: sha512-fHNtVqPHSYE7UFDSLVFUjxQjnSVXxseNJmRW+XuP4pXXDwePdPda43NL7/BBCFTxHjycOc44JNDaOPtFDNui9A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.68.0':
+    resolution: {integrity: sha512-NnKXr4Wgo4nps3erhrE0f8shBvBPZMHg72nDsvX0JyrRvsNiP3f1JNvbCKh+A6VFvpF7ZoJxu904P3cKMhvZnA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.68.0':
+    resolution: {integrity: sha512-zg5pA+84AlU6XHJ3ruiRxziO71QTrz8nLsk6u01JGS5+tL9/bnlakFiklFrcy4R1/V7ktWtaNitN3JZWmKnf6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
@@ -2473,6 +2805,47 @@ packages:
   '@rushstack/ts-command-line@5.0.1':
     resolution: {integrity: sha512-bsbUucn41UXrQK7wgM8CNM/jagBytEyJqXw/umtI8d68vFm1Jwxh1OtLrlW7uGZgjCWiiPH6ooUNa1aVsuVr3Q==}
 
+  '@sentry/core@10.55.0':
+    resolution: {integrity: sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/node-core@10.55.0':
+    resolution: {integrity: sha512-M8XMMIk9Y0PGZoEt37Oe5dQCdqDdJlBcwLXidpz/s5k4QtJvCO/BbtcivcuKI2htw5FwxJkSrHUzRvT36tlDpg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
+
+  '@sentry/node@10.55.0':
+    resolution: {integrity: sha512-+fB/ByoHVWPLGgoafYciiMatTNyX1FHj1bsqZBN+Pw3McbuEU1nwCPLt9zuyZZiWlQtXKsyuACS4ZhXnID5l8A==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.55.0':
+    resolution: {integrity: sha512-0+YrNmVNrttki4rWP4DW+UTt5MziepwDLNBde39tgc3cGCcy5fLSdDfhb4JfTaE5TXt4kd5XrkgvS/sDgm3RZg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+
   '@splidejs/react-splide@0.7.12':
     resolution: {integrity: sha512-UfXH+j47jsMc4x5HA/aOwuuHPqn6y9+ZTNYPWDRD8iLKvIVMZlzq2unjUEvyDAU+TTVPZOXkG2Ojeoz0P4AkZw==}
 
@@ -3012,6 +3385,9 @@ packages:
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.57.0':
     resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3273,6 +3649,11 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3290,6 +3671,10 @@ packages:
   agent-base@9.0.0:
     resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
     engines: {node: '>= 20'}
+
+  agent-install@0.0.5:
+    resolution: {integrity: sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==}
+    hasBin: true
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -3393,6 +3778,9 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
+  atomically@2.1.1:
+    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -3464,6 +3852,10 @@ packages:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -3511,6 +3903,9 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -3545,6 +3940,10 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -3567,11 +3966,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  conf@15.1.0:
+    resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
+    engines: {node: '>=20'}
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
   consola@2.15.3:
     resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
@@ -3688,6 +4094,10 @@ packages:
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
+  debounce-fn@6.0.0:
+    resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
+    engines: {node: '>=18'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -3751,6 +4161,9 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  deslop-js@0.0.14:
+    resolution: {integrity: sha512-FY0rNK+mdTozXwNmcJAt5tD9hVOkXEX5ac+Mg77KJvnnsoAh3qIUW64PMnofutjeYz7g1vENMbOcrBmD1v4FlA==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -3772,12 +4185,19 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dot-prop@10.1.0:
+    resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
+    engines: {node: '>=20'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
   easy-table@1.1.0:
     resolution: {integrity: sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA==}
+
+  effect@4.0.0-beta.70:
+    resolution: {integrity: sha512-8AwGTRiNriirHGEYHrOS0E9fzdhIqCdZjiHP1YXmNo2UyPGS43ILsymsSHT7V0DJS+8dvlKq2RxnrDBUhDNZHg==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -3805,6 +4225,10 @@ packages:
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -3870,6 +4294,12 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react-refresh@0.5.2:
     resolution: {integrity: sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==}
@@ -3953,8 +4383,16 @@ packages:
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -3976,6 +4414,9 @@ packages:
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -4003,6 +4444,13 @@ packages:
 
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-my-way-ts@0.1.6:
+    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -4096,6 +4544,10 @@ packages:
   get-uri@8.0.0:
     resolution: {integrity: sha512-CqtZlMKvfJeY0Zxv8wazDwXmSKmnMnsmNy8j8+wudi8EyG/pMUB1NqHc+Tv1QaNtpYsK9nOYjb7r7Ufu32RPSw==}
     engines: {node: '>= 20'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -4218,6 +4670,10 @@ packages:
   immer@11.1.8:
     resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
 
+  import-in-the-middle@3.0.1:
+    resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
+    engines: {node: '>=18'}
+
   import-lazy@4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
     engines: {node: '>=8'}
@@ -4229,6 +4685,10 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  ini@7.0.0:
+    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -4331,6 +4791,10 @@ packages:
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-obj@1.0.1:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
@@ -4458,6 +4922,9 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -4465,6 +4932,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
@@ -4476,8 +4946,15 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
+  kubernetes-types@1.30.0:
+    resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
 
   leaflet@1.9.4:
     resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
@@ -4640,6 +5117,14 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -4647,6 +5132,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -4681,12 +5170,22 @@ packages:
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
 
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
+    hasBin: true
+
+  msgpackr@2.0.2:
+    resolution: {integrity: sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==}
 
   msw@2.14.6:
     resolution: {integrity: sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==}
@@ -4700,6 +5199,9 @@ packages:
 
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
+  multipasta@0.2.7:
+    resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
 
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
@@ -4729,6 +5231,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-releases@2.0.46:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
@@ -4768,8 +5274,29 @@ packages:
     resolution: {integrity: sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  oxc-parser@0.132.0:
+    resolution: {integrity: sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   oxc-resolver@11.19.1:
     resolution: {integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==}
+
+  oxlint-plugin-react-doctor@0.2.16:
+    resolution: {integrity: sha512-Ul1UxcYfjBnt+HjgNaMnkvMJjyewS6rkSZl3LiD1g/QqSll1jiynYH/ZoNpUaGHp1pDQ/xLvCcXNQvqopN0tHA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxlint@1.68.0:
+    resolution: {integrity: sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -4872,6 +5399,10 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
   proxy-agent@8.0.1:
     resolution: {integrity: sha512-kccqGBqHZXR8onQhY/ganJjoO8QIKKRiFBhPOzbTZK16attzSZ/0XSmp9H7jrRxPKHjhGyx1q32lMPrJ3uLFgA==}
     engines: {node: '>= 20'}
@@ -4884,8 +5415,14 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
+
   quansync@0.2.10:
     resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quickjs-wasi@2.2.0:
     resolution: {integrity: sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==}
@@ -4907,6 +5444,11 @@ packages:
   react-docgen@8.0.3:
     resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
     engines: {node: ^20.9.0 || >=22}
+
+  react-doctor@0.2.16:
+    resolution: {integrity: sha512-o108QscqM/TlC1QmKgDORf/P53PeZ69nZbRsvy53rXkKvWdKZC1Y0u1JRPmThbTh6v+QpMispBwEnFHhlpZQ7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
@@ -5047,6 +5589,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
@@ -5066,6 +5612,10 @@ packages:
   rettime@0.11.11:
     resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rollup@2.80.0:
     resolution: {integrity: sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==}
     engines: {node: '>=10.0.0'}
@@ -5083,6 +5633,9 @@ packages:
   run-async@3.0.0:
     resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
     engines: {node: '>=0.12.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -5194,6 +5747,9 @@ packages:
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -5331,6 +5887,12 @@ packages:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
 
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -5410,9 +5972,17 @@ packages:
     resolution: {integrity: sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==}
     hasBin: true
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  toml@4.1.1:
+    resolution: {integrity: sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==}
+    engines: {node: '>=20'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -5521,6 +6091,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
@@ -5626,6 +6201,10 @@ packages:
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   victory-vendor@37.3.6:
@@ -5780,6 +6359,9 @@ packages:
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -5906,8 +6488,8 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
-  yaml@2.8.0:
-    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -6840,9 +7422,29 @@ snapshots:
 
   '@date-fns/tz@1.4.1': {}
 
+  '@effect/platform-node-shared@4.0.0-beta.70(effect@4.0.0-beta.70)':
+    dependencies:
+      '@types/ws': 8.18.1
+      effect: 4.0.0-beta.70
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -7057,6 +7659,8 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iarna/toml@2.2.5': {}
+
   '@inquirer/ansi@2.0.6': {}
 
   '@inquirer/confirm@6.1.0(@types/node@25.9.1)':
@@ -7115,11 +7719,11 @@ snapshots:
 
   '@isaacs/cliui@9.0.0': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -7190,6 +7794,24 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    optional: true
+
   '@mswjs/interceptors@0.41.9':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -7198,6 +7820,13 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
@@ -7235,6 +7864,18 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
       uid: 2.0.2
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@nuxt/opencollective@0.4.1':
     dependencies:
@@ -7288,52 +7929,135 @@ snapshots:
       - encoding
       - supports-color
 
+  '@opentelemetry/api-logs@0.214.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm-eabi@0.132.0':
     optional: true
 
   '@oxc-parser/binding-android-arm64@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-android-arm64@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-darwin-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.132.0':
     optional: true
 
   '@oxc-parser/binding-darwin-x64@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-darwin-x64@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-freebsd-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-musl@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.132.0':
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.127.0':
@@ -7343,16 +8067,34 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
+  '@oxc-parser/binding-wasm32-wasi@0.132.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
     optional: true
 
   '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-win32-x64-msvc@0.127.0':
     optional: true
 
+  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
+    optional: true
+
   '@oxc-project/types@0.127.0': {}
+
+  '@oxc-project/types@0.132.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     optional: true
@@ -7402,9 +8144,9 @@ snapshots:
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -7417,6 +8159,63 @@ snapshots:
     optional: true
 
   '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.68.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.68.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.68.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.68.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.68.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.68.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.68.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.68.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.68.0':
     optional: true
 
   '@polka/url@1.0.0-next.29': {}
@@ -8068,6 +8867,43 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@sentry/core@10.55.0': {}
+
+  '@sentry/node-core@10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
+    dependencies:
+      '@sentry/core': 10.55.0
+      '@sentry/opentelemetry': 10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 3.0.1
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@sentry/node@10.55.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry/core': 10.55.0
+      '@sentry/node-core': 10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      '@sentry/opentelemetry': 10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 3.0.1
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry/core': 10.55.0
+
   '@splidejs/react-splide@0.7.12':
     dependencies:
       '@splidejs/splide': 4.1.4
@@ -8078,21 +8914,21 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-a11y@10.4.1(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-a11y@10.4.1(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.4
-      storybook: 10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/addon-docs@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@storybook/addon-docs@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.15)(react@19.2.6)
-      '@storybook/csf-plugin': 10.4.1(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+      '@storybook/csf-plugin': 10.4.1(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@storybook/icons': 2.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@storybook/react-dom-shim': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/react-dom-shim': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      storybook: 10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@types/react': 19.2.15
@@ -8103,25 +8939,25 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/builder-vite@10.4.1(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@storybook/builder-vite@10.4.1(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.1(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
-      storybook: 10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@storybook/csf-plugin': 10.4.1(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.1(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@storybook/csf-plugin@10.4.1(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      storybook: 10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.7
       rollup: 4.57.1
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@storybook/global@5.0.0': {}
 
@@ -8130,30 +8966,30 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@storybook/react-dom-shim@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/react-dom-shim@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      storybook: 10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
 
-  '@storybook/react-vite@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.27.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@storybook/react-vite@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.27.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@storybook/builder-vite': 10.4.1(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
-      '@storybook/react': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.4.1(esbuild@0.27.7)(rollup@4.57.1)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@storybook/react': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       empathic: 2.0.1
       magic-string: 0.30.21
       react: 19.2.6
       react-docgen: 8.0.3
       react-dom: 19.2.6(react@19.2.6)
       resolve: 1.22.12
-      storybook: 10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tsconfig-paths: 4.2.0
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -8163,15 +8999,15 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)':
+  '@storybook/react@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/react-dom-shim': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       react: 19.2.6
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.6(react@19.2.6)
-      storybook: 10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
@@ -8311,12 +9147,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@tailwindcss/vite@4.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@tanstack/history@1.162.0': {}
 
@@ -8390,7 +9226,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@tanstack/router-plugin@1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
@@ -8407,7 +9243,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8590,6 +9426,10 @@ snapshots:
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/wrap-ansi@3.0.0': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.1
 
   '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@10.0.3(jiti@2.7.0))(typescript@5.9.3))(eslint@10.0.3(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -8836,11 +9676,11 @@ snapshots:
       '@typescript-eslint/types': 8.60.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-basic-ssl@2.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@vitejs/plugin-basic-ssl@2.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -8848,7 +9688,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8864,7 +9704,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -8883,14 +9723,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@vitest/mocker@4.1.7(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.14.6(@types/node@25.9.1)(typescript@5.9.3)
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -8927,7 +9767,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -8988,6 +9828,10 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -9002,6 +9846,15 @@ snapshots:
 
   agent-base@9.0.0: {}
 
+  agent-install@0.0.5:
+    dependencies:
+      '@iarna/toml': 2.2.5
+      commander: 14.0.3
+      jsonc-parser: 3.3.1
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      yaml: 2.9.0
+
   ajv-draft-04@1.0.0(ajv@8.13.0):
     optionalDependencies:
       ajv: 8.13.0
@@ -9009,6 +9862,10 @@ snapshots:
   ajv-formats@3.0.1(ajv@8.13.0):
     optionalDependencies:
       ajv: 8.13.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@6.14.0:
     dependencies:
@@ -9107,6 +9964,11 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -9199,6 +10061,10 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   browserslist@4.28.2:
     dependencies:
       baseline-browser-mapping: 2.10.32
@@ -9253,6 +10119,8 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
+  cjs-module-lexer@2.2.0: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -9282,6 +10150,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@14.0.3: {}
+
   commander@2.20.3: {}
 
   commander@8.3.0: {}
@@ -9301,9 +10171,23 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 17.7.2
 
+  conf@15.1.0:
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      atomically: 2.1.1
+      debounce-fn: 6.0.0
+      dot-prop: 10.1.0
+      env-paths: 3.0.0
+      json-schema-typed: 8.0.2
+      semver: 7.8.1
+      uint8array-extras: 1.5.0
+
   confbox@0.1.8: {}
 
   confbox@0.2.2: {}
+
+  confbox@0.2.4: {}
 
   consola@2.15.3: {}
 
@@ -9411,6 +10295,10 @@ snapshots:
 
   de-indent@1.0.2: {}
 
+  debounce-fn@6.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -9462,6 +10350,18 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  deslop-js@0.0.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+    dependencies:
+      '@oxc-project/types': 0.132.0
+      fast-glob: 3.3.3
+      minimatch: 10.2.5
+      oxc-parser: 0.132.0
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
@@ -9476,6 +10376,10 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dot-prop@10.1.0:
+    dependencies:
+      type-fest: 5.6.0
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -9485,6 +10389,19 @@ snapshots:
   easy-table@1.1.0:
     optionalDependencies:
       wcwidth: 1.0.1
+
+  effect@4.0.0-beta.70:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 4.8.0
+      find-my-way-ts: 0.1.6
+      ini: 7.0.0
+      kubernetes-types: 1.30.0
+      msgpackr: 2.0.2
+      multipasta: 0.2.7
+      toml: 4.1.1
+      uuid: 14.0.0
+      yaml: 2.9.0
 
   ejs@3.1.10:
     dependencies:
@@ -9504,6 +10421,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@8.0.0: {}
+
+  env-paths@3.0.0: {}
 
   es-abstract@1.24.2:
     dependencies:
@@ -9658,6 +10577,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-plugin-react-hooks@7.1.1(eslint@10.0.3(jiti@2.7.0)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      eslint: 10.0.3(jiti@2.7.0)
+      hermes-parser: 0.25.1
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-react-refresh@0.5.2(eslint@10.0.3(jiti@2.7.0)):
     dependencies:
       eslint: 10.0.3(jiti@2.7.0)
@@ -9766,7 +10696,19 @@ snapshots:
 
   exsolve@1.0.7: {}
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -9785,6 +10727,10 @@ snapshots:
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -9812,6 +10758,12 @@ snapshots:
   filelist@1.0.6:
     dependencies:
       minimatch: 5.1.9
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-my-way-ts@0.1.6: {}
 
   find-up@5.0.0:
     dependencies:
@@ -9919,6 +10871,10 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob-parent@6.0.2:
     dependencies:
@@ -10036,11 +10992,20 @@ snapshots:
 
   immer@11.1.8: {}
 
+  import-in-the-middle@3.0.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
   import-lazy@4.0.0: {}
 
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  ini@7.0.0: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -10144,6 +11109,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-number@7.0.0: {}
 
   is-obj@1.0.1: {}
 
@@ -10269,9 +11236,13 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  json-schema-typed@8.0.2: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonfile@6.2.1:
     dependencies:
@@ -10285,7 +11256,11 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kleur@3.0.3: {}
+
   kolorist@1.8.0: {}
+
+  kubernetes-types@1.30.0: {}
 
   leaflet@1.9.4: {}
 
@@ -10415,11 +11390,20 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mimic-function@5.0.1: {}
 
   min-indent@1.0.1: {}
 
@@ -10454,9 +11438,27 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.1
 
+  module-details-from-path@1.0.4: {}
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
+
+  msgpackr-extract@3.0.4:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
+    optional: true
+
+  msgpackr@2.0.2:
+    optionalDependencies:
+      msgpackr-extract: 3.0.4
 
   msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3):
     dependencies:
@@ -10485,6 +11487,8 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
+  multipasta@0.2.7: {}
+
   mute-stream@1.0.0: {}
 
   mute-stream@4.0.0: {}
@@ -10498,6 +11502,11 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-releases@2.0.46: {}
 
@@ -10565,7 +11574,32 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
       '@oxc-parser/binding-win32-x64-msvc': 0.127.0
 
-  oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+  oxc-parser@0.132.0:
+    dependencies:
+      '@oxc-project/types': 0.132.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.132.0
+      '@oxc-parser/binding-android-arm64': 0.132.0
+      '@oxc-parser/binding-darwin-arm64': 0.132.0
+      '@oxc-parser/binding-darwin-x64': 0.132.0
+      '@oxc-parser/binding-freebsd-x64': 0.132.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.132.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.132.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.132.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.132.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.132.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-x64-musl': 0.132.0
+      '@oxc-parser/binding-openharmony-arm64': 0.132.0
+      '@oxc-parser/binding-wasm32-wasi': 0.132.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.132.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.132.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.132.0
+
+  oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.19.1
       '@oxc-resolver/binding-android-arm64': 11.19.1
@@ -10583,13 +11617,42 @@ snapshots:
       '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-musl': 11.19.1
       '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
       '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  oxlint-plugin-react-doctor@0.2.16:
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      oxc-parser: 0.132.0
+
+  oxlint@1.68.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.68.0
+      '@oxlint/binding-android-arm64': 1.68.0
+      '@oxlint/binding-darwin-arm64': 1.68.0
+      '@oxlint/binding-darwin-x64': 1.68.0
+      '@oxlint/binding-freebsd-x64': 1.68.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.68.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.68.0
+      '@oxlint/binding-linux-arm64-gnu': 1.68.0
+      '@oxlint/binding-linux-arm64-musl': 1.68.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.68.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.68.0
+      '@oxlint/binding-linux-riscv64-musl': 1.68.0
+      '@oxlint/binding-linux-s390x-gnu': 1.68.0
+      '@oxlint/binding-linux-x64-gnu': 1.68.0
+      '@oxlint/binding-linux-x64-musl': 1.68.0
+      '@oxlint/binding-openharmony-arm64': 1.68.0
+      '@oxlint/binding-win32-arm64-msvc': 1.68.0
+      '@oxlint/binding-win32-ia32-msvc': 1.68.0
+      '@oxlint/binding-win32-x64-msvc': 1.68.0
 
   p-limit@3.1.0:
     dependencies:
@@ -10685,6 +11748,11 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
   proxy-agent@8.0.1:
     dependencies:
       agent-base: 9.0.0
@@ -10702,7 +11770,11 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pure-rand@8.4.0: {}
+
   quansync@0.2.10: {}
+
+  queue-microtask@1.2.3: {}
 
   quickjs-wasi@2.2.0: {}
 
@@ -10736,6 +11808,34 @@ snapshots:
       strip-indent: 4.1.1
     transitivePeerDependencies:
       - supports-color
+
+  react-doctor@0.2.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@10.0.3(jiti@2.7.0)):
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@effect/platform-node-shared': 4.0.0-beta.70(effect@4.0.0-beta.70)
+      '@sentry/node': 10.55.0
+      agent-install: 0.0.5
+      conf: 15.1.0
+      confbox: 0.2.4
+      deslop-js: 0.0.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      effect: 4.0.0-beta.70
+      eslint-plugin-react-hooks: 7.1.1(eslint@10.0.3(jiti@2.7.0))
+      jiti: 2.7.0
+      magicast: 0.5.3
+      oxlint: 1.68.0
+      oxlint-plugin-react-doctor: 0.2.16
+      prompts: 2.4.2
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - bufferutil
+      - eslint
+      - oxlint-tsgolint
+      - supports-color
+      - utf-8-validate
+      - vite-plus
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:
@@ -10885,6 +11985,13 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   reselect@5.1.1: {}
 
   resolve-pkg-maps@1.0.0:
@@ -10904,6 +12011,8 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   rettime@0.11.11: {}
+
+  reusify@1.1.0: {}
 
   rollup@2.80.0:
     optionalDependencies:
@@ -10943,6 +12052,10 @@ snapshots:
   run-applescript@7.1.0: {}
 
   run-async@3.0.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   rxjs@7.8.2:
     dependencies:
@@ -11065,6 +12178,8 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  sisteransi@1.0.5: {}
+
   smart-buffer@4.2.0: {}
 
   smob@1.6.2: {}
@@ -11115,7 +12230,7 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -11127,7 +12242,7 @@ snapshots:
       esbuild: 0.27.7
       open: 10.2.0
       oxc-parser: 0.127.0
-      oxc-resolver: 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       recast: 0.23.11
       semver: 7.8.1
       use-sync-external-store: 1.6.0(react@19.2.6)
@@ -11221,6 +12336,12 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -11285,11 +12406,17 @@ snapshots:
     dependencies:
       tldts-core: 7.4.0
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   token-types@6.1.2:
     dependencies:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  toml@4.1.1: {}
 
   totalist@3.0.1: {}
 
@@ -11402,6 +12529,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  typescript@6.0.3: {}
+
   ufo@1.6.1: {}
 
   uid@2.0.2:
@@ -11490,6 +12619,8 @@ snapshots:
 
   uuid@10.0.0: {}
 
+  uuid@14.0.0: {}
+
   victory-vendor@37.3.6:
     dependencies:
       '@types/d3-array': 3.2.2
@@ -11507,7 +12638,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-plugin-dts@4.5.4(@types/node@25.9.1)(rollup@4.57.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)):
+  vite-plugin-dts@4.5.4(@types/node@25.9.1)(rollup@4.57.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@microsoft/api-extractor': 7.52.8(@types/node@25.9.1)
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
@@ -11520,39 +12651,39 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.9.3
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-pwa@1.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.1):
+  vite-plugin-pwa@1.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.1):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.16
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       workbox-build: 7.4.0(@types/babel__core@7.20.5)
       workbox-window: 7.4.1
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-top-level-await@1.6.0(rollup@2.80.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)):
+  vite-plugin-top-level-await@1.6.0(rollup@2.80.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@2.80.0)
       '@swc/core': 1.15.33
       '@swc/wasm': 1.15.33
       uuid: 10.0.0
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
 
-  vite-plugin-wasm@3.6.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)):
+  vite-plugin-wasm@3.6.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0):
+  vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -11567,12 +12698,12 @@ snapshots:
       lightningcss: 1.32.0
       terser: 5.48.0
       tsx: 4.21.0
-      yaml: 2.8.0
+      yaml: 2.9.0
 
-  vitest@4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0))
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -11589,9 +12720,10 @@ snapshots:
       tinyexec: 1.2.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.1
       '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
       '@vitest/ui': 4.1.7(vitest@4.1.7)
@@ -11638,6 +12770,8 @@ snapshots:
       lodash.sortby: 4.7.0
       tr46: 1.0.1
       webidl-conversions: 4.0.2
+
+  when-exit@2.1.5: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -11839,8 +12973,7 @@ snapshots:
 
   yallist@4.0.0: {}
 
-  yaml@2.8.0:
-    optional: true
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
Move pure helpers and static literals out of component bodies so they are allocated once at module scope instead of on every render, and drop useMemo/useCallback wrappers that no longer serve a purpose. Also normalises tailwind size utilities, replaces three-dot strings with the typographic ellipsis, and minor maintainability cleanups across components, hooks, routes, and the map layer.