### PR TITLE
feat(backend): serve liveness and readiness probes under /api

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -65,6 +65,6 @@ EXPOSE 3020
 ENV APP_ENVIRONMENT=production
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://localhost:3020/health || exit 1
+  CMD wget --quiet --tries=1 --spider http://localhost:3020/api/health || exit 1
 
 ENTRYPOINT ["/usr/bin/tini", "--", "./green-ecolution"]

--- a/backend/crates/server/src/http/health.rs
+++ b/backend/crates/server/src/http/health.rs
@@ -21,8 +21,8 @@ pub fn routes() -> OpenApiRouter<Arc<AppState>> {
     summary = "Liveness probe",
     description = "Lightweight liveness probe for container orchestrators. \
         Returns 200 OK while the HTTP server is responsive; performs no \
-        downstream service checks. Use /ready for a readiness probe \
-        that verifies critical dependencies, or /v1/info/services for a deep \
+        downstream service checks. Use /api/ready for a readiness probe \
+        that verifies critical dependencies, or /api/v1/info/services for a deep \
         services health check.",
     responses(
         (status = 200, description = "Server is alive"),
@@ -47,7 +47,7 @@ pub struct ReadinessResponse {
         critical dependencies (the database) are reachable and returns 200 only \
         when the service can serve traffic; returns 503 otherwise so the pod is \
         pulled from the load balancer. Optional services (auth, MQTT) are \
-        reported by /v1/info/services and do not gate readiness.",
+        reported by /api/v1/info/services and do not gate readiness.",
     responses(
         (status = 200, description = "Service is ready to serve traffic", body = ReadinessResponse),
         (status = 503, description = "A critical dependency is unavailable", body = ReadinessResponse),

--- a/backend/crates/server/src/http/mod.rs
+++ b/backend/crates/server/src/http/mod.rs
@@ -116,7 +116,7 @@ async fn frontend_config_js(
 
 pub fn openapi_doc(base_url: &str) -> utoipa::openapi::OpenApi {
     let (_, mut api) = OpenApiRouter::<Arc<AppState>>::with_openapi(ApiDoc::openapi())
-        .merge(health::routes())
+        .nest("/api", health::routes())
         .nest("/api/v1", v1::public_router().merge(v1::protected_router()))
         .split_for_parts();
 
@@ -131,7 +131,7 @@ pub fn router(
     auth_layer: AuthLayer,
 ) -> Router {
     let (router, mut api) = OpenApiRouter::with_openapi(ApiDoc::openapi())
-        .merge(health::routes())
+        .nest("/api", health::routes())
         .nest("/api/v1", v1::router(auth_layer))
         .split_for_parts();
 

--- a/backend/crates/server/test/api/health.rs
+++ b/backend/crates/server/test/api/health.rs
@@ -4,25 +4,24 @@ use crate::helpers::spawn_app;
 async fn get_health_returns_200() {
     let app = spawn_app().await;
 
-    let response = app.get("/health").await;
+    let response = app.get("/api/health").await;
 
     assert_eq!(response.status().as_u16(), 200);
 }
 
 #[tokio::test]
-async fn get_health_has_no_api_prefix() {
+async fn get_health_lives_under_api_but_not_versioned() {
     let app = spawn_app().await;
 
-    let response = app.get("/api/v1/health").await;
-
-    assert_eq!(response.status().as_u16(), 404);
+    assert_eq!(app.get("/health").await.status().as_u16(), 404);
+    assert_eq!(app.get("/api/v1/health").await.status().as_u16(), 404);
 }
 
 #[tokio::test]
 async fn get_ready_returns_200_when_dependencies_healthy() {
     let app = spawn_app().await;
 
-    let response = app.get("/ready").await;
+    let response = app.get("/api/ready").await;
 
     assert_eq!(response.status().as_u16(), 200);
     let body: serde_json::Value = response.json().await.expect("readiness body is json");
@@ -34,7 +33,7 @@ async fn get_ready_returns_503_when_database_unreachable() {
     let app = spawn_app().await;
     app.db_pool.close().await;
 
-    let response = app.get("/ready").await;
+    let response = app.get("/api/ready").await;
 
     assert_eq!(response.status().as_u16(), 503);
     let body: serde_json::Value = response.json().await.expect("readiness body is json");

--- a/backend/crates/server/test/api/request_id.rs
+++ b/backend/crates/server/test/api/request_id.rs
@@ -4,7 +4,7 @@ use crate::helpers::spawn_app;
 async fn response_carries_generated_x_request_id_header() {
     let app = spawn_app().await;
 
-    let response = app.get("/health").await;
+    let response = app.get("/api/health").await;
 
     let header = response
         .headers()
@@ -22,7 +22,7 @@ async fn response_echoes_client_supplied_x_request_id_header() {
     let app = spawn_app().await;
 
     let response = reqwest::Client::new()
-        .get(format!("{}/health", app.address))
+        .get(format!("{}/api/health", app.address))
         .header("x-request-id", "test-correlation-123")
         .send()
         .await

--- a/compose.app.yaml
+++ b/compose.app.yaml
@@ -16,7 +16,7 @@ services:
           "--quiet",
           "--tries=1",
           "--spider",
-          "http://localhost:3000/ready",
+          "http://localhost:3000/api/ready",
         ]
       interval: 30s
       timeout: 5s


### PR DESCRIPTION
Mount the health/readiness routes with `.nest("/api", ...)` instead of merging them at the root, so they live at /api/health and /api/ready. Behind an ingress that only forwards /api/*, the probes were previously unreachable from outside the cluster.

The client-facing OpenAPI is unchanged: rewrite_paths_for_client strips the /api prefix and the server URL already carries it, so the generated frontend client needs no regeneration.

Update the container healthchecks (Dockerfile, compose.app.yaml) and the integration tests accordingly.