### PR TITLE
fix(map): float cluster detail panel over the map with shared dialog chrome

### DIFF
--- a/frontend/app/src/components/map-gl/MapPanel.tsx
+++ b/frontend/app/src/components/map-gl/MapPanel.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren } from 'react'
+import type { PropsWithChildren, ReactNode } from 'react'
 import { useState } from 'react'
 import { Button, cn, Drawer, DrawerContent, DrawerTitle } from '@green-ecolution/ui'
 import { X } from 'lucide-react'
@@ -8,23 +8,47 @@ interface MapPanelProps extends PropsWithChildren {
   title: string
   onClose: () => void
   className?: string
+  // Accessible label for the close button (the panel context differs per flow).
+  closeLabel?: string
+  // Extra header control rendered left of the close button (e.g. an edit action).
+  headerAction?: ReactNode
   // Collapsed height of the mobile bottom-sheet; tune per flow so longer forms
   // show a bit more before the user drags up.
   mobileCollapsedSnap?: string
+  // Controlled mobile snap point. Pass both to let the caller expand the sheet
+  // (e.g. on entering edit mode); omit to let MapPanel manage it internally.
+  activeSnapPoint?: number | string | null
+  setActiveSnapPoint?: (snap: number | string | null) => void
 }
 
 const MapPanel = ({
   title,
   onClose,
   className,
+  closeLabel = 'Abbrechen',
+  headerAction,
   children,
   mobileCollapsedSnap = '360px',
+  activeSnapPoint,
+  setActiveSnapPoint,
 }: MapPanelProps) => {
   const isDesktop = useMediaQuery('(min-width: 1024px)')
-  const [snapPoint, setSnapPoint] = useState<number | string | null>(mobileCollapsedSnap)
+  const [internalSnap, setInternalSnap] = useState<number | string | null>(mobileCollapsedSnap)
+  const snapControlled = setActiveSnapPoint !== undefined
+  const snapPoint = snapControlled ? (activeSnapPoint ?? null) : internalSnap
+  const setSnapPoint = setActiveSnapPoint ?? setInternalSnap
   // Collapsed snap keeps the map visible/tappable so the user can pick trees or a
-  // location while the form stays reachable; dragging up to `1` reveals the full form.
+  // location while the panel stays reachable; dragging up to `1` reveals it fully.
   const snapPoints: (number | string)[] = [mobileCollapsedSnap, 1]
+
+  const headerControls = (
+    <div className="flex items-center gap-1">
+      {headerAction}
+      <Button variant="ghost" size="icon" aria-label={closeLabel} onClick={onClose}>
+        <X />
+      </Button>
+    </div>
+  )
 
   if (!isDesktop) {
     return (
@@ -41,9 +65,7 @@ const MapPanel = ({
         <DrawerContent showOverlay={false}>
           <div className="flex shrink-0 items-center justify-between gap-4 px-5 pb-3 pt-1">
             <DrawerTitle className="font-lato text-lg font-semibold">{title}</DrawerTitle>
-            <Button variant="ghost" size="icon" aria-label="Abbrechen" onClick={onClose}>
-              <X />
-            </Button>
+            {headerControls}
           </div>
           <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 pb-5">{children}</div>
         </DrawerContent>
@@ -60,9 +82,7 @@ const MapPanel = ({
     >
       <div className="mb-4 flex shrink-0 items-center justify-between gap-4">
         <h2 className="font-lato text-lg font-semibold">{title}</h2>
-        <Button variant="ghost" size="icon" aria-label="Abbrechen" onClick={onClose}>
-          <X />
-        </Button>
+        {headerControls}
       </div>
       {children}
     </div>

--- a/frontend/app/src/components/map/cluster-panel/ClusterPanel.tsx
+++ b/frontend/app/src/components/map/cluster-panel/ClusterPanel.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Loading } from '@green-ecolution/ui'
+import { Button, Loading } from '@green-ecolution/ui'
+import { Pencil } from 'lucide-react'
 import { isValidUuid, treeClusterIdQuery } from '@/api/queries'
+import MapPanel from '@/components/map-gl/MapPanel'
 import ClusterPanelShell from './ClusterPanelShell'
 import ClusterPanelView from './ClusterPanelView'
 import ClusterPanelEdit from './ClusterPanelEdit'
@@ -11,42 +13,66 @@ interface ClusterPanelProps {
   onClose: () => void
   onOpenDashboard: () => void
   onExpand?: () => void
+  activeSnapPoint?: number | string | null
+  setActiveSnapPoint?: (snap: number | string | null) => void
 }
 
-const ClusterPanel = ({ clusterId, onClose, onOpenDashboard, onExpand }: ClusterPanelProps) => {
+const ClusterPanel = ({
+  clusterId,
+  onClose,
+  onOpenDashboard,
+  onExpand,
+  activeSnapPoint,
+  setActiveSnapPoint,
+}: ClusterPanelProps) => {
   const [mode, setMode] = useState<'view' | 'edit'>('view')
   const { data, isError } = useQuery(treeClusterIdQuery(clusterId))
   const failed = !isValidUuid(clusterId) || isError
 
+  const startEdit = () => {
+    setMode('edit')
+    onExpand?.()
+  }
+
+  const title = mode === 'edit' ? 'Gruppe bearbeiten' : (data?.name ?? 'Baumgruppe')
+
+  const headerAction =
+    data && mode === 'view' ? (
+      <Button variant="ghost" size="icon" aria-label="Gruppe bearbeiten" onClick={startEdit}>
+        <Pencil />
+      </Button>
+    ) : undefined
+
   return (
-    <ClusterPanelShell onClose={onClose}>
-      {data ? (
-        mode === 'view' ? (
-          <ClusterPanelView
-            treecluster={data}
-            onEdit={() => {
-              setMode('edit')
-              onExpand?.()
-            }}
-            onClose={onClose}
-            onOpenDashboard={onOpenDashboard}
-          />
+    <MapPanel
+      title={title}
+      headerAction={headerAction}
+      onClose={onClose}
+      closeLabel="Seitenansicht schließen"
+      mobileCollapsedSnap="260px"
+      activeSnapPoint={activeSnapPoint}
+      setActiveSnapPoint={setActiveSnapPoint}
+    >
+      <ClusterPanelShell onClose={onClose}>
+        {data ? (
+          mode === 'view' ? (
+            <ClusterPanelView treecluster={data} onOpenDashboard={onOpenDashboard} />
+          ) : (
+            <ClusterPanelEdit
+              treecluster={data}
+              onCancel={() => setMode('view')}
+              onSaved={() => setMode('view')}
+            />
+          )
+        ) : failed ? (
+          <p className="py-10 text-center text-dark-600">
+            Die Baumgruppe konnte nicht geladen werden.
+          </p>
         ) : (
-          <ClusterPanelEdit
-            treecluster={data}
-            onCancel={() => setMode('view')}
-            onClose={onClose}
-            onSaved={() => setMode('view')}
-          />
-        )
-      ) : failed ? (
-        <p className="py-10 text-center text-dark-600">
-          Die Baumgruppe konnte nicht geladen werden.
-        </p>
-      ) : (
-        <Loading className="justify-center py-10" label="Lade Baumgruppe..." />
-      )}
-    </ClusterPanelShell>
+          <Loading className="justify-center py-10" label="Lade Baumgruppe..." />
+        )}
+      </ClusterPanelShell>
+    </MapPanel>
   )
 }
 

--- a/frontend/app/src/components/map/cluster-panel/ClusterPanelEdit.test.tsx
+++ b/frontend/app/src/components/map/cluster-panel/ClusterPanelEdit.test.tsx
@@ -37,40 +37,19 @@ afterEach(cleanup)
 
 describe('ClusterPanelEdit', () => {
   it('renders the name field with the initial value', () => {
-    render(
-      <ClusterPanelEdit
-        treecluster={cluster}
-        onCancel={vi.fn()}
-        onClose={vi.fn()}
-        onSaved={vi.fn()}
-      />,
-    )
+    render(<ClusterPanelEdit treecluster={cluster} onCancel={vi.fn()} onSaved={vi.fn()} />)
     expect(screen.getByLabelText(/Name/)).toHaveValue('Hafenspitze')
   })
 
   it('submits on save', async () => {
-    render(
-      <ClusterPanelEdit
-        treecluster={cluster}
-        onCancel={vi.fn()}
-        onClose={vi.fn()}
-        onSaved={vi.fn()}
-      />,
-    )
+    render(<ClusterPanelEdit treecluster={cluster} onCancel={vi.fn()} onSaved={vi.fn()} />)
     await userEvent.click(screen.getByRole('button', { name: 'Speichern' }))
     expect(onSubmit).toHaveBeenCalled()
   })
 
   it('cancels', async () => {
     const onCancel = vi.fn()
-    render(
-      <ClusterPanelEdit
-        treecluster={cluster}
-        onCancel={onCancel}
-        onClose={vi.fn()}
-        onSaved={vi.fn()}
-      />,
-    )
+    render(<ClusterPanelEdit treecluster={cluster} onCancel={onCancel} onSaved={vi.fn()} />)
     await userEvent.click(screen.getByRole('button', { name: 'Abbrechen' }))
     expect(onCancel).toHaveBeenCalledTimes(1)
   })

--- a/frontend/app/src/components/map/cluster-panel/ClusterPanelEdit.tsx
+++ b/frontend/app/src/components/map/cluster-panel/ClusterPanelEdit.tsx
@@ -1,5 +1,4 @@
 import { Controller } from 'react-hook-form'
-import { X } from 'lucide-react'
 import {
   Button,
   FormField,
@@ -18,11 +17,10 @@ import { useClusterPanelEdit } from './useClusterPanelEdit'
 interface ClusterPanelEditProps {
   treecluster: TreeClusterResponse
   onCancel: () => void
-  onClose: () => void
   onSaved: () => void
 }
 
-const ClusterPanelEdit = ({ treecluster, onCancel, onClose, onSaved }: ClusterPanelEditProps) => {
+const ClusterPanelEdit = ({ treecluster, onCancel, onSaved }: ClusterPanelEditProps) => {
   const { form, onSubmit, isPending } = useClusterPanelEdit(treecluster, { onSaved })
   const {
     register,
@@ -38,19 +36,6 @@ const ClusterPanelEdit = ({ treecluster, onCancel, onClose, onSaved }: ClusterPa
         void onSubmit()
       }}
     >
-      <header className="flex items-center justify-between gap-3">
-        <h2 className="font-lato text-xl font-bold text-dark-900">Gruppe bearbeiten</h2>
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label="Seitenansicht schließen"
-          className="hidden rounded-full bg-dark-50 text-dark-500 hover:bg-dark-100 hover:text-dark-700 lg:flex"
-          onClick={onClose}
-        >
-          <X />
-        </Button>
-      </header>
-
       <FormField label="Name" required error={errors.name?.message} {...register('name')} />
       <FormField
         label="Adresse"

--- a/frontend/app/src/components/map/cluster-panel/ClusterPanelShell.tsx
+++ b/frontend/app/src/components/map/cluster-panel/ClusterPanelShell.tsx
@@ -18,11 +18,7 @@ const ClusterPanelShell = ({ onClose, children }: ClusterPanelShellProps) => {
     return () => document.removeEventListener('keydown', handleEscape)
   }, [handleEscape])
 
-  return (
-    <div className="flex h-full flex-col overflow-y-auto px-6 pb-6 pt-4 font-nunito-sans">
-      {children}
-    </div>
-  )
+  return <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">{children}</div>
 }
 
 export default ClusterPanelShell

--- a/frontend/app/src/components/map/cluster-panel/ClusterPanelView.test.tsx
+++ b/frontend/app/src/components/map/cluster-panel/ClusterPanelView.test.tsx
@@ -30,74 +30,33 @@ const cluster = {
 afterEach(cleanup)
 
 describe('ClusterPanelView', () => {
-  it('renders name, address and tree count', () => {
-    render(
-      <ClusterPanelView
-        treecluster={cluster}
-        onEdit={vi.fn()}
-        onClose={vi.fn()}
-        onOpenDashboard={vi.fn()}
-      />,
-    )
-    expect(screen.getByRole('heading', { name: 'Hafenspitze' })).toBeInTheDocument()
+  it('renders address and tree count', () => {
+    render(<ClusterPanelView treecluster={cluster} onOpenDashboard={vi.fn()} />)
     expect(screen.getByText(/Schiffbrücke 12/)).toBeInTheDocument()
+    expect(screen.getByText(/2 Bäume/)).toBeInTheDocument()
   })
 
   it('lists sensor trees first', () => {
-    render(
-      <ClusterPanelView
-        treecluster={cluster}
-        onEdit={vi.fn()}
-        onClose={vi.fn()}
-        onOpenDashboard={vi.fn()}
-      />,
-    )
+    render(<ClusterPanelView treecluster={cluster} onOpenDashboard={vi.fn()} />)
     const items = screen.getAllByTestId('cluster-panel-tree')
     expect(items[0]).toHaveTextContent('Stieleiche')
     expect(items[0]).toHaveTextContent('Sensor-Baum')
   })
 
   it('shows the moisture level scaled to a percentage', () => {
-    render(
-      <ClusterPanelView
-        treecluster={cluster}
-        onEdit={vi.fn()}
-        onClose={vi.fn()}
-        onOpenDashboard={vi.fn()}
-      />,
-    )
+    render(<ClusterPanelView treecluster={cluster} onOpenDashboard={vi.fn()} />)
     expect(screen.getByText('14 %')).toBeInTheDocument()
   })
 
   it('shows the soil temperature from the latest sensor reading', () => {
-    render(
-      <ClusterPanelView
-        treecluster={cluster}
-        onEdit={vi.fn()}
-        onClose={vi.fn()}
-        onOpenDashboard={vi.fn()}
-      />,
-    )
+    render(<ClusterPanelView treecluster={cluster} onOpenDashboard={vi.fn()} />)
     expect(screen.getByText('21.4 °C')).toBeInTheDocument()
   })
 
-  it('fires onEdit, onClose and onOpenDashboard', async () => {
-    const onEdit = vi.fn()
-    const onClose = vi.fn()
+  it('fires onOpenDashboard', async () => {
     const onOpenDashboard = vi.fn()
-    render(
-      <ClusterPanelView
-        treecluster={cluster}
-        onEdit={onEdit}
-        onClose={onClose}
-        onOpenDashboard={onOpenDashboard}
-      />,
-    )
-    await userEvent.click(screen.getByRole('button', { name: 'Gruppe bearbeiten' }))
-    await userEvent.click(screen.getByRole('button', { name: 'Seitenansicht schließen' }))
+    render(<ClusterPanelView treecluster={cluster} onOpenDashboard={onOpenDashboard} />)
     await userEvent.click(screen.getByRole('button', { name: 'Zum Dashboard' }))
-    expect(onEdit).toHaveBeenCalledTimes(1)
-    expect(onClose).toHaveBeenCalledTimes(1)
     expect(onOpenDashboard).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/app/src/components/map/cluster-panel/ClusterPanelView.tsx
+++ b/frontend/app/src/components/map/cluster-panel/ClusterPanelView.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps } from 'react'
-import { MoveRight, Pencil, RadioTower, X } from 'lucide-react'
+import { MoveRight, RadioTower } from 'lucide-react'
 import { format, formatDistanceToNow } from 'date-fns'
 import { de } from 'date-fns/locale'
 import { Badge, Button, StatusCard } from '@green-ecolution/ui'
@@ -11,8 +11,6 @@ import { latestSensorReading, sortTreesSensorFirst, summarizeTopSpecies } from '
 
 interface ClusterPanelViewProps {
   treecluster: TreeClusterResponse
-  onEdit: () => void
-  onClose: () => void
   onOpenDashboard: () => void
 }
 
@@ -29,12 +27,7 @@ const FILLED_BADGE: Record<string, ComponentProps<typeof Badge>['variant']> = {
   'outline-green-dark': 'success',
 }
 
-const ClusterPanelView = ({
-  treecluster,
-  onEdit,
-  onClose,
-  onOpenDashboard,
-}: ClusterPanelViewProps) => {
+const ClusterPanelView = ({ treecluster, onOpenDashboard }: ClusterPanelViewProps) => {
   const status = getWateringStatusDetails(treecluster.wateringStatus)
   const species = summarizeTopSpecies(treecluster.trees)
   const sortedTrees = sortTreesSensorFirst(treecluster.trees)
@@ -55,7 +48,7 @@ const ClusterPanelView = ({
 
   return (
     <div className="flex flex-col gap-y-5">
-      <header className="flex items-center justify-between gap-3">
+      <div className="space-y-2">
         <Badge variant={FILLED_BADGE[status.color] ?? 'muted'} size="lg" className="gap-1.5">
           <span
             className="size-1.5 rounded-full"
@@ -64,32 +57,6 @@ const ClusterPanelView = ({
           />
           {status.label}
         </Badge>
-        <div className="flex items-center gap-1.5">
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Gruppe bearbeiten"
-            className="rounded-full bg-dark-50 text-dark-500 hover:bg-dark-100 hover:text-green-dark"
-            onClick={onEdit}
-          >
-            <Pencil className="stroke-[1.5]" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Seitenansicht schließen"
-            className="hidden rounded-full bg-dark-50 text-dark-500 hover:bg-dark-100 hover:text-dark-700 lg:flex"
-            onClick={onClose}
-          >
-            <X />
-          </Button>
-        </div>
-      </header>
-
-      <div className="space-y-1.5">
-        <h2 className="font-lato text-3xl font-bold leading-tight text-dark-900">
-          {treecluster.name}
-        </h2>
         <p className="text-sm text-dark-600">
           {treecluster.address} · {treeCount} {treeCount === 1 ? 'Baum' : 'Bäume'}
           {species && ` · ${species}`}

--- a/frontend/app/src/routes/_protected/map/route.tsx
+++ b/frontend/app/src/routes/_protected/map/route.tsx
@@ -13,8 +13,7 @@ import MapBackgroundClick from '@/components/map-gl/MapBackgroundClick'
 import MapToolbarBar from '@/components/map/MapToolbarBar'
 import ClusterPanel from '@/components/map/cluster-panel/ClusterPanel'
 import { clusterBoundariesQuery, clusterMarkersQuery } from '@/api/queries'
-import { Drawer, DrawerContent, DrawerTitle, Loading } from '@green-ecolution/ui'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { Loading } from '@green-ecolution/ui'
 import { Suspense, useCallback, useState } from 'react'
 
 const mapSearchParamsSchema = z.object({
@@ -62,7 +61,6 @@ function MapRoot() {
   const { pathname } = useLocation()
   const navigate = useNavigate()
   const search = useSearch({ strict: false })
-  const isDesktop = useMediaQuery('(min-width: 1024px)')
   // Reactive exact-match: matchRoute() didn't reliably re-render MapRoot on
   // pathname-only changes, leaving isIndex stale across /map ↔ sub-route nav.
   const isIndex = pathname === '/map' || pathname === '/map/'
@@ -103,48 +101,19 @@ function MapRoot() {
               </Suspense>
             </MapCanvas>
           </Suspense>
-        </div>
-        {isDesktop && panelClusterId && (
-          <aside
-            key={panelClusterId}
-            className="w-[28rem] shrink-0 border-l border-dark-100 bg-white animate-in slide-in-from-right-[100%] duration-300 ease-out"
-          >
+          {panelClusterId && (
             <ClusterPanel
+              key={panelClusterId}
               clusterId={panelClusterId}
               onClose={handleClosePanel}
               onOpenDashboard={handleOpenDashboard}
+              onExpand={handleExpandPanel}
+              activeSnapPoint={snapPoint}
+              setActiveSnapPoint={setSnapPoint}
             />
-          </aside>
-        )}
+          )}
+        </div>
       </div>
-
-      {!isDesktop && (
-        <Drawer
-          open={!!panelClusterId}
-          onOpenChange={(open) => {
-            if (!open) handleClosePanel()
-          }}
-          modal={false}
-          snapPoints={['260px', 1]}
-          activeSnapPoint={snapPoint}
-          setActiveSnapPoint={setSnapPoint}
-        >
-          <DrawerContent showOverlay={false}>
-            <DrawerTitle className="sr-only">Baumgruppen-Details</DrawerTitle>
-            {panelClusterId && (
-              <div className="min-h-0 flex-1 overflow-hidden">
-                <ClusterPanel
-                  key={panelClusterId}
-                  clusterId={panelClusterId}
-                  onClose={handleClosePanel}
-                  onOpenDashboard={handleOpenDashboard}
-                  onExpand={handleExpandPanel}
-                />
-              </div>
-            )}
-          </DrawerContent>
-        </Drawer>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
The tree-cluster detail panel opened as an in-flow sidebar that shrank the map and rendered its own header (status badge + round icon buttons), so it looked and behaved differently from the create/edit panels.

Route the cluster panel through the same MapPanel component the create flows use: it floats over the map on desktop, keeps the bottom-sheet drawer on mobile, and shares the title + close-button header. MapPanel gains an optional headerAction slot (edit pencil) and a closeLabel; the create routes are unaffected. The status badge moves into the panel body.