### PR TITLE
fix(sensor): populate latest_reading in view_search and view_by_ids (GECO-144)

### DIFF
--- a/backend-rs/.sqlx/query-358a97e0e07d7203951cb7dc7c1de9bdc9cb920548b5975d9f9f6398056af4c8.json
+++ b/backend-rs/.sqlx/query-358a97e0e07d7203951cb7dc7c1de9bdc9cb920548b5975d9f9f6398056af4c8.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT s.id, s.created_at, s.updated_at,\n                      s.activated_at,\n                      s.type          AS \"sensor_type: SensorType\",\n                      s.provider,\n                      s.additional_informations AS \"additional_info: serde_json::Value\",\n                      sm.id           AS model_id,\n                      sm.name         AS model_name,\n                      t.id            AS \"linked_tree_id?\",\n                      t.latitude      AS \"tree_lat?\",\n                      t.longitude     AS \"tree_lng?\",\n                      sl.serial_number AS \"serial_number?\",\n                      sl.dev_eui       AS \"dev_eui?\",\n                      sl.app_eui       AS \"app_eui?\",\n                      sl.at_pin,\n                      sl.ota_pin,\n                      sl.config        AS \"config: serde_json::Value\",\n                      (SELECT sd.id FROM sensor_data sd WHERE sd.sensor_id = s.id\n                       ORDER BY sd.id DESC LIMIT 1) AS \"last_reading_id?: Uuid\"\n            FROM sensors s\n            INNER JOIN sensor_models sm ON sm.id = s.model_id\n            LEFT JOIN sensor_lorawan sl ON sl.id = s.id\n            LEFT JOIN trees t          ON t.sensor_id = s.id\n            WHERE ($1::text IS NULL OR s.provider = $1)\n            ORDER BY s.id\n            LIMIT $2 OFFSET $3",
+  "query": "SELECT s.id, s.created_at, s.updated_at,\n                      s.activated_at,\n                      s.type          AS \"sensor_type: SensorType\",\n                      s.provider,\n                      s.additional_informations AS \"additional_info: serde_json::Value\",\n                      sm.id           AS model_id,\n                      sm.name         AS model_name,\n                      t.id            AS \"linked_tree_id?\",\n                      t.latitude      AS \"tree_lat?\",\n                      t.longitude     AS \"tree_lng?\",\n                      sl.serial_number AS \"serial_number?\",\n                      sl.dev_eui       AS \"dev_eui?\",\n                      sl.app_eui       AS \"app_eui?\",\n                      sl.at_pin,\n                      sl.ota_pin,\n                      sl.config        AS \"config: serde_json::Value\",\n                      lr.id            AS \"last_reading_id?: Uuid\",\n                      lr.updated_at    AS \"last_reading_updated_at?\",\n                      lr.data          AS \"last_reading_data?\"\n            FROM sensors s\n            INNER JOIN sensor_models sm ON sm.id = s.model_id\n            LEFT JOIN sensor_lorawan sl ON sl.id = s.id\n            LEFT JOIN trees t          ON t.sensor_id = s.id\n            LEFT JOIN LATERAL (\n                SELECT sd.id, sd.updated_at, sd.data\n                FROM sensor_data sd\n                WHERE sd.sensor_id = s.id\n                ORDER BY sd.id DESC\n                LIMIT 1\n            ) lr ON true\n            WHERE s.id = ANY($1::text[])",
   "describe": {
     "columns": [
       {
@@ -106,13 +106,21 @@
         "ordinal": 18,
         "name": "last_reading_id?: Uuid",
         "type_info": "Uuid"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_reading_updated_at?",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 20,
+        "name": "last_reading_data?",
+        "type_info": "Jsonb"
       }
     ],
     "parameters": {
       "Left": [
-        "Text",
-        "Int8",
-        "Int8"
+        "TextArray"
       ]
     },
     "nullable": [
@@ -125,17 +133,19 @@
       true,
       false,
       false,
-      false,
-      false,
-      false,
-      false,
-      false,
-      false,
       true,
       true,
       true,
-      null
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true
     ]
   },
-  "hash": "acd4142a8a413b8892a3347048f3fb145f9437b3ea9cd82125ae00598a990bb3"
+  "hash": "358a97e0e07d7203951cb7dc7c1de9bdc9cb920548b5975d9f9f6398056af4c8"
 }

--- a/backend-rs/.sqlx/query-45e417fdb7fc8a3437418742a88cebed37bd2119ffc6636f3fea5bf8290dc0a7.json
+++ b/backend-rs/.sqlx/query-45e417fdb7fc8a3437418742a88cebed37bd2119ffc6636f3fea5bf8290dc0a7.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO trees (id, sensor_id, planting_year, species, number, latitude, longitude,\n                              geometry, description)\n        VALUES ($1, 'sensor-tree-data', 2020, 'Eiche', 'T-DATA', 53.55, 9.99,\n                ST_SetSRID(ST_MakePoint(9.99, 53.55), 4326), 'Test')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "45e417fdb7fc8a3437418742a88cebed37bd2119ffc6636f3fea5bf8290dc0a7"
+}

--- a/backend-rs/.sqlx/query-831a591e9bb18c8cff690446cc7df990b6a9f47ff56ac5c70839239e4579e2f4.json
+++ b/backend-rs/.sqlx/query-831a591e9bb18c8cff690446cc7df990b6a9f47ff56ac5c70839239e4579e2f4.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT s.id, s.created_at, s.updated_at,\n                      s.activated_at,\n                      s.type          AS \"sensor_type: SensorType\",\n                      s.provider,\n                      s.additional_informations AS \"additional_info: serde_json::Value\",\n                      sm.id           AS model_id,\n                      sm.name         AS model_name,\n                      t.id            AS \"linked_tree_id?\",\n                      t.latitude      AS \"tree_lat?\",\n                      t.longitude     AS \"tree_lng?\",\n                      sl.serial_number AS \"serial_number?\",\n                      sl.dev_eui       AS \"dev_eui?\",\n                      sl.app_eui       AS \"app_eui?\",\n                      sl.at_pin,\n                      sl.ota_pin,\n                      sl.config        AS \"config: serde_json::Value\",\n                      (SELECT sd.id FROM sensor_data sd WHERE sd.sensor_id = s.id\n                       ORDER BY sd.id DESC LIMIT 1) AS \"last_reading_id?: Uuid\"\n            FROM sensors s\n            INNER JOIN sensor_models sm ON sm.id = s.model_id\n            LEFT JOIN sensor_lorawan sl ON sl.id = s.id\n            LEFT JOIN trees t          ON t.sensor_id = s.id\n            WHERE s.id = ANY($1::text[])",
+  "query": "SELECT s.id, s.created_at, s.updated_at,\n                      s.activated_at,\n                      s.type          AS \"sensor_type: SensorType\",\n                      s.provider,\n                      s.additional_informations AS \"additional_info: serde_json::Value\",\n                      sm.id           AS model_id,\n                      sm.name         AS model_name,\n                      t.id            AS \"linked_tree_id?\",\n                      t.latitude      AS \"tree_lat?\",\n                      t.longitude     AS \"tree_lng?\",\n                      sl.serial_number AS \"serial_number?\",\n                      sl.dev_eui       AS \"dev_eui?\",\n                      sl.app_eui       AS \"app_eui?\",\n                      sl.at_pin,\n                      sl.ota_pin,\n                      sl.config        AS \"config: serde_json::Value\",\n                      lr.id            AS \"last_reading_id?: Uuid\",\n                      lr.updated_at    AS \"last_reading_updated_at?\",\n                      lr.data          AS \"last_reading_data?\"\n            FROM sensors s\n            INNER JOIN sensor_models sm ON sm.id = s.model_id\n            LEFT JOIN sensor_lorawan sl ON sl.id = s.id\n            LEFT JOIN trees t          ON t.sensor_id = s.id\n            LEFT JOIN LATERAL (\n                SELECT sd.id, sd.updated_at, sd.data\n                FROM sensor_data sd\n                WHERE sd.sensor_id = s.id\n                ORDER BY sd.id DESC\n                LIMIT 1\n            ) lr ON true\n            WHERE ($1::text IS NULL OR s.provider = $1)\n            ORDER BY s.id\n            LIMIT $2 OFFSET $3",
   "describe": {
     "columns": [
       {
@@ -106,11 +106,23 @@
         "ordinal": 18,
         "name": "last_reading_id?: Uuid",
         "type_info": "Uuid"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_reading_updated_at?",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 20,
+        "name": "last_reading_data?",
+        "type_info": "Jsonb"
       }
     ],
     "parameters": {
       "Left": [
-        "TextArray"
+        "Text",
+        "Int8",
+        "Int8"
       ]
     },
     "nullable": [
@@ -126,14 +138,16 @@
       true,
       true,
       true,
+      false,
+      false,
+      false,
       true,
       true,
       true,
       true,
       true,
-      true,
-      null
+      true
     ]
   },
-  "hash": "bff976b25086330383ea028ff90422094cb4c8b9b198237415dc3d85bfb76271"
+  "hash": "831a591e9bb18c8cff690446cc7df990b6a9f47ff56ac5c70839239e4579e2f4"
 }

--- a/backend-rs/crates/server/src/infra/pg_sensor.rs
+++ b/backend-rs/crates/server/src/infra/pg_sensor.rs
@@ -165,8 +165,6 @@ impl SensorReader for PgSensorRepository {
         .await?
         .ok_or(RepositoryError::NotFound)?;
 
-        // sensor_data.created_at was dropped; order by id (UUID v7) which
-        // preserves chronological order via its embedded timestamp.
         let latest_reading = sqlx::query!(
             r#"SELECT id, sensor_id, updated_at, data
             FROM sensor_data WHERE sensor_id = $1
@@ -237,12 +235,20 @@ impl SensorReader for PgSensorRepository {
                       sl.at_pin,
                       sl.ota_pin,
                       sl.config        AS "config: serde_json::Value",
-                      (SELECT sd.id FROM sensor_data sd WHERE sd.sensor_id = s.id
-                       ORDER BY sd.id DESC LIMIT 1) AS "last_reading_id?: Uuid"
+                      lr.id            AS "last_reading_id?: Uuid",
+                      lr.updated_at    AS "last_reading_updated_at?",
+                      lr.data          AS "last_reading_data?"
             FROM sensors s
             INNER JOIN sensor_models sm ON sm.id = s.model_id
             LEFT JOIN sensor_lorawan sl ON sl.id = s.id
             LEFT JOIN trees t          ON t.sensor_id = s.id
+            LEFT JOIN LATERAL (
+                SELECT sd.id, sd.updated_at, sd.data
+                FROM sensor_data sd
+                WHERE sd.sensor_id = s.id
+                ORDER BY sd.id DESC
+                LIMIT 1
+            ) lr ON true
             WHERE s.id = ANY($1::text[])"#,
             &ids as &[&str]
         )
@@ -251,9 +257,15 @@ impl SensorReader for PgSensorRepository {
 
         rows.into_iter()
             .map(|r| {
+                let latest_reading = build_latest_reading(
+                    &r.id,
+                    r.last_reading_id,
+                    r.last_reading_updated_at,
+                    r.last_reading_data,
+                );
                 let status = derive_connectivity(
                     r.activated_at.map(|t| t.and_utc()),
-                    r.last_reading_id.and_then(|id| uuid_v7_timestamp(&id)),
+                    latest_reading.as_ref().map(|lr| lr.created_at),
                     Utc::now(),
                     self.offline_after,
                 );
@@ -279,7 +291,7 @@ impl SensorReader for PgSensorRepository {
                         r.ota_pin,
                         r.config,
                     ),
-                    latest_reading: None,
+                    latest_reading,
                 })
             })
             .collect()
@@ -320,12 +332,20 @@ impl SensorReader for PgSensorRepository {
                       sl.at_pin,
                       sl.ota_pin,
                       sl.config        AS "config: serde_json::Value",
-                      (SELECT sd.id FROM sensor_data sd WHERE sd.sensor_id = s.id
-                       ORDER BY sd.id DESC LIMIT 1) AS "last_reading_id?: Uuid"
+                      lr.id            AS "last_reading_id?: Uuid",
+                      lr.updated_at    AS "last_reading_updated_at?",
+                      lr.data          AS "last_reading_data?"
             FROM sensors s
             INNER JOIN sensor_models sm ON sm.id = s.model_id
             LEFT JOIN sensor_lorawan sl ON sl.id = s.id
             LEFT JOIN trees t          ON t.sensor_id = s.id
+            LEFT JOIN LATERAL (
+                SELECT sd.id, sd.updated_at, sd.data
+                FROM sensor_data sd
+                WHERE sd.sensor_id = s.id
+                ORDER BY sd.id DESC
+                LIMIT 1
+            ) lr ON true
             WHERE ($1::text IS NULL OR s.provider = $1)
             ORDER BY s.id
             LIMIT $2 OFFSET $3"#,
@@ -339,9 +359,15 @@ impl SensorReader for PgSensorRepository {
         let items = rows
             .into_iter()
             .map(|r| {
+                let latest_reading = build_latest_reading(
+                    &r.id,
+                    r.last_reading_id,
+                    r.last_reading_updated_at,
+                    r.last_reading_data,
+                );
                 let status = derive_connectivity(
                     r.activated_at.map(|t| t.and_utc()),
-                    r.last_reading_id.and_then(|id| uuid_v7_timestamp(&id)),
+                    latest_reading.as_ref().map(|lr| lr.created_at),
                     Utc::now(),
                     self.offline_after,
                 );
@@ -367,7 +393,7 @@ impl SensorReader for PgSensorRepository {
                         r.ota_pin,
                         r.config,
                     ),
-                    latest_reading: None,
+                    latest_reading,
                 })
             })
             .collect::<Result<Vec<_>, RepositoryError>>()?;
@@ -624,6 +650,27 @@ fn build_lorawan_info(
         at_pin,
         ota_pin,
         config,
+    })
+}
+
+/// Builds the embedded `latest_reading` from a LATERAL-joined newest row.
+/// All three columns come from the same `LEFT JOIN LATERAL`, so they are
+/// either all present (a reading exists) or all absent.
+fn build_latest_reading(
+    sensor_id: &str,
+    id: Option<Uuid>,
+    updated_at: Option<chrono::NaiveDateTime>,
+    data: Option<serde_json::Value>,
+) -> Option<SensorReadingView> {
+    let (Some(id), Some(updated_at), Some(data)) = (id, updated_at, data) else {
+        return None;
+    };
+    Some(SensorReadingView {
+        created_at: uuid_v7_timestamp(&id).expect("sensor_data.id is minted as uuid v7"),
+        id,
+        sensor_id: sensor_id.to_owned(),
+        updated_at: updated_at.and_utc(),
+        data,
     })
 }
 

--- a/backend-rs/crates/server/test/api/sensors.rs
+++ b/backend-rs/crates/server/test/api/sensors.rs
@@ -21,6 +21,18 @@ async fn insert_sensor(app: &crate::helpers::TestApp, id: &str) {
     .unwrap();
 }
 
+async fn insert_reading(app: &crate::helpers::TestApp, sensor_id: &str, data: serde_json::Value) {
+    sqlx::query!(
+        r#"INSERT INTO sensor_data (id, sensor_id, data) VALUES ($1, $2, $3)"#,
+        uuid::Uuid::now_v7(),
+        sensor_id,
+        data,
+    )
+    .execute(&app.db_pool)
+    .await
+    .unwrap();
+}
+
 #[tokio::test]
 async fn list_sensors_returns_200() {
     let app = spawn_app().await;
@@ -290,6 +302,72 @@ async fn ingest_via_create_and_activate_updates_watering_status() {
             .await
             .unwrap();
     assert_eq!(linked_sensor.as_deref(), Some("sensor-mq-1"));
+}
+
+#[tokio::test]
+async fn list_sensors_includes_latest_reading() {
+    let app = spawn_app().await;
+
+    insert_sensor(&app, "sensor-latest").await;
+    insert_reading(
+        &app,
+        "sensor-latest",
+        serde_json::json!({"temperature": 22.5}),
+    )
+    .await;
+
+    let response = app.get("/api/v1/sensors").await;
+    let body: serde_json::Value = response.json().await.unwrap();
+
+    let sensor = &body["data"][0];
+    assert_eq!(sensor["id"], "sensor-latest");
+
+    let latest = &sensor["latest_data"];
+    assert!(
+        !latest.is_null(),
+        "latest_data should be present in the list response, got: {sensor}"
+    );
+    assert_eq!(latest["data"]["temperature"], 22.5);
+    assert!(latest["id"].is_string());
+    assert!(latest["created_at"].is_string());
+    assert!(latest["updated_at"].is_string());
+}
+
+#[tokio::test]
+async fn list_trees_embeds_sensor_latest_reading() {
+    let app = spawn_app().await;
+
+    insert_sensor(&app, "sensor-tree-data").await;
+    sqlx::query!(
+        r#"INSERT INTO trees (id, sensor_id, planting_year, species, number, latitude, longitude,
+                              geometry, description)
+        VALUES ($1, 'sensor-tree-data', 2020, 'Eiche', 'T-DATA', 53.55, 9.99,
+                ST_SetSRID(ST_MakePoint(9.99, 53.55), 4326), 'Test')"#,
+        uuid::Uuid::now_v7(),
+    )
+    .execute(&app.db_pool)
+    .await
+    .unwrap();
+    insert_reading(
+        &app,
+        "sensor-tree-data",
+        serde_json::json!({"temperature": 19.1}),
+    )
+    .await;
+
+    // The tree list endpoint batch-resolves embedded sensors via view_by_ids.
+    let response = app.get("/api/v1/trees").await;
+    assert_eq!(response.status().as_u16(), 200);
+
+    let body: serde_json::Value = response.json().await.unwrap();
+    let tree = &body["data"][0];
+    let latest = &tree["sensor"]["latest_data"];
+    assert!(
+        !latest.is_null(),
+        "latest_data should be embedded via view_by_ids, got: {}",
+        tree["sensor"]
+    );
+    assert_eq!(latest["data"]["temperature"], 19.1);
 }
 
 #[tokio::test]

--- a/frontend/app/src/components/general/cards/SensorCard.tsx
+++ b/frontend/app/src/components/general/cards/SensorCard.tsx
@@ -35,7 +35,6 @@ const SensorCard: React.FC<SensorCardProps> = ({ sensor }) => {
 
         <div>
           <ListCardTitle className="mb-0.5">ID: {sensor.id}</ListCardTitle>
-          {/* TODO: treeSensorIdQuery was removed - needs a dedicated endpoint in the Rust backend */}
           <p className="text-dark-800 text-sm">Sensor-Details</p>
         </div>
 


### PR DESCRIPTION
`view_search` and `view_by_ids` only selected the last reading id (used for connectivity), leaving `latest_reading: None`. Replace the correlated subquery with a `LEFT JOIN LATERAL` returning the full newest row so the embedded `latest_data` appears in the sensor list and in batch-resolved embedded sensors
