### PR TITLE
fix(layout): collapse sidebar to icon rail on iPad-width viewports

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -11,7 +11,7 @@ function App() {
   return (
     <>
       <Header />
-      <main className="flex-1 lg:pl-[16rem]">
+      <main className="flex-1 lg:pl-[4.5rem] xl:pl-[16rem]">
         <Outlet />
       </main>
       <Footer />

--- a/frontend/app/src/components/layout/Footer.tsx
+++ b/frontend/app/src/components/layout/Footer.tsx
@@ -27,7 +27,7 @@ function Footer() {
   ]
 
   return (
-    <footer className={`bg-white lg:pl-[16rem] mt-16 ${isMapPage ? 'hidden' : ''}`}>
+    <footer className={`bg-white lg:pl-[4.5rem] xl:pl-[16rem] mt-16 ${isMapPage ? 'hidden' : ''}`}>
       <div className="container text-sm border-t border-dark-50 py-4 lg:flex lg:justify-between lg:items-center">
         <p className="text-dark-400 mb-5 lg:mb-0">
           Smartes Grünflächenmanagement - Green Ecolution {version}

--- a/frontend/app/src/components/layout/Header.tsx
+++ b/frontend/app/src/components/layout/Header.tsx
@@ -29,7 +29,7 @@ function Header() {
   }, [isLargeScreen])
 
   return (
-    <header className="relative z-10 bg-white lg:pl-[16rem]">
+    <header className="relative z-10 bg-white lg:pl-[4.5rem] xl:pl-[16rem]">
       <div className="container text-sm border-b border-dark-50 py-4 flex justify-between items-center">
         {!isLargeScreen && (
           <Button

--- a/frontend/app/src/components/layout/Navigation.tsx
+++ b/frontend/app/src/components/layout/Navigation.tsx
@@ -171,14 +171,14 @@ const Navigation: React.FC<NavigationProps> = ({ isOpen, closeSidebar }) => {
       id="main-navigation"
       aria-label="Hauptnavigation"
       className={`fixed inset-0 z-50 bg-dark w-screen h-screen flex flex-col ease-in-out duration-300 transition-[left,visibility]
-        lg:left-0 lg:w-[16rem] lg:visible
+        lg:left-0 lg:w-[4.5rem] lg:visible xl:w-[16rem]
         ${isOpen ? 'visible left-0' : 'invisible -left-full'}`}
     >
-      <div className="shrink-0 px-4 pt-5">
+      <div className="shrink-0 px-4 pt-5 lg:px-2 xl:px-4">
         <NavHeader closeSidebar={closeSidebar} />
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto no-scrollbar px-4">
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto no-scrollbar px-4 lg:px-2 xl:px-4">
         {navigationData.map((section) => (
           <React.Fragment key={section.id}>
             <NavHeadline label={section.headline} />

--- a/frontend/app/src/components/navigation/NavHeader.tsx
+++ b/frontend/app/src/components/navigation/NavHeader.tsx
@@ -12,7 +12,7 @@ const NavHeader: React.FC<NavHeader> = ({ closeSidebar }) => {
   const isLargeScreen = useMediaQuery('(min-width: 1024px)')
 
   return (
-    <div className="relative mb-6 flex items-start justify-between">
+    <div className="relative mb-6 flex items-start justify-between lg:justify-center xl:justify-between">
       <Link
         to="/dashboard"
         className="block transition-all ease-in-out duration-300 hover:opacity-75"
@@ -20,9 +20,14 @@ const NavHeader: React.FC<NavHeader> = ({ closeSidebar }) => {
         onClick={closeSidebar}
       >
         <img
-          className="h-9 w-auto"
+          className="h-9 w-auto lg:hidden xl:block"
           src="/images/logo/logo-with-text-white.svg"
           alt="Logo von Green Ecolution — Smartes Grünflächenmanagement"
+        />
+        <img
+          className="hidden h-9 w-auto lg:block xl:hidden"
+          src="/images/logo/logo-icon-white.svg"
+          alt="Green Ecolution"
         />
       </Link>
       {!isLargeScreen && (

--- a/frontend/app/src/components/navigation/NavHeadline.tsx
+++ b/frontend/app/src/components/navigation/NavHeadline.tsx
@@ -8,7 +8,7 @@ const NavHeadline: React.FC<NavHeadline> = ({ label }) => {
   if (!label) return null
 
   return (
-    <p className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-dark-400">
+    <p className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-dark-400 lg:hidden xl:block">
       {label}
     </p>
   )

--- a/frontend/app/src/components/navigation/NavLink.tsx
+++ b/frontend/app/src/components/navigation/NavLink.tsx
@@ -24,11 +24,13 @@ const NavLink = (props: NavLinkProps) => {
           className: 'border-transparent',
         }}
         onClick={closeSidebar}
-        className="flex items-center gap-x-3 text-light border text-sm px-3 py-2.5 rounded-xl transition-all ease-in-out duration-300 hover:bg-green-light/20 hover:text-green-light-200"
+        title={label}
+        aria-label={label}
+        className="flex items-center gap-x-3 text-light border text-sm px-3 py-2.5 rounded-xl transition-all ease-in-out duration-300 hover:bg-green-light/20 hover:text-green-light-200 lg:justify-center lg:px-2 xl:justify-start xl:px-3"
         {...linkProps}
       >
         <span className="shrink-0">{icon}</span>
-        <span className="font-lato font-semibold tracking-[0.1]">{label}</span>
+        <span className="font-lato font-semibold tracking-[0.1] lg:hidden xl:inline">{label}</span>
       </Link>
     </li>
   )

--- a/frontend/app/src/components/treecluster/TreeClusterDashboard.tsx
+++ b/frontend/app/src/components/treecluster/TreeClusterDashboard.tsx
@@ -72,7 +72,7 @@ const TreeClusterDashboard = ({ treecluster }: TreeClusterDashboardProps) => {
       </article>
 
       <section className="mt-10">
-        <ul className="flex flex-col gap-y-5 md:grid md:gap-5 md:grid-cols-2 lg:grid-cols-4">
+        <ul className="flex flex-col gap-y-5 md:grid md:gap-5 md:grid-cols-2 xl:grid-cols-4">
           <li className="h-full">
             <StatusCard
               status={wateringStatus.color}


### PR DESCRIPTION
The full 256px sidebar plus desktop-density grids kicked in at lg (1024px), leaving iPad-landscape viewports (1024-1279px) cramped. Shift the tablet->desktop boundary to xl (1280px): in the new 1024-1279px tier the sidebar collapses to a 4.5rem icon rail, reclaiming ~184px for content. Mobile (<1024px) and desktop (>=1280px) are unchanged.

- Navigation/App/Header/Footer: sidebar width and content offset lg:[4.5rem] xl:[16rem]
- NavLink: center icon, hide label, add title/aria-label in rail
- NavHeadline: hide section labels in rail (kept on mobile + desktop)
- NavHeader: icon-only logo in rail
- TreeClusterDashboard: stat cards go 4-up at xl instead of lg (2x2 on iPad)