### PR TITLE
fix(backend): set watering status to just watered after a finished plan (OP#3144)

### DIFF
--- a/backend/.sqlx/query-177039255e2923687b476b3e2466c7d2221fc80e1530254154b966cc62ac9ef2.json
+++ b/backend/.sqlx/query-177039255e2923687b476b3e2466c7d2221fc80e1530254154b966cc62ac9ef2.json
@@ -1,0 +1,168 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT tc.id, tc.name, tc.address, tc.description,\n                      tc.archived, tc.moisture_level, tc.region_id,\n                      tc.watering_status AS \"watering_status: WateringStatus\",\n                      tc.soil_condition AS \"soil_condition: Option<SoilCondition>\",\n                      tc.latitude, tc.longitude,\n                      tc.last_watered AS \"last_watered: DateTime<Utc>\",\n                      tc.provider,\n                      tc.additional_informations AS additional_info,\n                      tc.organization_id,\n                      COALESCE(ARRAY_AGG(t.id ORDER BY t.number) FILTER (WHERE t.id IS NOT NULL), ARRAY[]::uuid[]) AS \"tree_ids!: Vec<RawId>\"\n            FROM tree_clusters tc\n            LEFT JOIN trees t ON t.tree_cluster_id = tc.id\n            WHERE tc.watering_status = 'just watered'\n              AND (tc.last_watered IS NULL OR tc.last_watered < $1)\n            GROUP BY tc.id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "archived",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "moisture_level",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 6,
+        "name": "region_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "watering_status: WateringStatus",
+        "type_info": {
+          "Custom": {
+            "name": "watering_status",
+            "kind": {
+              "Enum": [
+                "good",
+                "moderate",
+                "bad",
+                "unknown",
+                "just watered"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 8,
+        "name": "soil_condition: Option<SoilCondition>",
+        "type_info": {
+          "Custom": {
+            "name": "tree_soil_condition",
+            "kind": {
+              "Enum": [
+                "Ss",
+                "Sl2",
+                "Sl3",
+                "Sl4",
+                "Slu",
+                "St2",
+                "St3",
+                "Su2",
+                "Su3",
+                "Su4",
+                "Ls2",
+                "Ls3",
+                "Ls4",
+                "Lt2",
+                "Lt3",
+                "Lts",
+                "Lu",
+                "Uu",
+                "Uls",
+                "Us",
+                "Ut2",
+                "Ut3",
+                "Ut4",
+                "Tt",
+                "Tl",
+                "Tu2",
+                "Tu3",
+                "Tu4",
+                "Ts2",
+                "Ts3",
+                "Ts4",
+                "fS",
+                "mS",
+                "gS",
+                "unknown"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "latitude",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 10,
+        "name": "longitude",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 11,
+        "name": "last_watered: DateTime<Utc>",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 12,
+        "name": "provider",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "additional_info",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 14,
+        "name": "organization_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "tree_ids!: Vec<RawId>",
+        "type_info": "UuidArray"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Timestamp"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      null
+    ]
+  },
+  "hash": "177039255e2923687b476b3e2466c7d2221fc80e1530254154b966cc62ac9ef2"
+}

--- a/backend/config/base.yaml
+++ b/backend/config/base.yaml
@@ -37,6 +37,9 @@ info:
   repository_url: "https://github.com/green-ecolution/"
 sensor:
   offline_after_secs: 86400
+watering:
+  just_watered_ttl_secs: 86400
+  just_watered_sweep_interval_secs: 3600
 routing:
   enabled: false
   streamlet_url: "http://localhost:2510"

--- a/backend/crates/domain/src/cluster/mod.rs
+++ b/backend/crates/domain/src/cluster/mod.rs
@@ -326,6 +326,19 @@ impl TreeCluster {
         self.last_watered = Some(ts);
     }
 
+    /// Records a completed watering run: timestamp plus
+    /// [`WateringStatus::JustWatered`].
+    ///
+    /// Bypasses the majority vote on purpose — a finished watering plan is a
+    /// first-hand observation, unlike the sensor-derived statuses
+    /// [`TreeCluster::recalculate_watering_status`] aggregates. The status is
+    /// released again by [`TreeCluster::recalculate_watering_status`] once the
+    /// grace period expires.
+    pub fn mark_just_watered(&mut self, ts: DateTime<Utc>) {
+        self.mark_watered_at(ts);
+        self.watering_status = WateringStatus::JustWatered;
+    }
+
     /// Reassigns the cluster to `target`'s organization. No-op (and no event)
     /// if it already belongs there. Callers must cascade the transfer to
     /// member trees and their attached sensors (see `ClusterService::transfer`).
@@ -552,6 +565,28 @@ mod tests {
         let ts = Utc::now();
         c.mark_watered_at(ts);
         assert_eq!(c.last_watered, Some(ts));
+    }
+
+    #[test]
+    fn mark_just_watered_sets_status_and_timestamp() {
+        let mut c = fixed_cluster();
+        c.recalculate_watering_status(&[WateringStatus::Bad]);
+        let ts = Utc::now();
+
+        c.mark_just_watered(ts);
+
+        assert_eq!(c.watering_status(), WateringStatus::JustWatered);
+        assert_eq!(c.last_watered, Some(ts));
+    }
+
+    #[test]
+    fn recalculate_watering_status_releases_just_watered() {
+        let mut c = fixed_cluster();
+        c.mark_just_watered(Utc::now());
+
+        c.recalculate_watering_status(&[WateringStatus::Good, WateringStatus::Good]);
+
+        assert_eq!(c.watering_status(), WateringStatus::Good);
     }
 
     #[test]

--- a/backend/crates/domain/src/cluster/repository.rs
+++ b/backend/crates/domain/src/cluster/repository.rs
@@ -68,6 +68,13 @@ pub trait TreeClusterReader: Send + Sync {
         bucket: SoilMoistureBucket,
     ) -> Result<Vec<SoilMoistureDepthSeries>, RepositoryError>;
 
+    /// Clusters still flagged [`crate::shared::watering_status::WateringStatus::JustWatered`]
+    /// whose `last_watered` is older than `cutoff` (or missing entirely).
+    async fn just_watered_before(
+        &self,
+        cutoff: DateTime<Utc>,
+    ) -> Result<Vec<TreeCluster>, RepositoryError>;
+
     /// Finished watering-plan runs that included this cluster, newest first.
     async fn watering_events(
         &self,

--- a/backend/crates/domain/src/tree/mod.rs
+++ b/backend/crates/domain/src/tree/mod.rs
@@ -259,6 +259,32 @@ impl Tree {
         self.last_watered = Some(ts);
     }
 
+    /// Records a completed manual watering: timestamp plus
+    /// [`WateringStatus::JustWatered`].
+    ///
+    /// Deliberately emits no `TreeWateringStatusChanged`. The cluster status is
+    /// set explicitly by the same flow, and re-running the majority vote here
+    /// would reset a cluster without sensor-backed trees to `Unknown`.
+    pub fn mark_just_watered(&mut self, ts: DateTime<Utc>) {
+        self.mark_watered_at(ts);
+        self.watering_status = WateringStatus::JustWatered;
+    }
+
+    /// Drops [`WateringStatus::JustWatered`] once its grace period has passed.
+    /// Returns whether the status changed, so callers can skip the write.
+    ///
+    /// The tree falls back to `Unknown` rather than to a sensor-derived value:
+    /// deriving one needs readings this aggregate does not have, and the next
+    /// reading overwrites it anyway. Emits no event for the same reason as
+    /// [`Tree::mark_just_watered`].
+    pub fn expire_just_watered(&mut self) -> bool {
+        if self.watering_status != WateringStatus::JustWatered {
+            return false;
+        }
+        self.watering_status = WateringStatus::Unknown;
+        true
+    }
+
     /// Derives a [`WateringStatus`] from three Watermark sensor readings
     /// (tension at depths 30/60/90 cm) and the tree's age. Mirrors the
     /// calibration the Go backend used — see
@@ -544,6 +570,36 @@ mod tests {
         let ts = Utc::now();
         t.mark_watered_at(ts);
         assert_eq!(t.last_watered, Some(ts));
+    }
+
+    #[test]
+    fn mark_just_watered_sets_status_and_timestamp_without_event() {
+        let mut t = fixed_tree();
+        let _ = t.record_watering_status(WateringStatus::Bad);
+        let ts = Utc::now();
+
+        t.mark_just_watered(ts);
+
+        assert_eq!(t.watering_status(), WateringStatus::JustWatered);
+        assert_eq!(t.last_watered, Some(ts));
+    }
+
+    #[test]
+    fn expire_just_watered_falls_back_to_unknown() {
+        let mut t = fixed_tree();
+        t.mark_just_watered(Utc::now());
+
+        assert!(t.expire_just_watered());
+        assert_eq!(t.watering_status(), WateringStatus::Unknown);
+    }
+
+    #[test]
+    fn expire_just_watered_leaves_other_statuses_untouched() {
+        let mut t = fixed_tree();
+        let _ = t.record_watering_status(WateringStatus::Moderate);
+
+        assert!(!t.expire_just_watered());
+        assert_eq!(t.watering_status(), WateringStatus::Moderate);
     }
 
     #[test]

--- a/backend/crates/server/src/configuration.rs
+++ b/backend/crates/server/src/configuration.rs
@@ -24,6 +24,8 @@ pub struct Settings {
     #[serde(default)]
     pub sensor: SensorSettings,
     #[serde(default)]
+    pub watering: WateringSettings,
+    #[serde(default)]
     pub routing: RoutingSettings,
     #[serde(default)]
     pub plugins: PluginsSettings,
@@ -279,6 +281,33 @@ fn default_sensor_offline_after_secs() -> u64 {
 }
 
 #[derive(serde::Deserialize, Clone)]
+pub struct WateringSettings {
+    /// How long a finished watering plan keeps its clusters and trees on
+    /// "just watered" before they fall back to the sensor-derived status.
+    #[serde(default = "default_just_watered_ttl_secs")]
+    pub just_watered_ttl_secs: u64,
+    /// How often the expiry sweep runs.
+    #[serde(default = "default_just_watered_sweep_interval_secs")]
+    pub just_watered_sweep_interval_secs: u64,
+}
+
+impl Default for WateringSettings {
+    fn default() -> Self {
+        Self {
+            just_watered_ttl_secs: default_just_watered_ttl_secs(),
+            just_watered_sweep_interval_secs: default_just_watered_sweep_interval_secs(),
+        }
+    }
+}
+
+fn default_just_watered_ttl_secs() -> u64 {
+    86_400
+}
+fn default_just_watered_sweep_interval_secs() -> u64 {
+    3_600
+}
+
+#[derive(serde::Deserialize, Clone)]
 pub struct AuthSettings {
     pub enabled: bool,
     pub issuer_url: String,
@@ -383,6 +412,7 @@ impl Settings {
             map: MapSettings::default(),
             info: InfoSettings::default(),
             sensor: SensorSettings::default(),
+            watering: WateringSettings::default(),
             routing: RoutingSettings::default(),
             plugins: PluginsSettings::default(),
         }

--- a/backend/crates/server/src/infra/mod.rs
+++ b/backend/crates/server/src/infra/mod.rs
@@ -18,3 +18,4 @@ pub mod statistics_repo;
 pub mod streamlet;
 pub mod system_info;
 pub mod update_checker;
+pub mod watering_status_expiry;

--- a/backend/crates/server/src/infra/pg_cluster.rs
+++ b/backend/crates/server/src/infra/pg_cluster.rs
@@ -493,6 +493,36 @@ impl TreeClusterReader for PgTreeClusterRepository {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
+    async fn just_watered_before(
+        &self,
+        cutoff: DateTime<Utc>,
+    ) -> Result<Vec<TreeCluster>, RepositoryError> {
+        let snaps = sqlx::query_as!(
+            TreeClusterSnapshot,
+            r#"SELECT tc.id, tc.name, tc.address, tc.description,
+                      tc.archived, tc.moisture_level, tc.region_id,
+                      tc.watering_status AS "watering_status: WateringStatus",
+                      tc.soil_condition AS "soil_condition: Option<SoilCondition>",
+                      tc.latitude, tc.longitude,
+                      tc.last_watered AS "last_watered: DateTime<Utc>",
+                      tc.provider,
+                      tc.additional_informations AS additional_info,
+                      tc.organization_id,
+                      COALESCE(ARRAY_AGG(t.id ORDER BY t.number) FILTER (WHERE t.id IS NOT NULL), ARRAY[]::uuid[]) AS "tree_ids!: Vec<RawId>"
+            FROM tree_clusters tc
+            LEFT JOIN trees t ON t.tree_cluster_id = tc.id
+            WHERE tc.watering_status = 'just watered'
+              AND (tc.last_watered IS NULL OR tc.last_watered < $1)
+            GROUP BY tc.id"#,
+            cutoff.naive_utc()
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(snaps.into_iter().map(TreeCluster::reconstitute).collect())
+    }
+
+    #[tracing::instrument(level = "trace", skip_all)]
     async fn watering_events(
         &self,
         id: Id<TreeCluster>,

--- a/backend/crates/server/src/infra/watering_status_expiry.rs
+++ b/backend/crates/server/src/infra/watering_status_expiry.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use tokio::task::JoinHandle;
+use tokio::time::{MissedTickBehavior, interval};
+
+use crate::service::cluster_service::ClusterService;
+
+/// Periodically releases the `JustWatered` status once its grace period has
+/// passed. The first sweep runs immediately so statuses that expired while the
+/// server was down are cleaned up on boot.
+pub fn spawn(
+    cluster_service: Arc<ClusterService>,
+    sweep_interval: Duration,
+    ttl: chrono::Duration,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = interval(sweep_interval.max(Duration::from_secs(1)));
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            match cluster_service.expire_just_watered(Utc::now() - ttl).await {
+                Ok(0) => {}
+                Ok(count) => tracing::info!(clusters = count, "released just-watered status"),
+                Err(error) => tracing::warn!(%error, "just-watered expiry sweep failed"),
+            }
+        }
+    })
+}

--- a/backend/crates/server/src/service/cluster_service.rs
+++ b/backend/crates/server/src/service/cluster_service.rs
@@ -194,6 +194,47 @@ impl ClusterService {
         Ok(self.writer.archive(id).await?)
     }
 
+    /// Releases `JustWatered` on every cluster last watered before `cutoff` and
+    /// returns how many were reset. Clusters keep advertising a fresh watering
+    /// until this runs, so a cluster without sensor-backed trees would stay on
+    /// `JustWatered` forever without it.
+    ///
+    /// A cluster that fails is logged and skipped — the sweep runs
+    /// periodically, so the next pass retries it.
+    #[tracing::instrument(level = "debug", skip_all, fields(%cutoff))]
+    pub async fn expire_just_watered(&self, cutoff: DateTime<Utc>) -> Result<usize, ServiceError> {
+        let clusters = self.reader.just_watered_before(cutoff).await?;
+        let mut expired = 0;
+
+        for mut cluster in clusters {
+            match self.release_just_watered(&mut cluster).await {
+                Ok(()) => expired += 1,
+                Err(error) => {
+                    tracing::warn!(%error, cluster.id = %cluster.id, "skipping just-watered expiry")
+                }
+            }
+        }
+        Ok(expired)
+    }
+
+    async fn release_just_watered(&self, cluster: &mut TreeCluster) -> Result<(), ServiceError> {
+        let mut trees = self.tree_reader.by_ids(&cluster.tree_ids).await?;
+        for tree in trees.iter_mut() {
+            if tree.expire_just_watered() {
+                self.tree_writer.save(tree).await?;
+            }
+        }
+
+        let statuses: Vec<_> = trees
+            .iter()
+            .filter(|t| t.sensor_id().is_some())
+            .map(|t| t.watering_status())
+            .collect();
+        cluster.recalculate_watering_status(&statuses);
+        self.writer.save(cluster).await?;
+        Ok(())
+    }
+
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn statistics(&self, visible: Visibility) -> Result<ClusterStatistics, ServiceError> {
         Ok(self.reader.statistics(visible).await?)

--- a/backend/crates/server/src/service/handlers/cluster_just_watered.rs
+++ b/backend/crates/server/src/service/handlers/cluster_just_watered.rs
@@ -1,0 +1,83 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+
+use crate::service::event_bus::{EventHandler, EventHandlerError};
+use domain::{
+    Id,
+    cluster::{TreeCluster, TreeClusterReader, TreeClusterWriter},
+    events::DomainEvent,
+    tree::{TreeReader, TreeWriter},
+};
+
+/// Flags a finished watering plan's clusters and their trees as
+/// [`domain::shared::watering_status::WateringStatus::JustWatered`].
+///
+/// Only `WateringPlanFinished` triggers this; starting, canceling or failing a
+/// plan leaves the status alone. The status is released again by
+/// `ClusterService::expire_just_watered` once the grace period passes.
+pub struct ClusterJustWateredHandler {
+    cluster_reader: Arc<dyn TreeClusterReader>,
+    cluster_writer: Arc<dyn TreeClusterWriter>,
+    tree_reader: Arc<dyn TreeReader>,
+    tree_writer: Arc<dyn TreeWriter>,
+}
+
+impl ClusterJustWateredHandler {
+    pub fn new(
+        cluster_reader: Arc<dyn TreeClusterReader>,
+        cluster_writer: Arc<dyn TreeClusterWriter>,
+        tree_reader: Arc<dyn TreeReader>,
+        tree_writer: Arc<dyn TreeWriter>,
+    ) -> Self {
+        Self {
+            cluster_reader,
+            cluster_writer,
+            tree_reader,
+            tree_writer,
+        }
+    }
+
+    async fn mark_cluster(
+        &self,
+        cluster_id: Id<TreeCluster>,
+        finished_at: DateTime<Utc>,
+    ) -> Result<(), EventHandlerError> {
+        let mut cluster = self.cluster_reader.by_id(cluster_id).await?;
+        let mut trees = self.tree_reader.by_ids(&cluster.tree_ids).await?;
+
+        for tree in trees.iter_mut() {
+            tree.mark_just_watered(finished_at);
+            self.tree_writer.save(tree).await?;
+        }
+
+        cluster.mark_just_watered(finished_at);
+        self.cluster_writer.save(&cluster).await?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl EventHandler for ClusterJustWateredHandler {
+    fn name(&self) -> &str {
+        "cluster_just_watered"
+    }
+
+    async fn handle(&self, event: &DomainEvent) -> Result<Vec<DomainEvent>, EventHandlerError> {
+        let DomainEvent::WateringPlanFinished {
+            cluster_ids,
+            finished_at,
+            ..
+        } = event
+        else {
+            return Ok(vec![]);
+        };
+
+        for cluster_id in cluster_ids {
+            if let Err(error) = self.mark_cluster(*cluster_id, *finished_at).await {
+                tracing::warn!(%error, cluster.id = %cluster_id, "skipping just-watered update");
+            }
+        }
+        Ok(vec![])
+    }
+}

--- a/backend/crates/server/src/service/handlers/mod.rs
+++ b/backend/crates/server/src/service/handlers/mod.rs
@@ -1,3 +1,4 @@
+pub mod cluster_just_watered;
 pub mod cluster_recalc;
 pub mod cluster_soil_recalc;
 pub mod cluster_status;

--- a/backend/crates/server/src/startup.rs
+++ b/backend/crates/server/src/startup.rs
@@ -38,6 +38,7 @@ use crate::{
         cluster_service::ClusterService,
         evaluation_service::EvaluationService,
         event_bus::{EventBus, EventHandler, InMemoryEventBus},
+        handlers::cluster_just_watered::ClusterJustWateredHandler,
         handlers::cluster_recalc::ClusterRecalculationHandler,
         handlers::cluster_soil_recalc::ClusterSoilRecalcHandler,
         handlers::cluster_status::ClusterStatusAggregatorHandler,
@@ -143,6 +144,13 @@ impl Application {
             spawn_mqtt_subscriber(&settings, services.sensor.clone(), shutdown_rx);
         let (health_reader, readiness_reader) =
             spawn_health_probes(&pool, &settings, probe_http_client.clone(), mqtt_state).await;
+        let _expiry_handle = infra::watering_status_expiry::spawn(
+            services.cluster.clone(),
+            Duration::from_secs(settings.watering.just_watered_sweep_interval_secs),
+            chrono::Duration::seconds(
+                i64::try_from(settings.watering.just_watered_ttl_secs).unwrap_or(i64::MAX),
+            ),
+        );
         let _update_handle = infra::update_checker::spawn(
             update_checker,
             probe_http_client,
@@ -464,6 +472,12 @@ fn build_event_bus(repos: &Repositories) -> Arc<dyn EventBus> {
             repos.tree_writer.clone(),
             repos.cluster_reader.clone(),
             repos.sensor_reading_reader.clone(),
+        )),
+        Arc::new(ClusterJustWateredHandler::new(
+            repos.cluster_reader.clone(),
+            repos.cluster_writer.clone(),
+            repos.tree_reader.clone(),
+            repos.tree_writer.clone(),
         )),
         Arc::new(ClusterStatusAggregatorHandler::new(
             repos.cluster_reader.clone(),

--- a/backend/crates/server/test/api/watering_plans.rs
+++ b/backend/crates/server/test/api/watering_plans.rs
@@ -42,6 +42,25 @@ async fn create_cluster(app: &helpers::TestApp) -> serde_json::Value {
     resp.json().await.unwrap()
 }
 
+async fn create_tree_in_cluster(
+    app: &helpers::TestApp,
+    number: &str,
+    cluster_id: &str,
+) -> serde_json::Value {
+    let body = serde_json::json!({
+        "species": "Eiche",
+        "number": number,
+        "planting_year": 2020,
+        "latitude": 54.79,
+        "longitude": 9.43,
+        "description": "Testbaum",
+        "tree_cluster_id": cluster_id
+    });
+    let resp = app.post_json("/api/v1/trees", &body).await;
+    assert_eq!(resp.status().as_u16(), 201);
+    resp.json().await.unwrap()
+}
+
 fn plan_body(transporter_id: &str, cluster_ids: Vec<&str>) -> serde_json::Value {
     serde_json::json!({
         "date": "2026-05-01T08:00:00Z",
@@ -298,7 +317,7 @@ fn update_body_with_status(
 }
 
 #[tokio::test]
-async fn finish_watering_plan_propagates_last_watered_and_persists_evaluations() {
+async fn finish_watering_plan_marks_just_watered_and_persists_evaluations() {
     let app = spawn_app().await;
 
     let transporter = create_transporter(&app).await;
@@ -310,6 +329,8 @@ async fn finish_watering_plan_propagates_last_watered_and_persists_evaluations()
         cluster["last_watered"].is_null(),
         "cluster should start without last_watered"
     );
+    let tree = create_tree_in_cluster(&app, "T-JW-001", cid).await;
+    let tree_id = tree["id"].as_str().unwrap();
 
     let create_resp = app
         .post_json("/api/v1/watering-plans", &plan_body(tid, vec![cid]))
@@ -322,6 +343,17 @@ async fn finish_watering_plan_propagates_last_watered_and_persists_evaluations()
         .put_json(&format!("/api/v1/watering-plans/{}", plan_id), &activate)
         .await;
     assert_eq!(activate_resp.status().as_u16(), 200);
+
+    let cluster_active: serde_json::Value = app
+        .get(&format!("/api/v1/clusters/{}", cid))
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        cluster_active["watering_status"], "unknown",
+        "starting a plan must not change the watering status"
+    );
 
     let finish = update_body_with_status(
         tid,
@@ -353,6 +385,126 @@ async fn finish_watering_plan_propagates_last_watered_and_persists_evaluations()
         "cluster.last_watered must be set after plan finish, got {:?}",
         cluster_after["last_watered"]
     );
+    assert_eq!(
+        cluster_after["watering_status"], "just watered",
+        "cluster must be flagged just watered after plan finish"
+    );
+
+    let tree_after: serde_json::Value = app
+        .get(&format!("/api/v1/trees/{}", tree_id))
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        tree_after["watering_status"], "just watered",
+        "trees of a watered cluster must be flagged just watered"
+    );
+    assert!(
+        tree_after["last_watered"].is_string(),
+        "tree.last_watered must be set after plan finish, got {:?}",
+        tree_after["last_watered"]
+    );
+}
+
+#[tokio::test]
+async fn just_watered_expires_back_to_sensor_derived_status() {
+    let app = spawn_app().await;
+
+    let transporter = create_transporter(&app).await;
+    let tid = transporter["id"].as_str().unwrap();
+    let cluster = create_cluster(&app).await;
+    let cid = cluster["id"].as_str().unwrap();
+    let tree = create_tree_in_cluster(&app, "T-JW-002", cid).await;
+    let tree_id = tree["id"].as_str().unwrap();
+
+    finish_plan_for_cluster(&app, tid, cid).await;
+
+    let fresh = app
+        .state
+        .cluster_service
+        .expire_just_watered(chrono::Utc::now() - chrono::Duration::hours(24))
+        .await
+        .expect("expiry sweep must succeed");
+    assert_eq!(fresh, 0, "a cluster watered just now must not expire yet");
+
+    let expired = app
+        .state
+        .cluster_service
+        .expire_just_watered(chrono::Utc::now() + chrono::Duration::hours(1))
+        .await
+        .expect("expiry sweep must succeed");
+    assert_eq!(expired, 1);
+
+    let cluster_after: serde_json::Value = app
+        .get(&format!("/api/v1/clusters/{}", cid))
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        cluster_after["watering_status"], "unknown",
+        "a cluster without sensor-backed trees falls back to unknown"
+    );
+    assert!(
+        cluster_after["last_watered"].is_string(),
+        "expiry must keep last_watered"
+    );
+
+    let tree_after: serde_json::Value = app
+        .get(&format!("/api/v1/trees/{}", tree_id))
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(tree_after["watering_status"], "unknown");
+    assert!(
+        tree_after["last_watered"].is_string(),
+        "expiry must keep last_watered"
+    );
+}
+
+async fn finish_plan_for_cluster(app: &helpers::TestApp, transporter_id: &str, cluster_id: &str) {
+    let create_resp = app
+        .post_json(
+            "/api/v1/watering-plans",
+            &plan_body(transporter_id, vec![cluster_id]),
+        )
+        .await;
+    let plan: serde_json::Value = create_resp.json().await.unwrap();
+    let plan_id = plan["id"].as_str().unwrap();
+
+    let activate = app
+        .put_json(
+            &format!("/api/v1/watering-plans/{}", plan_id),
+            &update_body_with_status(
+                transporter_id,
+                vec![cluster_id],
+                "active",
+                "",
+                serde_json::json!([]),
+            ),
+        )
+        .await;
+    assert_eq!(activate.status().as_u16(), 200);
+
+    let finish = app
+        .put_json(
+            &format!("/api/v1/watering-plans/{}", plan_id),
+            &update_body_with_status(
+                transporter_id,
+                vec![cluster_id],
+                "finished",
+                "",
+                serde_json::json!([{
+                    "watering_plan_id": plan_id,
+                    "tree_cluster_id": cluster_id,
+                    "consumed_water": 500.0
+                }]),
+            ),
+        )
+        .await;
+    assert_eq!(finish.status().as_u16(), 200);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Finishing a watering plan only wrote last_watered; the status kept showing the old sensor-derived value because JustWatered was never written anywhere in the backend and WateringPlanFinished had no subscriber. The Go backend set both halves - only last_watered survived the port.

A new cluster_just_watered handler reacts to WateringPlanFinished and flags the plan's clusters and their trees via the new mark_just_watered intent methods. Those emit no TreeWateringStatusChanged on purpose: the cluster status is set explicitly in the same flow, and re-running the majority vote would reset a cluster without sensor-backed trees to Unknown.

ClusterService::expire_just_watered releases the status again once the grace period passes: trees fall back to Unknown, the cluster is recomputed from its sensor-backed trees, last_watered is kept. A sweep in infra/watering_status_expiry.rs drives it on the new watering.just_watered_* config interval (24h grace period, hourly sweep), so the service layer stays tokio-free.
