### PR TITLE
feat(sensor): show LoRaWAN send interval on "Letztes Signal" card (GECO-264)

### DIFF
--- a/frontend/app/src/components/sensor/detail/SensorStatusGrid.tsx
+++ b/frontend/app/src/components/sensor/detail/SensorStatusGrid.tsx
@@ -1,6 +1,7 @@
 import { StatusCard } from '@green-ecolution/ui'
 import { getSensorStatusDetails } from '@/hooks/details/useDetailsForSensorStatus'
 import { formatBatteryVoltage, formatLastSeen, parseBatteryVoltage } from './latestDataParsing'
+import { formatSendInterval } from './configParsing'
 import type { Sensor } from '@/api/backendApi'
 
 interface SensorStatusGridProps {
@@ -12,6 +13,7 @@ const SensorStatusGrid = ({ sensor }: SensorStatusGridProps) => {
   const battery = parseBatteryVoltage(sensor.latestData)
   const batteryStatus =
     battery === null ? 'default' : battery < 2.8 ? 'outline-red' : 'outline-green-dark'
+  const sendInterval = formatSendInterval(sensor)
 
   return (
     <section aria-labelledby="sensor-status-heading">
@@ -45,7 +47,11 @@ const SensorStatusGrid = ({ sensor }: SensorStatusGridProps) => {
           <StatusCard
             label="Letztes Signal"
             value={formatLastSeen(sensor.latestData)}
-            description="Letzte Datenübermittlung"
+            description={
+              sendInterval
+                ? `Letzte Datenübermittlung · sendet ${sendInterval}`
+                : 'Letzte Datenübermittlung'
+            }
           />
         </li>
       </ul>

--- a/frontend/app/src/components/sensor/detail/configParsing.test.ts
+++ b/frontend/app/src/components/sensor/detail/configParsing.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import type { Sensor } from '@/api/backendApi'
+import { formatSendInterval } from './configParsing'
+
+const lorawanSensor = (config: Record<string, unknown> | null): Sensor =>
+  ({ sensorType: 'lorawan', lorawan: config ? { config } : {} }) as unknown as Sensor
+
+describe('formatSendInterval', () => {
+  it('formats sub-minute intervals in seconds', () => {
+    expect(formatSendInterval(lorawanSensor({ TDC: '30000' }))).toBe('alle 30 Sek.')
+  })
+
+  it('formats minute intervals', () => {
+    expect(formatSendInterval(lorawanSensor({ TDC: '60000' }))).toBe('alle 1 Min.')
+    expect(formatSendInterval(lorawanSensor({ TDC: '120000' }))).toBe('alle 2 Min.')
+  })
+
+  it('formats hour intervals', () => {
+    expect(formatSendInterval(lorawanSensor({ TDC: '3600000' }))).toBe('alle 1 Std.')
+  })
+
+  it('accepts a numeric TDC value', () => {
+    expect(formatSendInterval(lorawanSensor({ TDC: 300000 }))).toBe('alle 5 Min.')
+  })
+
+  it('returns null when TDC is missing', () => {
+    expect(formatSendInterval(lorawanSensor({ OTAA: '1' }))).toBeNull()
+    expect(formatSendInterval(lorawanSensor(null))).toBeNull()
+  })
+
+  it('returns null for invalid or non-positive TDC', () => {
+    expect(formatSendInterval(lorawanSensor({ TDC: 'abc' }))).toBeNull()
+    expect(formatSendInterval(lorawanSensor({ TDC: '0' }))).toBeNull()
+    expect(formatSendInterval(lorawanSensor({ TDC: '-1000' }))).toBeNull()
+  })
+
+  it('returns null for non-lorawan sensors', () => {
+    const sensor = {
+      sensorType: 'other',
+      lorawan: { config: { TDC: '60000' } },
+    } as unknown as Sensor
+    expect(formatSendInterval(sensor)).toBeNull()
+  })
+})

--- a/frontend/app/src/components/sensor/detail/configParsing.ts
+++ b/frontend/app/src/components/sensor/detail/configParsing.ts
@@ -1,0 +1,18 @@
+import type { Sensor } from '@/api/backendApi'
+
+// LoRaWAN devices report their transmit interval via the TDC AT-command (milliseconds).
+export const formatSendInterval = (sensor: Sensor): string | null => {
+  if (sensor.sensorType !== 'lorawan') return null
+
+  const config = sensor.lorawan?.config as Record<string, unknown> | undefined
+  const ms = Number(config?.TDC)
+  if (!Number.isFinite(ms) || ms <= 0) return null
+
+  const seconds = ms / 1000
+  if (seconds < 60) return `alle ${Math.round(seconds)} Sek.`
+
+  const minutes = seconds / 60
+  if (minutes < 60) return `alle ${Math.round(minutes)} Min.`
+
+  return `alle ${Math.round(minutes / 60)} Std.`
+}


### PR DESCRIPTION
Read the TDC value (ms) from lorawan.config and append the send interval to the "Letztes Signal" card description, e.g. "sendet alle 20 Min.".