### PR TITLE
refactor(frontend): move sidebar collapse toggle to header

### DIFF
--- a/frontend/app/src/components/layout/Header.tsx
+++ b/frontend/app/src/components/layout/Header.tsx
@@ -9,6 +9,8 @@ import { useAuthSession } from '@/lib/auth/authSessionContext'
 import { useCurrentUser } from '@/lib/auth/useCurrentUser'
 import { useCurrentUserAvatar } from '@/lib/auth/useCurrentUserAvatar'
 import { Avatar, AvatarFallback, AvatarImage, Button } from '@green-ecolution/ui'
+import SidebarToggle from '../navigation/SidebarToggle'
+import useStore from '@/store/store'
 
 function Header() {
   const [open, setOpen] = useState(false)
@@ -18,6 +20,7 @@ function Header() {
   const { isAuthenticated } = useAuthSession()
   const { firstName, lastName, email } = useCurrentUser()
   const avatarUrl = useCurrentUserAvatar()
+  const setSidebarCollapsed = useStore((s) => s.setSidebarCollapsed)
 
   const closeSidebar = useCallback(() => {
     setOpen(false)
@@ -45,7 +48,12 @@ function Header() {
     >
       {/* min-h keeps the pre-NavUser header height (40px avatar + py-4 + border);
           the map height calc (100dvh - 4.563rem) depends on it */}
-      <div className="container min-h-[4.563rem] text-sm border-b border-dark-50 py-4 flex justify-between items-center">
+      <div className="container min-h-[4.563rem] text-sm border-b border-dark-50 py-4 flex justify-start items-center">
+        {isLargeScreen && (
+          <div className="mr-4 flex items-center">
+            <SidebarToggle collapsed={collapsed} onToggle={() => setSidebarCollapsed(!collapsed)} />
+          </div>
+        )}
         {!isLargeScreen && (
           <Button
             id="main-navigation-toggle"
@@ -58,7 +66,7 @@ function Header() {
             className="size-8 rounded-full bg-dark hover:bg-dark-600"
             onClick={toggleSidebar}
           >
-            <AlignJustifyIcon className="!size-5 text-light" />
+            <AlignJustifyIcon className="size-5! text-light" />
           </Button>
         )}
         {!isStartPage && <Breadcrumb />}

--- a/frontend/app/src/components/layout/Navigation.tsx
+++ b/frontend/app/src/components/layout/Navigation.tsx
@@ -15,7 +15,6 @@ import { LinkProps } from '@tanstack/react-router'
 import NavLink from '../navigation/NavLink'
 import NavHeadline from '../navigation/NavHeadline'
 import NavHeader from '../navigation/NavHeader'
-import SidebarToggle from '../navigation/SidebarToggle'
 import NavUser from '../navigation/NavUser'
 import { useAuthSession } from '@/lib/auth/authSessionContext'
 import { useCurrentUser } from '@/lib/auth/useCurrentUser'
@@ -24,7 +23,6 @@ import Tree from '../icons/Tree'
 import SensorIcon from '../icons/Sensor'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useSidebarCollapsed } from '@/hooks/useSidebarCollapsed'
-import useStore from '@/store/store'
 
 interface NavigationProps {
   isOpen: boolean
@@ -155,7 +153,6 @@ const Navigation: React.FC<NavigationProps> = ({ isOpen, closeSidebar }) => {
   const isLargeScreen = useMediaQuery('(min-width: 1024px)')
   const { isAuthenticated: isLoggedIn } = useAuthSession()
   const collapsed = useSidebarCollapsed()
-  const setSidebarCollapsed = useStore((s) => s.setSidebarCollapsed)
 
   const { firstName, lastName, email } = useCurrentUser()
   const avatarUrl = useCurrentUserAvatar()
@@ -208,9 +205,6 @@ const Navigation: React.FC<NavigationProps> = ({ isOpen, closeSidebar }) => {
         className={`shrink-0 border-t border-dark-400/30 px-4 pb-4 pt-4 ${collapsed ? 'lg:px-2' : ''} ${isLoggedIn ? '' : 'hidden lg:block'}`}
       >
         <ul className="space-y-1">
-          <li className="relative hidden lg:block">
-            <SidebarToggle collapsed={collapsed} onToggle={() => setSidebarCollapsed(!collapsed)} />
-          </li>
           {isLoggedIn &&
             footerNavData.map(({ key, label, icon, ...linkProps }) => (
               <NavLink

--- a/frontend/app/src/components/navigation/SidebarToggle.test.tsx
+++ b/frontend/app/src/components/navigation/SidebarToggle.test.tsx
@@ -8,7 +8,7 @@ describe('SidebarToggle', () => {
     cleanup()
   })
 
-  it('shows the collapse label and fires onToggle when expanded', async () => {
+  it('has the collapse label and fires onToggle when expanded', async () => {
     const user = userEvent.setup()
     const onToggle = vi.fn()
     render(<SidebarToggle collapsed={false} onToggle={onToggle} />)
@@ -16,17 +16,15 @@ describe('SidebarToggle', () => {
     const button = screen.getByRole('button', { name: 'Seitennavigation einklappen' })
     expect(button).toHaveAttribute('aria-expanded', 'true')
     expect(button).toHaveAttribute('aria-controls', 'main-navigation')
-    expect(screen.getByText('Einklappen')).toBeInTheDocument()
 
     await user.click(button)
     expect(onToggle).toHaveBeenCalledTimes(1)
   })
 
-  it('is icon-only with an expand label when collapsed', () => {
+  it('has the expand label when collapsed', () => {
     render(<SidebarToggle collapsed onToggle={vi.fn()} />)
 
     const button = screen.getByRole('button', { name: 'Seitennavigation ausklappen' })
     expect(button).toHaveAttribute('aria-expanded', 'false')
-    expect(screen.queryByText('Einklappen')).not.toBeInTheDocument()
   })
 })

--- a/frontend/app/src/components/navigation/SidebarToggle.tsx
+++ b/frontend/app/src/components/navigation/SidebarToggle.tsx
@@ -1,6 +1,5 @@
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import React from 'react'
-import { navItemClasses } from './navItemStyles'
 
 interface SidebarToggleProps {
   collapsed: boolean
@@ -14,13 +13,9 @@ const SidebarToggle: React.FC<SidebarToggleProps> = ({ collapsed, onToggle }) =>
     aria-expanded={!collapsed}
     aria-controls="main-navigation"
     aria-label={collapsed ? 'Seitennavigation ausklappen' : 'Seitennavigation einklappen'}
-    title={collapsed ? 'Ausklappen' : 'Einklappen'}
-    className={`${navItemClasses} w-full border-transparent ${collapsed ? 'justify-center px-2' : 'justify-start px-3'}`}
+    className="inline-flex cursor-pointer items-center justify-center text-dark transition-colors hover:text-dark-600"
   >
-    <span className="shrink-0">
-      {collapsed ? <PanelLeftOpen className="w-5 h-5" /> : <PanelLeftClose className="w-5 h-5" />}
-    </span>
-    {!collapsed && <span className="font-lato font-semibold tracking-[0.1]">Einklappen</span>}
+    {collapsed ? <PanelLeftOpen className="w-5 h-5" /> : <PanelLeftClose className="w-5 h-5" />}
   </button>
 )
 


### PR DESCRIPTION
Relocate the collapse/expand toggle from the sidebar footer into the header, next to the breadcrumb. The toggle is now icon-only and vertically centered with the breadcrumb.
