### PR TITLE
feat(logging): lift request_id to a top-level log field (GECO-227)

### DIFF
--- a/backend-rs/crates/server/src/telemetry.rs
+++ b/backend-rs/crates/server/src/telemetry.rs
@@ -9,8 +9,8 @@
 //! Rules:
 //! - `request_id` is the correlation key. It is set once on the `http_request` span
 //!   (see `http/tracing.rs`) and inherited by every event within the request via the span
-//!   scope (`with_span_list`; surfaced as `spans[0].request_id` in JSON); inline events must
-//!   not set it again.
+//!   scope; in JSON it is lifted to a top-level `request_id` field (see the Loki/Promtail
+//!   contract below). Inline events must not set it again.
 //! - `error` always carries the error's `Display` string; `kind` carries a stable,
 //!   low-cardinality category (`"auth"`, `"repository"`, ...).
 //! - Domain identifiers are `<entity>.id` (`tree.id`, `cluster.id`, ...); other attributes
@@ -47,11 +47,18 @@
 //! - Parse the `timestamp` field as RFC3339.
 //! - `level` is upper-case; Grafana detects it case-insensitively. Lower-casing, if wanted, is a
 //!   Promtail `template` stage, not a backend change.
-//! - `request_id` is currently nested: extract via `| json request_id="spans[0].request_id"`.
-//!   Promoting it to a flat top-level field is a separate, forthcoming change.
+//! - `request_id` is a top-level field on every event within a request — filter with
+//!   `| json | request_id="…"`. It is also retained inside `spans[0]` for span context, and is
+//!   always a query-time field, never a stream label (cardinality).
 
+use tracing::{Event, Subscriber};
 use tracing_subscriber::{
-    EnvFilter, fmt, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
+    EnvFilter, fmt,
+    fmt::format::{FmtSpan, Format, Json, Writer},
+    fmt::{FmtContext, FormatEvent, FormatFields},
+    layer::SubscriberExt,
+    registry::LookupSpan,
+    util::SubscriberInitExt,
 };
 
 use crate::configuration::{LogFormat, LogSettings};
@@ -64,20 +71,89 @@ pub fn init(config: &LogSettings) {
     let registry = tracing_subscriber::registry().with(env_filter);
 
     match config.format {
-        LogFormat::Json => registry
-            .with(
-                fmt::layer()
-                    .json()
-                    .flatten_event(true)
-                    .with_current_span(false)
-                    .with_span_list(true)
-                    .with_span_events(FmtSpan::CLOSE),
-            )
-            .init(),
+        LogFormat::Json => {
+            let mut layer = fmt::layer().json().event_format(request_id_json_format());
+            layer.set_span_events(FmtSpan::CLOSE);
+            registry.with(layer).init()
+        }
         LogFormat::Pretty => registry
             .with(fmt::layer().with_span_events(FmtSpan::CLOSE))
             .init(),
     }
+}
+
+/// Builds the JSON event formatter used in production: the standard flat-JSON layout plus
+/// `request_id` lifted to the top level.
+fn request_id_json_format() -> RequestIdJson {
+    RequestIdJson {
+        inner: fmt::format()
+            .json()
+            .flatten_event(true)
+            .with_current_span(false)
+            .with_span_list(true),
+    }
+}
+
+/// JSON event formatter that lifts `request_id` from the span scope to the top level.
+///
+/// `tracing-subscriber` cannot promote a span field to the top level, so the inner formatter
+/// renders the standard line and we move the span's `request_id` up afterwards. The value is
+/// still retained inside `spans[0]`.
+struct RequestIdJson {
+    inner: Format<Json>,
+}
+
+impl<S, N> FormatEvent<S, N> for RequestIdJson
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        let mut buf = String::new();
+        self.inner.format_event(ctx, Writer::new(&mut buf), event)?;
+
+        let mut line = match serde_json::from_str::<serde_json::Value>(buf.trim_end()) {
+            Ok(value) => value,
+            Err(_) => return write!(writer, "{buf}"),
+        };
+
+        if lift_request_id(&mut line) {
+            let rendered = serde_json::to_string(&line).map_err(|_| std::fmt::Error)?;
+            writeln!(writer, "{rendered}")
+        } else {
+            write!(writer, "{buf}")
+        }
+    }
+}
+
+/// Moves a span's `request_id` to the top level of `value`. Returns `false` when nothing
+/// changed — no `request_id` in scope, or the event already carries one — so the caller keeps
+/// the already-rendered line instead of re-serializing.
+fn lift_request_id(value: &mut serde_json::Value) -> bool {
+    let Some(object) = value.as_object_mut() else {
+        return false;
+    };
+    if object.contains_key("request_id") {
+        return false;
+    }
+    let Some(request_id) = object
+        .get("spans")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|spans| {
+            spans
+                .iter()
+                .find_map(|span| span.get("request_id").cloned())
+        })
+    else {
+        return false;
+    };
+    object.insert("request_id".to_owned(), request_id);
+    true
 }
 
 #[cfg(test)]
@@ -114,15 +190,20 @@ mod tests {
         }
     }
 
+    fn first_line_json(buf: &Arc<Mutex<Vec<u8>>>) -> serde_json::Value {
+        let raw = String::from_utf8(buf.lock().expect("log buffer not poisoned").clone())
+            .expect("log output is valid utf-8");
+        let line = raw.lines().next().expect("one log line").to_owned();
+        serde_json::from_str(&line).expect("log line is valid json")
+    }
+
     #[test]
-    fn json_event_fields_are_flat_and_span_carries_request_id() {
+    fn json_lifts_request_id_to_top_level_and_keeps_fields_flat() {
         let buf = Arc::new(Mutex::new(Vec::new()));
         let subscriber = tracing_subscriber::registry().with(
             fmt::layer()
                 .json()
-                .flatten_event(true)
-                .with_current_span(false)
-                .with_span_list(true)
+                .event_format(super::request_id_json_format())
                 .with_writer(BufWriter(buf.clone())),
         );
 
@@ -132,12 +213,9 @@ mod tests {
             tracing::info!(tree.id = 5, "tree watered");
         });
 
-        let raw = String::from_utf8(buf.lock().expect("log buffer not poisoned").clone())
-            .expect("log output is valid utf-8");
-        let line = raw.lines().next().expect("one log line");
-        let json: serde_json::Value = serde_json::from_str(line).expect("log line is valid json");
+        let json = first_line_json(&buf);
 
-        // event fields flattened to top level — no `fields` wrapper, no current-span object
+        // event fields flat — no `fields` wrapper, no current-span object
         assert!(
             json.get("fields").is_none(),
             "event fields must be flat: {json}"
@@ -151,8 +229,56 @@ mod tests {
         assert_eq!(json["level"], "INFO");
         assert!(json["timestamp"].is_string());
 
-        // request_id stays in span context, reachable via spans[0]
+        // request_id lifted to the top level, and still retained in span context
+        assert_eq!(json["request_id"], "req-1");
         assert_eq!(json["spans"][0]["request_id"], "req-1");
-        assert_eq!(json["spans"][0]["name"], "http_request");
+    }
+
+    #[test]
+    fn json_without_request_id_passes_through_unchanged() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(
+            fmt::layer()
+                .json()
+                .event_format(super::request_id_json_format())
+                .with_writer(BufWriter(buf.clone())),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(mqtt.topic = "v3/devices/up", "reading ingested");
+        });
+
+        let json = first_line_json(&buf);
+
+        assert!(
+            json.get("request_id").is_none(),
+            "no request_id without a span carrying one: {json}"
+        );
+        assert_eq!(json["message"], "reading ingested");
+        assert_eq!(json["mqtt.topic"], "v3/devices/up");
+    }
+
+    #[test]
+    fn pretty_output_exposes_request_id_inline() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(
+            fmt::layer()
+                .with_ansi(false)
+                .with_writer(BufWriter(buf.clone())),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("http_request", request_id = "req-1");
+            let _guard = span.enter();
+            tracing::info!("tree watered");
+        });
+
+        let raw = String::from_utf8(buf.lock().expect("log buffer not poisoned").clone())
+            .expect("log output is valid utf-8");
+
+        assert!(
+            raw.contains("request_id") && raw.contains("req-1"),
+            "pretty line must expose request_id inline: {raw}"
+        );
     }
 }

--- a/backend-rs/crates/server/test/api/main.rs
+++ b/backend-rs/crates/server/test/api/main.rs
@@ -9,6 +9,7 @@ pub mod helpers;
 pub mod info;
 pub mod plugins;
 pub mod regions;
+pub mod request_id;
 pub mod sensor_activate;
 pub mod sensor_create;
 pub mod sensor_models;

--- a/backend-rs/crates/server/test/api/request_id.rs
+++ b/backend-rs/crates/server/test/api/request_id.rs
@@ -1,0 +1,38 @@
+use crate::helpers::spawn_app;
+
+#[tokio::test]
+async fn response_carries_generated_x_request_id_header() {
+    let app = spawn_app().await;
+
+    let response = app.get("/health").await;
+
+    let header = response
+        .headers()
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok());
+
+    assert!(
+        header.is_some_and(|id| !id.is_empty()),
+        "every response must carry a non-empty x-request-id header, got {header:?}"
+    );
+}
+
+#[tokio::test]
+async fn response_echoes_client_supplied_x_request_id_header() {
+    let app = spawn_app().await;
+
+    let response = reqwest::Client::new()
+        .get(format!("{}/health", app.address))
+        .header("x-request-id", "test-correlation-123")
+        .send()
+        .await
+        .expect("failed to execute request");
+
+    assert_eq!(
+        response
+            .headers()
+            .get("x-request-id")
+            .and_then(|value| value.to_str().ok()),
+        Some("test-correlation-123"),
+    );
+}


### PR DESCRIPTION
Add a thin JSON event formatter (RequestIdJson) that lifts request_id from the span scope to a top-level field, so LogQL can filter via `| json | request_id="…"` without digging into spans[0]; the value is still retained inside spans[0]. The pretty format already shows request_id inline. Add integration tests confirming the x-request-id response header is present (generated) and that a client-supplied id round-trips.
