### PR TITLE
fix(frontend): restore pagination on tree list (GECO-129)

### DIFF
--- a/frontend/app/src/routes/_protected/trees/index.test.ts
+++ b/frontend/app/src/routes/_protected/trees/index.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import type { z } from 'zod'
+import { Route } from './index'
+
+const parseSearch = (input: Record<string, unknown>) =>
+  (Route.options.validateSearch as unknown as z.ZodSchema<{ page: number }>).parse(input)
+
+const loaderDeps = Route.options.loaderDeps as unknown as (opts: {
+  search: Record<string, unknown>
+}) => { page: number }
+
+describe('/trees route pagination (GECO-129)', () => {
+  it('parses page from search params', () => {
+    expect(parseSearch({ page: 2 }).page).toBe(2)
+  })
+
+  it('falls back to page 1 when page is missing or invalid', () => {
+    expect(parseSearch({}).page).toBe(1)
+    expect(parseSearch({ page: 'invalid' }).page).toBe(1)
+  })
+
+  it('passes page from search params through loaderDeps', () => {
+    expect(loaderDeps({ search: { page: 3 } }).page).toBe(3)
+  })
+})

--- a/frontend/app/src/routes/_protected/trees/index.tsx
+++ b/frontend/app/src/routes/_protected/trees/index.tsx
@@ -18,6 +18,7 @@ const treeFilterSchema = z.object({
   wateringStatuses: z.array(z.string()).optional(),
   hasCluster: z.boolean().optional(),
   plantingYears: z.array(z.number()).optional(),
+  page: z.number().catch(1),
 })
 
 function Trees() {
@@ -26,7 +27,7 @@ function Trees() {
   })
   const { data: treesRes } = useSuspenseQuery(
     treeQuery({
-      page: page ?? 1,
+      page,
       perPage: 10,
     }),
   )
@@ -108,7 +109,7 @@ export const Route = createFileRoute('/_protected/trees/')({
     wateringStatuses: search.wateringStatuses ?? undefined,
     hasCluster: search.hasCluster ?? undefined,
     plantingYears: search.plantingYears ?? undefined,
-    page: 1,
+    page: search.page,
   }),
   loader: ({
     deps: { page, wateringStatuses, hasCluster, plantingYears },


### PR DESCRIPTION
The `/trees` route search schema did not declare the page param, so zod stripped it and `loaderDeps` hardcoded page 1. Page navigation never changed the fetched page. Declare page in the schema and pass it through `loaderDeps`, matching the other paginated routes.