### PR TITLE
fix(cluster): persist geometry column on tree cluster save (GECO-248)

### DIFF
--- a/backend-rs/.sqlx/query-c4e898e8e3de73e04f3182c0db8b509d1ce12a4c7025d3195f9989f51e1bc946.json
+++ b/backend-rs/.sqlx/query-c4e898e8e3de73e04f3182c0db8b509d1ce12a4c7025d3195f9989f51e1bc946.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "UPDATE tree_clusters SET\n                name = $2, address = $3, description = $4, soil_condition = $5,\n                provider = $6, additional_informations = $7,\n                latitude = $8, longitude = $9, region_id = $10,\n                watering_status = $11, last_watered = $12, archived = $13,\n                moisture_level = $14\n            WHERE id = $1",
+  "query": "UPDATE tree_clusters SET\n                name = $2, address = $3, description = $4, soil_condition = $5,\n                provider = $6, additional_informations = $7,\n                latitude = $8, longitude = $9,\n                geometry = ST_SetSRID(ST_MakePoint($9, $8), 4326),\n                region_id = $10,\n                watering_status = $11, last_watered = $12, archived = $13,\n                moisture_level = $14\n            WHERE id = $1",
   "describe": {
     "columns": [],
     "parameters": {
@@ -79,5 +79,5 @@
     },
     "nullable": []
   },
-  "hash": "c6bd1a3dc9a71cf5c506060499a8fc84367a1537007a6d7f32459835c0a2d8f6"
+  "hash": "c4e898e8e3de73e04f3182c0db8b509d1ce12a4c7025d3195f9989f51e1bc946"
 }

--- a/backend-rs/.sqlx/query-c86bf7454d86ecba88393eb695509c0ad796a7329db9bcee5c6f2a61fea04319.json
+++ b/backend-rs/.sqlx/query-c86bf7454d86ecba88393eb695509c0ad796a7329db9bcee5c6f2a61fea04319.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT ST_X(geometry)::float8 AS \"x: f64\", ST_Y(geometry)::float8 AS \"y: f64\"\n           FROM tree_clusters WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "x: f64",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 1,
+        "name": "y: f64",
+        "type_info": "Float8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "c86bf7454d86ecba88393eb695509c0ad796a7329db9bcee5c6f2a61fea04319"
+}

--- a/backend-rs/crates/server/src/infra/pg_cluster.rs
+++ b/backend-rs/crates/server/src/infra/pg_cluster.rs
@@ -461,7 +461,9 @@ impl TreeClusterWriter for PgTreeClusterRepository {
             r#"UPDATE tree_clusters SET
                 name = $2, address = $3, description = $4, soil_condition = $5,
                 provider = $6, additional_informations = $7,
-                latitude = $8, longitude = $9, region_id = $10,
+                latitude = $8, longitude = $9,
+                geometry = ST_SetSRID(ST_MakePoint($9, $8), 4326),
+                region_id = $10,
                 watering_status = $11, last_watered = $12, archived = $13,
                 moisture_level = $14
             WHERE id = $1"#,

--- a/backend-rs/crates/server/test/api/clusters.rs
+++ b/backend-rs/crates/server/test/api/clusters.rs
@@ -333,6 +333,51 @@ async fn create_cluster_with_trees_computes_center_point() {
 }
 
 #[tokio::test]
+async fn create_cluster_with_trees_persists_geometry_column() {
+    let app = spawn_app().await;
+
+    let tree_id = insert_tree_at(&app, 53.55, 9.99, "T-GEOM").await;
+
+    let body = serde_json::json!({
+        "name": "Geometry Test",
+        "address": "Testweg",
+        "description": "Test",
+        "soil_condition": "Su3",
+        "tree_ids": [tree_id]
+    });
+
+    let response = app.post_json("/api/v1/clusters", &body).await;
+    assert_eq!(response.status().as_u16(), 201);
+
+    let cluster: serde_json::Value = response.json().await.unwrap();
+    let id = uuid::Uuid::parse_str(cluster["id"].as_str().unwrap()).unwrap();
+
+    let row = sqlx::query!(
+        r#"SELECT ST_X(geometry)::float8 AS "x: f64", ST_Y(geometry)::float8 AS "y: f64"
+           FROM tree_clusters WHERE id = $1"#,
+        id,
+    )
+    .fetch_one(&app.db_pool)
+    .await
+    .unwrap();
+
+    let x = row
+        .x
+        .expect("geometry column should be populated, not NULL");
+    let y = row
+        .y
+        .expect("geometry column should be populated, not NULL");
+    assert!(
+        (y - 53.55).abs() < 0.001,
+        "geometry latitude should be ~53.55, got {y}"
+    );
+    assert!(
+        (x - 9.99).abs() < 0.001,
+        "geometry longitude should be ~9.99, got {x}"
+    );
+}
+
+#[tokio::test]
 async fn create_cluster_with_trees_assigns_region() {
     let app = spawn_app().await;
 


### PR DESCRIPTION
The tree_clusters geometry column was never written: save_new's INSERT omits it and save's UPDATE wrote only the scalar latitude/longitude columns. App-created clusters therefore kept geometry NULL, unlike trees which populate it via ST_SetSRID(ST_MakePoint(...), 4326).

Write geometry from latitude/longitude in the UPDATE, mirroring pg_tree. ST_MakePoint is STRICT, so empty clusters (no centroid) keep geometry NULL automatically. Covered by a new integration test asserting the column is populated after creating a cluster with trees.