### PR TITLE
fix(auth): stabilize session handling in PWA and desktop

### DIFF
--- a/.docker/infra/keycloak/green-ecolution-realm.json
+++ b/.docker/infra/keycloak/green-ecolution-realm.json
@@ -5,7 +5,7 @@
   "displayNameHtml" : "",
   "notBefore" : 0,
   "defaultSignatureAlgorithm" : "RS256",
-  "revokeRefreshToken" : true,
+  "revokeRefreshToken" : false,
   "refreshTokenMaxReuse" : 0,
   "accessTokenLifespan" : 300,
   "accessTokenLifespanForImplicitFlow" : 900,

--- a/frontend/app/src/api/backendApi.ts
+++ b/frontend/app/src/api/backendApi.ts
@@ -33,15 +33,23 @@ const withAuthHeader = async (
     : config
 }
 
+let signinRedirectInFlight = false
+
 const backendFetch: FetchAPI = async (resource, config) => {
   const response = await fetch(resource, await withAuthHeader(config))
 
   // axum's Json extractor rejects malformed bodies with 422 before our handlers run,
   // so treat it like 401 and force a fresh sign-in.
-  if (response.status === 401 || response.status === 422) {
-    await getAuthSession().signinRedirect({
-      returnTo: window.location.pathname + window.location.search,
-    })
+  if ((response.status === 401 || response.status === 422) && !signinRedirectInFlight) {
+    signinRedirectInFlight = true
+    try {
+      await getAuthSession().signinRedirect({
+        returnTo: window.location.pathname + window.location.search,
+      })
+    } catch (err) {
+      signinRedirectInFlight = false
+      throw err
+    }
   }
   return response
 }

--- a/frontend/app/src/lib/auth/AuthSessionProvider.tsx
+++ b/frontend/app/src/lib/auth/AuthSessionProvider.tsx
@@ -1,12 +1,25 @@
-import { type ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { AuthProvider, useAuth } from 'react-oidc-context'
 import { getUserManager, isAuthBypass } from './userManager'
 import { DEMO_ACCESS_TOKEN } from './demoUser'
 import { getAuthSession } from './session'
+import { isSessionDeadError } from './renewError'
 import { AuthSessionContext, type AuthSessionContextValue } from './authSessionContext'
 
 function RealBridge({ children }: { children: ReactNode }) {
   const auth = useAuth()
+  useEffect(
+    () =>
+      auth.events.addSilentRenewError((err) => {
+        if (!isSessionDeadError(err)) return
+        void auth.removeUser().then(() =>
+          getAuthSession().signinRedirect({
+            returnTo: window.location.pathname + window.location.search,
+          }),
+        )
+      }),
+    [auth],
+  )
   const value: AuthSessionContextValue = {
     isAuthenticated: auth.isAuthenticated,
     accessToken: auth.user?.access_token ?? null,
@@ -30,10 +43,8 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
     return <AuthSessionContext value={demo}>{children}</AuthSessionContext>
   }
   return (
-    <AuthProvider
-      userManager={getUserManager()}
-      onSigninCallback={() => window.history.replaceState({}, '', window.location.pathname)}
-    >
+    // /auth/callback owns signinCallback; without skip the provider races it on the one-shot state
+    <AuthProvider userManager={getUserManager()} skipSigninCallback>
       <RealBridge>{children}</RealBridge>
     </AuthProvider>
   )

--- a/frontend/app/src/lib/auth/renewError.test.ts
+++ b/frontend/app/src/lib/auth/renewError.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { ErrorResponse } from 'oidc-client-ts'
+import { isSessionDeadError } from './renewError'
+
+describe('isSessionDeadError', () => {
+  it('is true for invalid_grant (Keycloak revoked/expired the session)', () => {
+    const err = new ErrorResponse({ error: 'invalid_grant' })
+    expect(isSessionDeadError(err)).toBe(true)
+  })
+
+  it('is false for other OIDC errors', () => {
+    const err = new ErrorResponse({ error: 'server_error' })
+    expect(isSessionDeadError(err)).toBe(false)
+  })
+
+  it('is false for network failures', () => {
+    expect(isSessionDeadError(new TypeError('Failed to fetch'))).toBe(false)
+  })
+})

--- a/frontend/app/src/lib/auth/renewError.ts
+++ b/frontend/app/src/lib/auth/renewError.ts
@@ -1,0 +1,6 @@
+import { ErrorResponse } from 'oidc-client-ts'
+
+// Only invalid_grant is fatal; network failures must not force a re-login (offline PWA)
+export function isSessionDeadError(err: unknown): boolean {
+  return err instanceof ErrorResponse && err.error === 'invalid_grant'
+}

--- a/frontend/app/src/lib/auth/userManager.test.ts
+++ b/frontend/app/src/lib/auth/userManager.test.ts
@@ -5,6 +5,16 @@ afterEach(() => {
   vi.resetModules()
 })
 
+describe('getUserManager', () => {
+  it('requests offline_access so PWA sessions survive long suspends', async () => {
+    vi.stubEnv('VITE_AUTH_BYPASS', '')
+    vi.stubEnv('VITE_OIDC_AUTHORITY', 'https://auth.example.com/realms/test')
+    vi.stubEnv('VITE_OIDC_CLIENT_ID', 'frontend')
+    const { getUserManager } = await import('./userManager')
+    expect(getUserManager().settings.scope).toContain('offline_access')
+  })
+})
+
 describe('isAuthBypass', () => {
   it('is true when VITE_AUTH_BYPASS === "true"', async () => {
     vi.stubEnv('VITE_AUTH_BYPASS', 'true')

--- a/frontend/app/src/lib/auth/userManager.ts
+++ b/frontend/app/src/lib/auth/userManager.ts
@@ -18,7 +18,8 @@ function buildSettings(): UserManagerSettings {
     redirect_uri: `${origin}/auth/callback`,
     post_logout_redirect_uri: `${origin}/`,
     response_type: 'code',
-    scope: 'openid profile email',
+    // offline_access keeps suspended PWAs renewable beyond the SSO idle timeout
+    scope: 'openid profile email offline_access',
     userStore: new WebStorageStateStore({ store: window.localStorage }),
     automaticSilentRenew: true,
     // Cross-domain iframe silent renew is blocked by third-party cookie rules;


### PR DESCRIPTION
The signin callback was consumed twice: react-oidc-context's AuthProvider auto-processes it while the /auth/callback route also calls signinCallback(). The state entry is single-use, so the loser threw "No matching state found in storage" and the user landed on the error page. The route now owns the callback via skipSigninCallback.

Silent renew failures were unhandled: when Keycloak rejects a refresh token with invalid_grant, the app now removes the user and re-runs the signin redirect (silent while the SSO cookie is alive) instead of staying on a dead session. Network errors deliberately do not trigger this so an offline PWA keeps its session.

Request offline_access so PWA sessions survive suspends longer than the 30-minute SSO idle timeout, deduplicate concurrent 401 signin redirects, and disable revokeRefreshToken in the local realm import — refresh token reuse detection killed the client session on multi-tab renews ("Session doesn't have required client").