### PR TITLE
fix(frontend): invalidate neighbouring aggregates after mutations (OP#3195)

### DIFF
--- a/frontend/app/src/api/queries.ts
+++ b/frontend/app/src/api/queries.ts
@@ -1,4 +1,9 @@
-import { queryOptions, infiniteQueryOptions, keepPreviousData } from '@tanstack/react-query'
+import {
+  queryOptions,
+  infiniteQueryOptions,
+  keepPreviousData,
+  type QueryKey,
+} from '@tanstack/react-query'
 import {
   AppInfoResponse,
   clusterApi,
@@ -85,6 +90,28 @@ export interface TreeMarkersFilters {
 
 /** Partial key matching every sensor list page; use for broad invalidation. */
 const SENSORS_KEY = ['sensors'] as const
+
+/**
+ * Every key prefix an aggregate owns, grouped per aggregate. The keys below
+ * grew inconsistent roots ('treecluster' vs 'treeclusters' vs 'clusters'), so
+ * invalidating one prefix silently misses the rest — go through this table
+ * instead of guessing. See lib/queryInvalidation.ts.
+ */
+export const queryRoots = {
+  cluster: [['treecluster'], ['treeclusters'], ['clusters']],
+  tree: [['tree'], ['trees'], ['planting-years']],
+  vehicle: [['vehicle'], ['vehicles']],
+  sensor: [['sensor'], ['sensors'], ['sensor data'], ['sensor-model']],
+  wateringPlan: [['watering-plan'], ['watering-plans'], ['watering-plan-route'], ['route-preview']],
+  evaluation: [['evaluation']],
+  region: [['regions']],
+  statistics: [['info']],
+  user: [['users']],
+  role: [['roles']],
+  organization: [['organizations']],
+} as const satisfies Record<string, readonly QueryKey[]>
+
+export type Aggregate = keyof typeof queryRoots
 
 export const clusterQueries = {
   list: (params?: ListClustersRequest) =>

--- a/frontend/app/src/components/sensor/detail/SensorActionsContext.tsx
+++ b/frontend/app/src/components/sensor/detail/SensorActionsContext.tsx
@@ -40,11 +40,9 @@ const SensorActionsProvider = ({ sensor, children }: PropsWithChildren<{ sensor:
   const [assignMode, setAssignMode] = useState<AssignMode | null>(null)
   const [removeOpen, setRemoveOpen] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  const previousTreeId = sensor.linkedTreeId ?? null
-
   const activate = useActivateSensor(sensor.id)
-  const reassign = useReassignSensorTree(sensor.id, previousTreeId)
-  const deactivate = useDeactivateSensor(sensor.id, previousTreeId)
+  const reassign = useReassignSensorTree(sensor.id)
+  const deactivate = useDeactivateSensor(sensor.id)
 
   const closeAssign = () => {
     setAssignMode(null)

--- a/frontend/app/src/components/sensor/detail/SensorActionsMenu.tsx
+++ b/frontend/app/src/components/sensor/detail/SensorActionsMenu.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { ChevronDown, Link2, Link2Off, Replace, Trash2 } from 'lucide-react'
 import {
   AlertDialog,
@@ -21,7 +21,7 @@ import {
 } from '@green-ecolution/ui'
 import type { Sensor } from '@/api/backendApi'
 import { sensorApi } from '@/api/backendApi'
-import { sensorQueries } from '@/api/queries'
+import { useInvalidateAggregates } from '@/lib/queryInvalidation'
 import { useHasPermission } from '@/lib/auth/useHasPermission'
 import { useSensorActions } from './SensorActionsContext'
 
@@ -35,7 +35,7 @@ const SensorActionsMenu = ({ sensor }: SensorActionsMenuProps) => {
   const isPrepared = sensor.status === 'prepared'
   const [dialogOpen, setDialogOpen] = useState(false)
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
+  const invalidate = useInvalidateAggregates()
   const canUpdate = useHasPermission(['sensor:update'])
   const canDelete = useHasPermission(['sensor:delete'])
 
@@ -43,8 +43,10 @@ const SensorActionsMenu = ({ sensor }: SensorActionsMenuProps) => {
     mutationFn: () => sensorApi.deleteSensor({ sensorId }),
     onSuccess: async () => {
       toast.success('Sensor wurde gelöscht.')
-      await queryClient.invalidateQueries({ queryKey: sensorQueries.key })
       await navigate({ to: '/sensors', search: { page: 1 } })
+      // After leaving: this page holds a live query on the sensor. Trees too,
+      // because deleting a sensor detaches it from the tree it was on.
+      await invalidate(['sensor', 'tree'])
     },
     onError: () => {
       toast.error('Der Sensor konnte nicht gelöscht werden.')

--- a/frontend/app/src/components/treecluster/DeleteSection.test.tsx
+++ b/frontend/app/src/components/treecluster/DeleteSection.test.tsx
@@ -8,6 +8,7 @@ import { ReactNode } from 'react'
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn().mockResolvedValue(undefined),
+  useRouter: () => ({ invalidate: vi.fn().mockResolvedValue(undefined) }),
 }))
 
 function createWrapper() {
@@ -38,6 +39,7 @@ describe('DeleteSection', () => {
       render(
         <DeleteSection
           mutationFn={mockMutationFn}
+          invalidates={['tree']}
           entityName="der Baum"
           redirectUrl={{ to: '/map' }}
         />,
@@ -51,6 +53,7 @@ describe('DeleteSection', () => {
       render(
         <DeleteSection
           mutationFn={mockMutationFn}
+          invalidates={['tree']}
           entityName="das Fahrzeug"
           type="archive"
           redirectUrl={{ to: '/vehicles' }}
@@ -69,6 +72,7 @@ describe('DeleteSection', () => {
       render(
         <DeleteSection
           mutationFn={mockMutationFn}
+          invalidates={['tree']}
           entityName="der Baum"
           redirectUrl={{ to: '/map' }}
         />,
@@ -86,6 +90,7 @@ describe('DeleteSection', () => {
       render(
         <DeleteSection
           mutationFn={mockMutationFn}
+          invalidates={['tree']}
           entityName="das Fahrzeug"
           type="archive"
           redirectUrl={{ to: '/vehicles' }}
@@ -104,6 +109,7 @@ describe('DeleteSection', () => {
       render(
         <DeleteSection
           mutationFn={mockMutationFn}
+          invalidates={['tree']}
           entityName="der Baum"
           redirectUrl={{ to: '/map' }}
         />,
@@ -121,6 +127,7 @@ describe('DeleteSection', () => {
       render(
         <DeleteSection
           mutationFn={mockMutationFn}
+          invalidates={['tree']}
           entityName="der Baum"
           redirectUrl={{ to: '/map' }}
         />,
@@ -147,6 +154,7 @@ describe('DeleteSection', () => {
       render(
         <DeleteSection
           mutationFn={mockMutationFn}
+          invalidates={['tree']}
           entityName="der Baum"
           redirectUrl={{ to: '/map' }}
         />,
@@ -167,6 +175,7 @@ describe('DeleteSection', () => {
       render(
         <DeleteSection
           mutationFn={mockMutationFn}
+          invalidates={['tree']}
           entityName="der Baum"
           redirectUrl={{ to: '/map' }}
         />,
@@ -188,6 +197,7 @@ describe('DeleteSection', () => {
       render(
         <DeleteSection
           mutationFn={deleteTreeFn}
+          invalidates={['tree']}
           entityName="der Baum"
           redirectUrl={{ to: '/map' }}
         />,
@@ -205,6 +215,7 @@ describe('DeleteSection', () => {
       render(
         <DeleteSection
           mutationFn={archiveVehicleFn}
+          invalidates={['tree']}
           entityName="das Fahrzeug"
           type="archive"
           redirectUrl={{ to: '/vehicles' }}
@@ -223,6 +234,7 @@ describe('DeleteSection', () => {
       render(
         <DeleteSection
           mutationFn={deleteClusterFn}
+          invalidates={['tree']}
           entityName="die Bewässerungsgruppe"
           redirectUrl={{ to: '/treecluster' }}
         />,
@@ -242,6 +254,7 @@ describe('DeleteSection', () => {
       render(
         <DeleteSection
           mutationFn={deletePlanFn}
+          invalidates={['tree']}
           entityName="der Einsatzplan"
           redirectUrl={{ to: '/watering-plans' }}
         />,
@@ -265,6 +278,7 @@ describe('DeleteSection', () => {
       render(
         <DeleteSection
           mutationFn={mockMutationFn}
+          invalidates={['tree']}
           entityName="der Baum"
           redirectUrl={{ to: '/map' }}
         />,

--- a/frontend/app/src/components/treecluster/DeleteSection.tsx
+++ b/frontend/app/src/components/treecluster/DeleteSection.tsx
@@ -14,12 +14,16 @@ import {
 } from '@green-ecolution/ui'
 import createToast from '@/hooks/createToast'
 import { LinkProps, useNavigate } from '@tanstack/react-router'
+import type { Aggregate } from '@/api/queries'
+import { useInvalidateAggregates } from '@/lib/queryInvalidation'
 
 interface DeleteSectionProps {
   mutationFn: () => Promise<unknown>
   entityName: string
   type?: 'archive' | 'delete'
   redirectUrl: LinkProps
+  /** Aggregates whose lists and details still contain the removed entity. */
+  invalidates: readonly Aggregate[]
 }
 
 const DeleteSection: React.FC<DeleteSectionProps> = ({
@@ -27,9 +31,11 @@ const DeleteSection: React.FC<DeleteSectionProps> = ({
   entityName,
   type = 'delete',
   redirectUrl,
+  invalidates,
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const navigate = useNavigate()
+  const invalidate = useInvalidateAggregates()
   const showToast = createToast()
 
   const actionText = type === 'archive' ? 'archiviert' : 'gelöscht'
@@ -39,6 +45,9 @@ const DeleteSection: React.FC<DeleteSectionProps> = ({
     onSuccess: () => {
       setIsModalOpen(false)
       navigate(redirectUrl)
+        // After leaving: a page still showing the removed entity would refetch
+        // it into a 404.
+        .then(() => invalidate(invalidates))
         .then(() =>
           showToast(
             `${entityName.charAt(0).toUpperCase()}${entityName.slice(1)} wurde erfolgreich ${actionText}.`,

--- a/frontend/app/src/components/treecluster/TreeClusterDashboard.tsx
+++ b/frontend/app/src/components/treecluster/TreeClusterDashboard.tsx
@@ -29,6 +29,7 @@ import {
   DropdownMenuTrigger,
 } from '@green-ecolution/ui'
 import { clusterApi, type TreeCluster } from '@/api/backendApi'
+import { useInvalidateAggregates } from '@/lib/queryInvalidation'
 
 interface TreeClusterDashboardProps {
   treecluster: TreeCluster
@@ -36,6 +37,7 @@ interface TreeClusterDashboardProps {
 
 const TreeClusterDashboard = ({ treecluster }: TreeClusterDashboardProps) => {
   const navigate = useNavigate()
+  const invalidate = useInvalidateAggregates()
   const showToast = createToast()
   const [confirmDelete, setConfirmDelete] = useState(false)
   const canEdit = useHasPermission(['tree_cluster:update'])
@@ -47,7 +49,11 @@ const TreeClusterDashboard = ({ treecluster }: TreeClusterDashboardProps) => {
   const handleDelete = () => {
     clusterApi
       .deleteCluster({ clusterId: treecluster.id.toString() })
+      // Invalidate only after leaving: this page holds a live query on the
+      // cluster, which would refetch into a 404 while still mounted. Trees too,
+      // because deleting a cluster walks its trees out of it.
       .then(() => navigate({ to: '/treecluster', search: { page: 1 } }))
+      .then(() => invalidate(['cluster', 'tree']))
       .then(() => showToast('Die Bewässerungsgruppe wurde gelöscht.'))
       .catch((error) => {
         console.error('Delete failed:', error)

--- a/frontend/app/src/components/vehicle/VehicleUpdate.tsx
+++ b/frontend/app/src/components/vehicle/VehicleUpdate.tsx
@@ -82,6 +82,7 @@ const VehicleUpdate = ({ vehicleId }: VehicleUpdateProps) => {
             type="archive"
             entityName="das Fahrzeug"
             redirectUrl={{ to: '/vehicles' }}
+            invalidates={['vehicle', 'wateringPlan']}
           />
         </Suspense>
       </Can>

--- a/frontend/app/src/components/watering-plan/WateringPlanStatusUpdate.tsx
+++ b/frontend/app/src/components/watering-plan/WateringPlanStatusUpdate.tsx
@@ -19,7 +19,8 @@ import {
 } from '@/schema/wateringPlanSchema'
 import { zodResolver } from '@/lib/zodResolver'
 import { SubmitHandler, useFieldArray, useForm } from 'react-hook-form'
-import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query'
+import { PLAN_STATUS_AGGREGATES, useInvalidateAggregates } from '@/lib/queryInvalidation'
 import { wateringPlanApi } from '@/api/backendApi'
 import { useNavigate } from '@tanstack/react-router'
 import createToast from '@/hooks/createToast'
@@ -31,7 +32,7 @@ interface WateringPlanStatusUpdateProps {
 const WateringPlanStatusUpdate = ({ wateringPlanId }: WateringPlanStatusUpdateProps) => {
   const { data: loadedData } = useSuspenseQuery(wateringPlanQueries.detail(wateringPlanId))
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
+  const invalidate = useInvalidateAggregates()
   const showToast = createToast()
   const statusDetails = getWateringPlanStatusDetails(loadedData.status)
   const [selectedStatus, setSelectedStatus] = useState(statusDetails)
@@ -44,12 +45,9 @@ const WateringPlanStatusUpdate = ({ wateringPlanId }: WateringPlanStatusUpdatePr
       }),
 
     onSuccess: (data: WateringPlan) => {
-      queryClient
-        .invalidateQueries(wateringPlanQueries.detail(String(data.id)))
-        .catch((error) => console.error('Invalidate "waterinPlanIdQuery" failed', error))
-      queryClient
-        .invalidateQueries({ queryKey: ['watering-plans'] })
-        .catch((error) => console.error('Invalidate "watering-plans" failed:', error))
+      invalidate(PLAN_STATUS_AGGREGATES).catch((error) =>
+        console.error('Invalidation after watering plan status update failed:', error),
+      )
 
       navigate({
         to: `/watering-plans/$wateringPlanId`,

--- a/frontend/app/src/components/watering-plan/WateringPlanUpdate.tsx
+++ b/frontend/app/src/components/watering-plan/WateringPlanUpdate.tsx
@@ -154,6 +154,7 @@ const WateringPlanUpdate = ({ wateringPlanId }: WateringPlanUpdateProps) => {
             mutationFn={handleDeleteWateringPlan}
             entityName="der Einsatzplan"
             redirectUrl={{ to: '/watering-plans' }}
+            invalidates={['wateringPlan', 'evaluation']}
           />
         </Suspense>
       </Can>

--- a/frontend/app/src/components/watering-plan/board/CancelPlanDialog.test.tsx
+++ b/frontend/app/src/components/watering-plan/board/CancelPlanDialog.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@/api/backendApi', async (importOriginal) => {
 })
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn().mockResolvedValue(undefined),
+  useRouter: () => ({ invalidate: vi.fn().mockResolvedValue(undefined) }),
   Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
 }))
 

--- a/frontend/app/src/components/watering-plan/board/CompletePlanDialog.test.tsx
+++ b/frontend/app/src/components/watering-plan/board/CompletePlanDialog.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@/api/backendApi', async (importOriginal) => {
 })
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn().mockResolvedValue(undefined),
+  useRouter: () => ({ invalidate: vi.fn().mockResolvedValue(undefined) }),
   Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
 }))
 

--- a/frontend/app/src/hooks/form/useEntityForm.ts
+++ b/frontend/app/src/hooks/form/useEntityForm.ts
@@ -1,6 +1,8 @@
-import { useMutation, useQueryClient, QueryClient } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import createToast from '@/hooks/createToast'
 import { useNavigate } from '@tanstack/react-router'
+import type { Aggregate } from '@/api/queries'
+import { useInvalidateAggregates } from '@/lib/queryInvalidation'
 import { DefaultValues, FieldValues, Resolver, useForm } from 'react-hook-form'
 import { useFormNavigationBlocker } from './useFormNavigationBlocker'
 import { useFormDraft } from '@/store/form/useFormDraft'
@@ -14,7 +16,8 @@ export interface EntityFormConfig<TForm extends FieldValues, TCreate, TUpdate, T
   createFn: (body: TCreate) => Promise<TEntity>
   updateFn: (id: string, body: TUpdate) => Promise<TEntity>
 
-  invalidateQueries: (data: TEntity, queryClient: QueryClient) => void
+  /** Every aggregate a save touches, including neighbours it changes indirectly. */
+  invalidates: readonly Aggregate[]
 
   successRoute: (id: string) => { to: string; params: Record<string, string> }
   replaceOnSuccess?: boolean
@@ -45,7 +48,7 @@ export function useEntityForm<
   opts: EntityFormOptions<TForm>,
 ) {
   const showToast = createToast()
-  const queryClient = useQueryClient()
+  const invalidate = useInvalidateAggregates()
   const navigate = useNavigate()
   const draft = useFormDraft<TForm>(config.formType, mutationType)
 
@@ -80,7 +83,11 @@ export function useEntityForm<
 
     onSuccess: (data: TEntity) => {
       draft.clear()
-      config.invalidateQueries(data, queryClient)
+      // Not awaited on purpose: invalidateQueries marks the entries stale
+      // synchronously, so the loader of the route we navigate to refetches.
+      invalidate(config.invalidates).catch((error) =>
+        console.error(`Invalidation after ${config.formType} mutation failed:`, error),
+      )
 
       navigationBlocker.allowNavigation()
       const route = config.successRoute(data.id)

--- a/frontend/app/src/hooks/form/useTreeClusterForm.test.tsx
+++ b/frontend/app/src/hooks/form/useTreeClusterForm.test.tsx
@@ -22,6 +22,7 @@ const mockUseBlocker = vi.fn().mockReturnValue({
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn().mockResolvedValue(undefined),
+  useRouter: () => ({ invalidate: vi.fn().mockResolvedValue(undefined) }),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   useBlocker: (...args: unknown[]) => mockUseBlocker(...args),
 }))

--- a/frontend/app/src/hooks/form/useTreeClusterForm.ts
+++ b/frontend/app/src/hooks/form/useTreeClusterForm.ts
@@ -1,5 +1,3 @@
-import { QueryClient } from '@tanstack/react-query'
-import { clusterQueries } from '@/api/queries'
 import type { TreeCluster, TreeClusterCreate, TreeClusterUpdate } from '@/api/backendApi'
 import { clusterApi } from '@/api/backendApi'
 import { TreeclusterForm } from '@/schema/treeclusterSchema'
@@ -20,14 +18,8 @@ const treeClusterConfig: EntityFormConfig<
   updateFn: (id, body) =>
     clusterApi.updateCluster({ clusterId: id, treeClusterUpdateRequest: body }),
 
-  invalidateQueries: (data, queryClient: QueryClient) => {
-    queryClient
-      .invalidateQueries(clusterQueries.detail(String(data.id)))
-      .catch((error) => console.error('Invalidate "clusterQueries.detail" failed:', error))
-    queryClient
-      .invalidateQueries(clusterQueries.list())
-      .catch((error) => console.error('Invalidate "clusterQueries.list" failed:', error))
-  },
+  // Tree too: replacing the cluster's trees changes their cluster membership.
+  invalidates: ['cluster', 'tree'],
 
   successRoute: (id) => ({
     to: '/treecluster/$treeclusterId',

--- a/frontend/app/src/hooks/form/useTreeForm.test.tsx
+++ b/frontend/app/src/hooks/form/useTreeForm.test.tsx
@@ -21,6 +21,7 @@ const mockUseBlocker = vi.fn().mockReturnValue({
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn().mockResolvedValue(undefined),
+  useRouter: () => ({ invalidate: vi.fn().mockResolvedValue(undefined) }),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   useBlocker: (...args: unknown[]) => mockUseBlocker(...args),
 }))

--- a/frontend/app/src/hooks/form/useTreeForm.ts
+++ b/frontend/app/src/hooks/form/useTreeForm.ts
@@ -1,5 +1,3 @@
-import { QueryClient } from '@tanstack/react-query'
-import { clusterQueries, treeQueries } from '@/api/queries'
 import type { Tree, TreeCreate, TreeUpdate } from '@/api/backendApi'
 import { treeApi } from '@/api/backendApi'
 import { TreeForm } from '@/schema/treeSchema'
@@ -14,19 +12,8 @@ const treeConfig: EntityFormConfig<TreeForm, TreeCreate, TreeUpdate, Tree> = {
   createFn: (body) => treeApi.createTree({ treeCreateRequest: body }),
   updateFn: (id, body) => treeApi.updateTree({ treeId: id, treeUpdateRequest: body }),
 
-  invalidateQueries: (data, queryClient: QueryClient) => {
-    queryClient
-      .invalidateQueries(treeQueries.detail(String(data.id)))
-      .catch((error) => console.error('Invalidate "treeQueries.detail" failed:', error))
-    queryClient
-      .invalidateQueries(treeQueries.list())
-      .catch((error) => console.error('Invalidate "treeQueries.list" failed:', error))
-    if (data.treeClusterId) {
-      queryClient
-        .invalidateQueries(clusterQueries.detail(String(data.treeClusterId)))
-        .catch((error) => console.error('Invalidate "clusterQueries.detail" failed:', error))
-    }
-  },
+  // Cluster too: assigning a tree shifts the cluster's centroid and status.
+  invalidates: ['tree', 'cluster'],
 
   successRoute: (id) => ({
     to: '/trees/$treeId',

--- a/frontend/app/src/hooks/form/useVehicleForm.test.tsx
+++ b/frontend/app/src/hooks/form/useVehicleForm.test.tsx
@@ -22,6 +22,7 @@ const mockUseBlocker = vi.fn().mockReturnValue({
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn().mockResolvedValue(undefined),
+  useRouter: () => ({ invalidate: vi.fn().mockResolvedValue(undefined) }),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   useBlocker: (...args: unknown[]) => mockUseBlocker(...args),
 }))

--- a/frontend/app/src/hooks/form/useVehicleForm.ts
+++ b/frontend/app/src/hooks/form/useVehicleForm.ts
@@ -1,5 +1,3 @@
-import { QueryClient } from '@tanstack/react-query'
-import { vehicleQueries } from '@/api/queries'
 import type { Vehicle, VehicleCreate, VehicleUpdate } from '@/api/backendApi'
 import { vehicleApi } from '@/api/backendApi'
 import { VehicleForm } from '@/schema/vehicleSchema'
@@ -14,14 +12,8 @@ const vehicleConfig: EntityFormConfig<VehicleForm, VehicleCreate, VehicleUpdate,
   createFn: (body) => vehicleApi.createVehicle({ vehicleCreateRequest: body }),
   updateFn: (id, body) => vehicleApi.updateVehicle({ vehicleId: id, vehicleUpdateRequest: body }),
 
-  invalidateQueries: (data, queryClient: QueryClient) => {
-    queryClient
-      .invalidateQueries(vehicleQueries.detail(String(data.id)))
-      .catch((error) => console.error('Invalidate "vehicleQueries.detail" failed:', error))
-    queryClient
-      .invalidateQueries(vehicleQueries.list())
-      .catch((error) => console.error('Invalidate "vehicleQueries.list" failed:', error))
-  },
+  // Watering plans embed their transporter and trailer.
+  invalidates: ['vehicle', 'wateringPlan'],
 
   successRoute: (id) => ({
     to: '/vehicles/$vehicleId',

--- a/frontend/app/src/hooks/form/useWateringPlanForm.test.tsx
+++ b/frontend/app/src/hooks/form/useWateringPlanForm.test.tsx
@@ -22,6 +22,7 @@ const mockUseBlocker = vi.fn().mockReturnValue({
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn().mockResolvedValue(undefined),
+  useRouter: () => ({ invalidate: vi.fn().mockResolvedValue(undefined) }),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   useBlocker: (...args: unknown[]) => mockUseBlocker(...args),
 }))

--- a/frontend/app/src/hooks/form/useWateringPlanForm.ts
+++ b/frontend/app/src/hooks/form/useWateringPlanForm.ts
@@ -1,5 +1,3 @@
-import { QueryClient } from '@tanstack/react-query'
-import { wateringPlanQueries } from '@/api/queries'
 import type { WateringPlan, WateringPlanCreate, WateringPlanUpdate } from '@/api/backendApi'
 import { wateringPlanApi } from '@/api/backendApi'
 import { WateringPlanForm } from '@/schema/wateringPlanSchema'
@@ -23,14 +21,7 @@ const wateringPlanConfig: EntityFormConfig<
       wateringPlanUpdateRequest: body,
     }),
 
-  invalidateQueries: (data, queryClient: QueryClient) => {
-    queryClient
-      .invalidateQueries(wateringPlanQueries.detail(String(data.id)))
-      .catch((error) => console.error('Invalidate "wateringPlanQueries.detail" failed', error))
-    queryClient
-      .invalidateQueries({ queryKey: ['watering-plans'] })
-      .catch((error) => console.error('Invalidate "watering-plans" failed:', error))
-  },
+  invalidates: ['wateringPlan'],
 
   successRoute: (id) => ({
     to: '/watering-plans/$wateringPlanId',

--- a/frontend/app/src/hooks/useSensorTreeMutations.ts
+++ b/frontend/app/src/hooks/useSensorTreeMutations.ts
@@ -1,52 +1,38 @@
 import { sensorApi } from '@/api/backendApi'
-import { sensorQueries, treeQueries } from '@/api/queries'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useRouter } from '@tanstack/react-router'
-import type { RegisteredRouter } from '@tanstack/react-router'
+import { useMutation } from '@tanstack/react-query'
+import { useInvalidateAggregates } from '@/lib/queryInvalidation'
 
-const invalidateSensorAndTrees = async (
-  queryClient: ReturnType<typeof useQueryClient>,
-  router: RegisteredRouter,
-  sensorId: string,
-  treeIds: (string | null | undefined)[],
-) => {
-  await Promise.all([
-    queryClient.invalidateQueries({ queryKey: sensorQueries.key }),
-    queryClient.invalidateQueries({ queryKey: sensorQueries.detail(sensorId).queryKey }),
-    ...treeIds
-      .filter((id): id is string => !!id)
-      .map((id) => queryClient.invalidateQueries({ queryKey: treeQueries.detail(id).queryKey })),
-  ])
-  // Detail routes read the sensor/tree from loader data; re-run their loaders.
-  await router.invalidate()
+/**
+ * Sensor/tree link changes. The sensor detail page stays mounted afterwards and
+ * its breadcrumb comes from loader data, so the route loaders re-run too.
+ */
+const useInvalidateSensorTreeLink = () => {
+  const invalidate = useInvalidateAggregates()
+  return () => invalidate(['sensor', 'tree'], { reloadRoutes: true })
 }
 
 export const useActivateSensor = (sensorId: string) => {
-  const queryClient = useQueryClient()
-  const router = useRouter()
+  const invalidateLink = useInvalidateSensorTreeLink()
   return useMutation({
     mutationFn: (treeId: string) =>
       sensorApi.activateSensor({ sensorId, activateSensorRequest: { treeId } }),
-    onSuccess: (_data, treeId) => invalidateSensorAndTrees(queryClient, router, sensorId, [treeId]),
+    onSuccess: invalidateLink,
   })
 }
 
-export const useReassignSensorTree = (sensorId: string, previousTreeId?: string | null) => {
-  const queryClient = useQueryClient()
-  const router = useRouter()
+export const useReassignSensorTree = (sensorId: string) => {
+  const invalidateLink = useInvalidateSensorTreeLink()
   return useMutation({
     mutationFn: (treeId: string) =>
       sensorApi.setSensorTree({ sensorId, setSensorTreeRequest: { treeId } }),
-    onSuccess: (_data, treeId) =>
-      invalidateSensorAndTrees(queryClient, router, sensorId, [previousTreeId, treeId]),
+    onSuccess: invalidateLink,
   })
 }
 
-export const useDeactivateSensor = (sensorId: string, previousTreeId?: string | null) => {
-  const queryClient = useQueryClient()
-  const router = useRouter()
+export const useDeactivateSensor = (sensorId: string) => {
+  const invalidateLink = useInvalidateSensorTreeLink()
   return useMutation({
     mutationFn: () => sensorApi.removeSensorTree({ sensorId }),
-    onSuccess: () => invalidateSensorAndTrees(queryClient, router, sensorId, [previousTreeId]),
+    onSuccess: invalidateLink,
   })
 }

--- a/frontend/app/src/hooks/useWateringPlanBoardMutations.test.tsx
+++ b/frontend/app/src/hooks/useWateringPlanBoardMutations.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { renderHook, waitFor } from '@testing-library/react'
+import { WateringPlanStatus } from '@green-ecolution/backend-client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { QueryKey } from '@tanstack/react-query'
+import { clusterQueries, treeQueries, wateringPlanQueries } from '@/api/queries'
+import { useWateringPlanBoardMutations } from './useWateringPlanBoardMutations'
+import type { WateringPlanInList } from '@/api/backendApi'
+
+const updateWateringPlan = vi.fn()
+vi.mock('@/api/backendApi', () => ({
+  wateringPlanApi: {
+    updateWateringPlan: (...args: unknown[]) => updateWateringPlan(...args) as unknown,
+  },
+}))
+
+const routerInvalidate = vi.fn().mockResolvedValue(undefined)
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({ invalidate: routerInvalidate }),
+}))
+
+vi.mock('@/hooks/createToast', () => ({ default: () => vi.fn() }))
+
+const CLUSTER_ID = '0190a8e9-7c4f-7000-8000-000000000001'
+const TREE_ID = '0190a8e9-7c4f-7000-8000-000000000002'
+const PLAN_ID = '0190a8e9-7c4f-7000-8000-000000000003'
+
+const CLUSTER_DETAIL: QueryKey = clusterQueries.detail(CLUSTER_ID).queryKey
+const CLUSTER_LIST: QueryKey = clusterQueries.list().queryKey
+const TREE_DETAIL: QueryKey = treeQueries.detail(TREE_ID).queryKey
+const PLAN_DETAIL: QueryKey = wateringPlanQueries.detail(PLAN_ID).queryKey
+
+const plan = {
+  id: PLAN_ID,
+  date: '2026-08-19T00:00:00Z',
+  description: '',
+  status: WateringPlanStatus.Active,
+  transporter: { id: '0190a8e9-7c4f-7000-8000-000000000004' },
+  treeclusters: [{ id: CLUSTER_ID }],
+  userIds: [],
+} as unknown as WateringPlanInList
+
+const evaluation = [{ wateringPlanId: PLAN_ID, treeClusterId: CLUSTER_ID, consumedWater: 100 }]
+
+/** Mirrors main.tsx: a 60s staleTime is what makes a missed invalidation visible. */
+function renderBoardMutations() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: 60_000, retry: false }, mutations: { retry: false } },
+  })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  const view = renderHook(() => useWateringPlanBoardMutations(), { wrapper })
+
+  // Cached views a user visited before the mutation.
+  ;[CLUSTER_DETAIL, CLUSTER_LIST, TREE_DETAIL, PLAN_DETAIL].forEach((key) =>
+    queryClient.setQueryData(key, { seeded: true }),
+  )
+
+  return { ...view, queryClient }
+}
+
+describe('useWateringPlanBoardMutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    updateWateringPlan.mockResolvedValue({ id: PLAN_ID })
+  })
+
+  it('invalidates clusters and trees after finishing a plan', async () => {
+    const { result, queryClient } = renderBoardMutations()
+    const isInvalidated = (key: QueryKey) => queryClient.getQueryState(key)?.isInvalidated === true
+
+    result.current.finishPlan.mutate({ plan, evaluation })
+
+    await waitFor(() => expect(isInvalidated(CLUSTER_DETAIL)).toBe(true))
+    expect(isInvalidated(CLUSTER_LIST)).toBe(true)
+    expect(isInvalidated(TREE_DETAIL)).toBe(true)
+    expect(isInvalidated(PLAN_DETAIL)).toBe(true)
+  })
+
+  it('re-runs the route loaders that loader-based detail pages read from', async () => {
+    const { result } = renderBoardMutations()
+
+    result.current.finishPlan.mutate({ plan, evaluation })
+
+    await waitFor(() => expect(routerInvalidate).toHaveBeenCalled())
+  })
+
+  it('keeps a user assignment scoped to watering plans', async () => {
+    const { result, queryClient } = renderBoardMutations()
+    const isInvalidated = (key: QueryKey) => queryClient.getQueryState(key)?.isInvalidated === true
+
+    result.current.assignUsers.mutate({ plan, userIds: ['u1'] })
+
+    await waitFor(() => expect(isInvalidated(PLAN_DETAIL)).toBe(true))
+    expect(isInvalidated(CLUSTER_DETAIL)).toBe(false)
+    expect(isInvalidated(TREE_DETAIL)).toBe(false)
+  })
+})

--- a/frontend/app/src/hooks/useWateringPlanBoardMutations.ts
+++ b/frontend/app/src/hooks/useWateringPlanBoardMutations.ts
@@ -9,7 +9,8 @@ export type PlanEvaluation = NonNullable<WateringPlanUpdateRequest['evaluation']
 
 import { wateringPlanApi } from '@/api/backendApi'
 import type { WateringPlanInList } from '@/api/backendApi'
-import { wateringPlanQueries } from '@/api/queries'
+import { wateringPlanQueries, type Aggregate } from '@/api/queries'
+import { PLAN_STATUS_AGGREGATES, useInvalidateAggregates } from '@/lib/queryInvalidation'
 import createToast from '@/hooks/createToast'
 
 export const toUpdateRequest = (
@@ -34,17 +35,19 @@ const activeKey = wateringPlanQueries.boardColumn([WateringPlanStatus.Active]).q
 
 export const useWateringPlanBoardMutations = () => {
   const queryClient = useQueryClient()
+  const invalidate = useInvalidateAggregates()
   const showToast = createToast()
 
-  const invalidateBoard = () => {
-    // cancelQueries is scoped to board to avoid aborting unrelated watering-plan queries; invalidate is broad for consistency.
-    queryClient
-      .invalidateQueries({ queryKey: ['watering-plans'] })
-      .catch((error) => console.error('Invalidate watering-plans failed:', error))
-    queryClient
-      .invalidateQueries({ queryKey: ['watering-plan'] })
-      .catch((error) => console.error('Invalidate watering-plan failed:', error))
-  }
+  // The board stays mounted after a mutation, so the route loaders have to
+  // re-run as well; cancelQueries elsewhere is scoped to the board to avoid
+  // aborting unrelated watering-plan queries.
+  const runInvalidation = (aggregates: readonly Aggregate[]) =>
+    invalidate(aggregates, { reloadRoutes: true }).catch((error) =>
+      console.error('Invalidation after watering plan mutation failed:', error),
+    )
+
+  const invalidateAfterStatusChange = () => void runInvalidation(PLAN_STATUS_AGGREGATES)
+  const invalidatePlans = () => void runInvalidation(['wateringPlan'])
 
   const update = (plan: WateringPlanInList, overrides: Partial<WateringPlanUpdateRequest>) =>
     wateringPlanApi.updateWateringPlan({
@@ -80,7 +83,7 @@ export const useWateringPlanBoardMutations = () => {
       showToast(`Der Start konnte nicht rückgängig gemacht werden: ${error.message}`, 'error')
     },
     onSuccess: () => showToast('Start rückgängig gemacht.'),
-    onSettled: invalidateBoard,
+    onSettled: invalidateAfterStatusChange,
   })
 
   const startPlan = useMutation({
@@ -114,7 +117,7 @@ export const useWateringPlanBoardMutations = () => {
       showToast('Einsatz gestartet.', 'success', {
         action: { label: 'Rückgängig', onClick: () => revertStart.mutate(plan) },
       }),
-    onSettled: invalidateBoard,
+    onSettled: invalidateAfterStatusChange,
   })
 
   const cancelPlan = useMutation({
@@ -124,7 +127,7 @@ export const useWateringPlanBoardMutations = () => {
       showToast(`Der Einsatz konnte nicht abgebrochen werden: ${error.message}`, 'error'),
     onSuccess: () => {
       showToast('Einsatz abgebrochen.')
-      invalidateBoard()
+      invalidateAfterStatusChange()
     },
   })
 
@@ -135,7 +138,7 @@ export const useWateringPlanBoardMutations = () => {
       showToast(`Der Einsatz konnte nicht abgeschlossen werden: ${error.message}`, 'error'),
     onSuccess: () => {
       showToast('Einsatz abgeschlossen.')
-      invalidateBoard()
+      invalidateAfterStatusChange()
     },
   })
 
@@ -146,7 +149,7 @@ export const useWateringPlanBoardMutations = () => {
       showToast(`Die Zuweisung konnte nicht gespeichert werden: ${error.message}`, 'error'),
     onSuccess: () => {
       showToast('Zuweisung gespeichert.')
-      invalidateBoard()
+      invalidatePlans()
     },
   })
 

--- a/frontend/app/src/lib/queryInvalidation.test.tsx
+++ b/frontend/app/src/lib/queryInvalidation.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest'
+import { QueryClient } from '@tanstack/react-query'
+import type { QueryKey } from '@tanstack/react-query'
+import { clusterQueries, treeQueries, wateringPlanQueries } from '@/api/queries'
+import { invalidateAggregates } from './queryInvalidation'
+
+const CLUSTER_ID = '0190a8e9-7c4f-7000-8000-000000000001'
+const TREE_ID = '0190a8e9-7c4f-7000-8000-000000000002'
+
+const makeClient = () =>
+  new QueryClient({ defaultOptions: { queries: { staleTime: 60_000, retry: false } } })
+
+const seed = (queryClient: QueryClient, keys: QueryKey[]) =>
+  keys.forEach((key) => queryClient.setQueryData(key, { seeded: true }))
+
+const isInvalidated = (queryClient: QueryClient, key: QueryKey) =>
+  queryClient.getQueryState(key)?.isInvalidated === true
+
+const routerStub = () => ({ invalidate: vi.fn().mockResolvedValue(undefined) })
+
+describe('invalidateAggregates', () => {
+  it('reaches every key root a cluster query can live under', async () => {
+    const queryClient = makeClient()
+    const keys: QueryKey[] = [
+      clusterQueries.detail(CLUSTER_ID).queryKey,
+      clusterQueries.list().queryKey,
+      clusterQueries.statistics().queryKey,
+      clusterQueries.markers().queryKey,
+      clusterQueries.boundaries().queryKey,
+      clusterQueries.soilMoisture(CLUSTER_ID, { bucket: 'day' }).queryKey,
+    ]
+    seed(queryClient, keys)
+
+    await invalidateAggregates(queryClient, routerStub(), ['cluster'])
+
+    keys.forEach((key) => expect(isInvalidated(queryClient, key)).toBe(true))
+  })
+
+  it('reaches every key root a tree query can live under', async () => {
+    const queryClient = makeClient()
+    const keys: QueryKey[] = [
+      treeQueries.detail(TREE_ID).queryKey,
+      treeQueries.list().queryKey,
+      treeQueries.plantingYears().queryKey,
+      treeQueries.nearest({ lat: 54.78, lng: 9.44 }).queryKey,
+      treeQueries.markers({ bbox: { swLat: 54.7, swLng: 9.4, neLat: 54.8, neLng: 9.5 } }).queryKey,
+    ]
+    seed(queryClient, keys)
+
+    await invalidateAggregates(queryClient, routerStub(), ['tree'])
+
+    keys.forEach((key) => expect(isInvalidated(queryClient, key)).toBe(true))
+  })
+
+  it('leaves unrelated aggregates alone', async () => {
+    const queryClient = makeClient()
+    seed(queryClient, [
+      clusterQueries.detail(CLUSTER_ID).queryKey,
+      treeQueries.detail(TREE_ID).queryKey,
+    ])
+
+    await invalidateAggregates(queryClient, routerStub(), ['wateringPlan'])
+
+    expect(isInvalidated(queryClient, clusterQueries.detail(CLUSTER_ID).queryKey)).toBe(false)
+    expect(isInvalidated(queryClient, treeQueries.detail(TREE_ID).queryKey)).toBe(false)
+  })
+
+  it('invalidates several aggregates at once', async () => {
+    const queryClient = makeClient()
+    const planKey = wateringPlanQueries.detail(CLUSTER_ID).queryKey
+    seed(queryClient, [
+      planKey,
+      clusterQueries.list().queryKey,
+      treeQueries.detail(TREE_ID).queryKey,
+    ])
+
+    await invalidateAggregates(queryClient, routerStub(), ['wateringPlan', 'cluster', 'tree'])
+
+    expect(isInvalidated(queryClient, planKey)).toBe(true)
+    expect(isInvalidated(queryClient, clusterQueries.list().queryKey)).toBe(true)
+    expect(isInvalidated(queryClient, treeQueries.detail(TREE_ID).queryKey)).toBe(true)
+  })
+
+  it('only re-runs the route loaders when asked to', async () => {
+    const queryClient = makeClient()
+
+    const quiet = routerStub()
+    await invalidateAggregates(queryClient, quiet, ['cluster'])
+    expect(quiet.invalidate).not.toHaveBeenCalled()
+
+    const reloading = routerStub()
+    await invalidateAggregates(queryClient, reloading, ['cluster'], { reloadRoutes: true })
+    expect(reloading.invalidate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/app/src/lib/queryInvalidation.ts
+++ b/frontend/app/src/lib/queryInvalidation.ts
@@ -1,0 +1,63 @@
+import { useCallback } from 'react'
+import { useQueryClient, type QueryClient } from '@tanstack/react-query'
+import { useRouter, type RegisteredRouter } from '@tanstack/react-router'
+import { queryRoots, type Aggregate } from '@/api/queries'
+
+/** The only router capability this module needs. */
+type RouteReloader = Pick<RegisteredRouter, 'invalidate'>
+
+export interface InvalidateOptions {
+  /**
+   * Also re-run the loaders of the active routes. Needed when the mutation
+   * keeps the user on an `entityRoute` page: those read the entity from loader
+   * data, which no query subscription reaches. Leave it off when the caller
+   * navigates afterwards — the navigation re-runs the loaders anyway — and
+   * especially after a delete, where re-running the loader of the now-missing
+   * entity renders EntityNotFound before the redirect lands.
+   */
+  reloadRoutes?: boolean
+}
+
+/**
+ * Invalidate every query root of the given aggregates.
+ *
+ * Callers that navigate right after do not need to await this:
+ * `invalidateQueries` marks the entries stale synchronously, so a route loader
+ * running in the same tick already refetches.
+ */
+export const invalidateAggregates = async (
+  queryClient: QueryClient,
+  router: RouteReloader,
+  aggregates: readonly Aggregate[],
+  { reloadRoutes = false }: InvalidateOptions = {},
+): Promise<void> => {
+  await Promise.all(
+    aggregates.flatMap((aggregate) =>
+      queryRoots[aggregate].map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+    ),
+  )
+  if (reloadRoutes) await router.invalidate()
+}
+
+/**
+ * Aggregates touched by a watering plan status change: finishing a plan flags
+ * its clusters and their trees as just watered, and the evaluation dashboard
+ * aggregates finished plans.
+ */
+export const PLAN_STATUS_AGGREGATES: readonly Aggregate[] = [
+  'wateringPlan',
+  'cluster',
+  'tree',
+  'evaluation',
+]
+
+export const useInvalidateAggregates = () => {
+  const queryClient = useQueryClient()
+  const router = useRouter()
+
+  return useCallback(
+    (aggregates: readonly Aggregate[], options?: InvalidateOptions) =>
+      invalidateAggregates(queryClient, router, aggregates, options),
+    [queryClient, router],
+  )
+}

--- a/frontend/app/src/routes/_protected/map/tree/edit/$treeId/index.tsx
+++ b/frontend/app/src/routes/_protected/map/tree/edit/$treeId/index.tsx
@@ -9,6 +9,7 @@ import { treeApi } from '@/api/backendApi'
 import { TreeForm } from '@/schema/treeSchema'
 import { useTreeForm } from '@/hooks/form/useTreeForm'
 import createToast from '@/hooks/createToast'
+import { useInvalidateAggregates } from '@/lib/queryInvalidation'
 import { entityNotFound, forbiddenErrorComponent, prefetch, requirePermission } from '@/lib/router'
 import { useHasPermission } from '@/lib/auth/useHasPermission'
 import FormForTree from '@/components/general/form/FormForTree'
@@ -42,6 +43,7 @@ export const Route = createFileRoute('/_protected/map/tree/edit/$treeId/')({
 function EditTreeOnMap() {
   const { treeId } = Route.useParams()
   const navigate = useNavigate({ from: Route.fullPath })
+  const invalidate = useInvalidateAggregates()
   const showToast = createToast()
   const map = useMaplibreMap()
   const { data: tree } = useSuspenseQuery(treeQueries.detail(treeId))
@@ -109,7 +111,11 @@ function EditTreeOnMap() {
     navigationBlocker.allowNavigation()
     treeApi
       .deleteTree({ treeId })
+      // Invalidate only after leaving: this panel holds a live query on the
+      // tree, which would refetch into a 404 while still mounted. Cluster too,
+      // because removing a tree shifts its cluster's centroid and status.
       .then(() => navigate({ to: '/map', search: (prev) => prev }))
+      .then(() => invalidate(['tree', 'cluster']))
       .then(() => showToast('Der Baum wurde gelöscht.'))
       .catch((error) => {
         console.error('Delete failed:', error)

--- a/frontend/app/src/routes/_protected/sensors/new/index.tsx
+++ b/frontend/app/src/routes/_protected/sensors/new/index.tsx
@@ -1,5 +1,6 @@
 import { sensorApi } from '@/api/backendApi'
-import { sensorQueries, treeQueries } from '@/api/queries'
+import { sensorQueries } from '@/api/queries'
+import { useInvalidateAggregates } from '@/lib/queryInvalidation'
 import { mapActivateError, resolveResponseStatus } from '@/api/sensorErrors'
 import SensorReviewStep from '@/components/sensor/wizard/SensorReviewStep'
 import SensorScanStep from '@/components/sensor/wizard/SensorScanStep'
@@ -13,7 +14,7 @@ import {
   type WizardStep,
 } from '@/components/sensor/wizard/state'
 import useGeolocation from '@/hooks/useGeolocation'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useCallback, useEffect, useReducer } from 'react'
 
@@ -23,7 +24,7 @@ export const Route = createFileRoute('/_protected/sensors/new/')({
 
 function NewSensor() {
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
+  const invalidate = useInvalidateAggregates()
   const [state, dispatch] = useReducer(wizardReducer, INITIAL_WIZARD_STATE)
   const {
     status: gpsStatus,
@@ -65,22 +66,7 @@ function NewSensor() {
     onMutate: () => dispatch({ type: 'submissionStart' }),
     onSuccess: async () => {
       dispatch({ type: 'submissionSuccess' })
-      const invalidations = [queryClient.invalidateQueries({ queryKey: sensorQueries.key })]
-      if (state.sensorId) {
-        invalidations.push(
-          queryClient.invalidateQueries({
-            queryKey: sensorQueries.detail(state.sensorId).queryKey,
-          }),
-        )
-      }
-      if (state.selectedTreeId) {
-        invalidations.push(
-          queryClient.invalidateQueries({
-            queryKey: treeQueries.detail(state.selectedTreeId).queryKey,
-          }),
-        )
-      }
-      await Promise.all(invalidations)
+      await invalidate(['sensor', 'tree'])
     },
     onError: (err) => dispatch({ type: 'submissionError', message: mapActivateError(err) }),
   })


### PR DESCRIPTION
Views kept showing pre-mutation data until a hard reload. After a watering plan status change only the plan queries were invalidated, so the cluster and tree caches served the old watering status for up to the global 60s staleTime. Deleting or archiving an entity invalidated nothing at all, so the list navigated to still contained it.

Query keys had grown inconsistent roots (`treecluster/treeclusters/clusters`, `tree/trees/planting-years`), which made per-call-site invalidation miss one root reliably. Add a `queryRoots` table listing every root per aggregate and route all invalidation through `invalidateAggregates`, then wire it into the plan status changes, the entity forms and the delete/archive paths.

Delete paths navigate before invalidating: a live query on the removed entity would otherwise refetch into a 404 and flash EntityNotFound.

`router.invalidate()` stays opt-in via `reloadRoutes`. Route loaders re-run on every navigation because `defaultStaleTime` is 0, so it is only needed where a mutation keeps the user on a loader-based page.