### PR TITLE
fix(frontend): show only assigned users on watering plan detail (OP#3193)

### DIFF
--- a/frontend/app/src/components/watering-plan/TabGeneralData.test.tsx
+++ b/frontend/app/src/components/watering-plan/TabGeneralData.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { WateringPlanStatus } from '@green-ecolution/backend-client'
+import type { WateringPlan } from '@/api/backendApi'
+
+const users = [
+  { id: 'u1', firstName: 'Max', lastName: 'Mustermann' },
+  { id: 'u2', firstName: 'Erika', lastName: 'Musterfrau' },
+]
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+  return {
+    ...actual,
+    useSuspenseQuery: () => ({ data: { data: users } }),
+    useQuery: () => ({ data: [] }),
+  }
+})
+
+const { default: TabGeneralData } = await import('./TabGeneralData')
+
+const plan = (userIds: string[]) =>
+  ({
+    id: 'p1',
+    date: '2026-03-01T00:00:00Z',
+    updatedAt: '2026-03-01T00:00:00Z',
+    status: WateringPlanStatus.Planned,
+    treeclusters: [],
+    evaluation: [],
+    distance: 1000,
+    userIds,
+  }) as unknown as WateringPlan
+
+const assignedValue = () =>
+  screen.getByText('Eingeteilte Mitarbeitende').nextElementSibling?.textContent
+
+describe('TabGeneralData', () => {
+  it('lists only the users assigned to the plan', () => {
+    render(<TabGeneralData wateringPlan={plan(['u1'])} />)
+
+    expect(assignedValue()).toBe('Max Mustermann')
+  })
+
+  it('shows a placeholder when nobody is assigned', () => {
+    render(<TabGeneralData wateringPlan={plan([])} />)
+
+    expect(assignedValue()).toBe('Keine Angabe')
+  })
+})

--- a/frontend/app/src/components/watering-plan/TabGeneralData.tsx
+++ b/frontend/app/src/components/watering-plan/TabGeneralData.tsx
@@ -14,9 +14,11 @@ interface TabGeneralDataProps {
 }
 
 const TabGeneralData: React.FC<TabGeneralDataProps> = ({ wateringPlan }) => {
-  const { data: userRes } = useSuspenseQuery(userQueries.list())
+  const { data: userRes } = useSuspenseQuery(userQueries.list({ page: 1, perPage: 100 }))
   const { data: startPoints } = useQuery(routingStartPointsQuery())
   const defaultStartPointName = startPoints?.[0]?.name
+
+  const assignedUsers = userRes.data?.filter((user) => wateringPlan.userIds.includes(user.id)) ?? []
 
   const updatedDate = wateringPlan?.updatedAt
     ? format(new Date(wateringPlan.updatedAt), 'dd.MM.yyyy')
@@ -60,8 +62,8 @@ const TabGeneralData: React.FC<TabGeneralDataProps> = ({ wateringPlan }) => {
     },
     {
       label: 'Eingeteilte Mitarbeitende',
-      value: userRes.data?.length
-        ? userRes.data.map((user) => `${user.firstName} ${user.lastName}`).join(', ')
+      value: assignedUsers.length
+        ? assignedUsers.map((user) => `${user.firstName} ${user.lastName}`).join(', ')
         : 'Keine Angabe',
     },
     {


### PR DESCRIPTION
The "Eingeteilte Mitarbeitende" field rendered the whole user list instead of the users assigned to the plan. Filter the list against the plan's userIds and request the same page size the board and edit form use, so an assigned user beyond the default 25-user page cannot drop out.