### PR TITLE
fix(treecluster): poll cluster dashboard so watering status updates without reload

### DIFF
--- a/frontend/app/src/routes/_protected/treecluster/$treeclusterId/index.tsx
+++ b/frontend/app/src/routes/_protected/treecluster/$treeclusterId/index.tsx
@@ -1,5 +1,7 @@
 import { Loading } from '@green-ecolution/ui'
 import TreeClusterDashboard from '@/components/treecluster/TreeClusterDashboard'
+import { treeClusterIdQuery } from '@/api/queries'
+import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, getRouteApi } from '@tanstack/react-router'
 
 const treeclusterRoute = getRouteApi('/_protected/treecluster/$treeclusterId')
@@ -12,7 +14,12 @@ export const Route = createFileRoute('/_protected/treecluster/$treeclusterId/')(
 })
 
 function SingleTreecluster() {
-  const { treecluster } = treeclusterRoute.useLoaderData()
+  const { treeclusterId } = treeclusterRoute.useParams()
+  const { data: treecluster } = useSuspenseQuery({
+    ...treeClusterIdQuery(treeclusterId),
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+  })
 
   return (
     <div className="container mt-6">


### PR DESCRIPTION
The cluster dashboard rendered from the router loader snapshot, so no query observer ever refetched and the watering status never changed — a problem in the installed PWA where there is no reload button.

Render the page from a live useSuspenseQuery observer with a 30s refetchInterval and refetchOnWindowFocus. The options are observer-scoped, so the shared treeClusterIdQuery (map panel, edit form, tree cards) keeps its current behaviour.