### PR TITLE
fix(map): make tree/cluster create panels usable on mobile

### DIFF
--- a/frontend/app/src/components/map-gl/MapPanel.tsx
+++ b/frontend/app/src/components/map-gl/MapPanel.tsx
@@ -1,28 +1,72 @@
 import type { PropsWithChildren } from 'react'
-import { Button, cn } from '@green-ecolution/ui'
+import { useState } from 'react'
+import { Button, cn, Drawer, DrawerContent, DrawerTitle } from '@green-ecolution/ui'
 import { X } from 'lucide-react'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 
 interface MapPanelProps extends PropsWithChildren {
   title: string
   onClose: () => void
   className?: string
+  // Collapsed height of the mobile bottom-sheet; tune per flow so longer forms
+  // show a bit more before the user drags up.
+  mobileCollapsedSnap?: string
 }
 
-const MapPanel = ({ title, onClose, className, children }: MapPanelProps) => (
-  <div
-    className={cn(
-      'absolute top-4 right-4 z-[1030] flex max-h-[calc(100%-2rem)] w-[30rem] max-w-[calc(100%-2rem)] flex-col rounded-xl bg-white p-5 font-nunito-sans shadow-xl',
-      className,
-    )}
-  >
-    <div className="mb-4 flex shrink-0 items-center justify-between gap-4">
-      <h2 className="font-lato text-lg font-semibold">{title}</h2>
-      <Button variant="ghost" size="icon" aria-label="Abbrechen" onClick={onClose}>
-        <X />
-      </Button>
+const MapPanel = ({
+  title,
+  onClose,
+  className,
+  children,
+  mobileCollapsedSnap = '360px',
+}: MapPanelProps) => {
+  const isDesktop = useMediaQuery('(min-width: 1024px)')
+  const [snapPoint, setSnapPoint] = useState<number | string | null>(mobileCollapsedSnap)
+  // Collapsed snap keeps the map visible/tappable so the user can pick trees or a
+  // location while the form stays reachable; dragging up to `1` reveals the full form.
+  const snapPoints: (number | string)[] = [mobileCollapsedSnap, 1]
+
+  if (!isDesktop) {
+    return (
+      <Drawer
+        open
+        onOpenChange={(open) => {
+          if (!open) onClose()
+        }}
+        modal={false}
+        snapPoints={snapPoints}
+        activeSnapPoint={snapPoint}
+        setActiveSnapPoint={setSnapPoint}
+      >
+        <DrawerContent showOverlay={false}>
+          <div className="flex shrink-0 items-center justify-between gap-4 px-5 pb-3 pt-1">
+            <DrawerTitle className="font-lato text-lg font-semibold">{title}</DrawerTitle>
+            <Button variant="ghost" size="icon" aria-label="Abbrechen" onClick={onClose}>
+              <X />
+            </Button>
+          </div>
+          <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 pb-5">{children}</div>
+        </DrawerContent>
+      </Drawer>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        'absolute top-4 right-4 z-[1030] flex max-h-[calc(100%-2rem)] w-[30rem] max-w-[calc(100%-2rem)] flex-col rounded-xl bg-white p-5 font-nunito-sans shadow-xl',
+        className,
+      )}
+    >
+      <div className="mb-4 flex shrink-0 items-center justify-between gap-4">
+        <h2 className="font-lato text-lg font-semibold">{title}</h2>
+        <Button variant="ghost" size="icon" aria-label="Abbrechen" onClick={onClose}>
+          <X />
+        </Button>
+      </div>
+      {children}
     </div>
-    {children}
-  </div>
-)
+  )
+}
 
 export default MapPanel

--- a/frontend/app/src/routes/_protected/map/tree/new/index.tsx
+++ b/frontend/app/src/routes/_protected/map/tree/new/index.tsx
@@ -73,7 +73,12 @@ function NewTree() {
 
   return (
     <>
-      <MapPanel title="Neuen Baum erfassen" onClose={handleCancel} className="overflow-y-auto">
+      <MapPanel
+        title="Neuen Baum erfassen"
+        onClose={handleCancel}
+        className="overflow-y-auto"
+        mobileCollapsedSnap="260px"
+      >
         {pos ? (
           <>
             <div className="mb-5 flex items-center gap-3 rounded-lg bg-dark-50 px-3 py-2.5">


### PR DESCRIPTION
The map create/edit panels rendered a fixed top-right overlay that covered the whole viewport on mobile, hiding the very map the user needs to pick trees or a location. Below 1024px MapPanel now renders a collapsible, non-modal bottom sheet (no overlay) reusing the existing cluster-detail drawer pattern, so the map stays visible and tappable. The collapsed snap height is configurable per flow.