### PR TITLE
fix(frontend): show stored avatars in the member management

### DIFF
--- a/frontend/app/src/components/settings/members/MemberDetail.tsx
+++ b/frontend/app/src/components/settings/members/MemberDetail.tsx
@@ -1,9 +1,8 @@
-import { Badge } from '@green-ecolution/ui'
+import { Avatar, AvatarFallback, AvatarImage, Badge } from '@green-ecolution/ui'
 import type { DrivingLicense, UserStatus } from '@green-ecolution/backend-client'
 import type { OrganizationResponse, RoleResponse, UserResponse } from '@/api/backendApi'
 import { getUserStatusDetails } from '@/hooks/details/useDetailsForUserStatus'
 import { initialsOf } from '@/lib/initials'
-import { TILE } from './cardChrome'
 import MemberActionButtons from './MemberActionButtons'
 import { fullNameOf, phoneNumberIssue, sinceLabel } from './memberList'
 import MemberOrganizationCard from './MemberOrganizationCard'
@@ -82,9 +81,12 @@ const MemberDetail = ({
   return (
     <div className="flex flex-col gap-6">
       <header className="flex min-w-0 items-start gap-4">
-        <span className={`${TILE} size-12 rounded-xl bg-green-dark text-base text-white`}>
-          {initialsOf(user.firstName, user.lastName)}
-        </span>
+        <Avatar size="lg" className="rounded-xl">
+          {user.avatarUrl && <AvatarImage src={user.avatarUrl} alt="" />}
+          <AvatarFallback variant="user" className="rounded-xl">
+            {initialsOf(user.firstName, user.lastName)}
+          </AvatarFallback>
+        </Avatar>
         <div className="min-w-0 flex-1">
           <h2 className="font-lato text-2xl font-bold text-dark break-words">{fullNameOf(user)}</h2>
           <p className="mt-0.5 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm text-dark-600">

--- a/frontend/app/src/components/settings/members/MemberListItem.tsx
+++ b/frontend/app/src/components/settings/members/MemberListItem.tsx
@@ -1,4 +1,4 @@
-import { Avatar, AvatarFallback, Badge, ListCard } from '@green-ecolution/ui'
+import { Avatar, AvatarFallback, AvatarImage, Badge, ListCard } from '@green-ecolution/ui'
 import type { UserResponse } from '@/api/backendApi'
 import { getUserStatusDetails } from '@/hooks/details/useDetailsForUserStatus'
 import { initialsOf } from '@/lib/initials'
@@ -22,6 +22,7 @@ const MemberListItem = ({ user, selected, onSelect }: MemberListItemProps) => {
     >
       <button type="button" onClick={onSelect} aria-current={selected} className="w-full text-left">
         <Avatar size="sm">
+          {user.avatarUrl && <AvatarImage src={user.avatarUrl} alt="" />}
           <AvatarFallback variant="user">
             {initialsOf(user.firstName, user.lastName)}
           </AvatarFallback>

--- a/frontend/app/src/components/settings/members/MembersPage.test.tsx
+++ b/frontend/app/src/components/settings/members/MembersPage.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, userEvent, waitFor, within } from '@/test/utils'
 import { UNRESTRICTED, type Permissions } from '@/lib/auth/permissions'
 import type { OrganizationResponse, RoleResponse, UserResponse } from '@/api/backendApi'
@@ -67,10 +67,17 @@ const badPhoneUser: UserResponse = {
   phoneNumber: '123',
 }
 
+// No organization and no avatar: the API sends an empty string for a profile
+// that never had one.
+const legacyUser: UserResponse = {
+  ...member('u-legacy', 'Cem', 'Demir', null, []),
+  avatarUrl: '',
+}
+
 const users: UserResponse[] = [
   member('u-anna', 'Anna', 'Ahlmann', 'amt', [ROLES[0]]),
   member('u-bo', 'Bo', 'Boysen', 'nord', []),
-  member('u-legacy', 'Cem', 'Demir', null, []),
+  legacyUser,
   badPhoneUser,
 ]
 
@@ -516,5 +523,43 @@ describe('MembersPage', () => {
     await select(/Anna Ahlmann/)
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument()
+  })
+
+  describe('avatars', () => {
+    // Radix keeps AvatarImage unmounted until the browser reports the image as
+    // loaded, which jsdom never does — so it stands in as an already-loaded one.
+    class PreloadedImage {
+      complete = true
+      naturalWidth = 1
+      src = ''
+      crossOrigin: string | null = null
+      addEventListener = vi.fn()
+      removeEventListener = vi.fn()
+    }
+
+    beforeEach(() => vi.stubGlobal('Image', PreloadedImage))
+    afterEach(() => vi.unstubAllGlobals())
+
+    it('shows a stored avatar in the list and on the detail panel', async () => {
+      const { container } = render(<MembersPage />)
+      const avatarsOf = (id: string) => container.querySelectorAll(`img[src="${avatarOf(id)}"]`)
+
+      // Anna is the auto-selected default, so her avatar shows up twice.
+      expect(avatarsOf('u-anna')).toHaveLength(2)
+      expect(avatarsOf('u-bo')).toHaveLength(1)
+
+      await select(/Bo Boysen/)
+
+      expect(avatarsOf('u-bo')).toHaveLength(2)
+      expect(avatarsOf('u-anna')).toHaveLength(1)
+    })
+
+    it('keeps the monogram for a member without an avatar', async () => {
+      const { container } = render(<MembersPage />)
+      await select(/Cem Demir/)
+
+      expect(container.querySelectorAll(`img[src*="u-legacy"]`)).toHaveLength(0)
+      expect(screen.getAllByText('CD')).toHaveLength(2)
+    })
   })
 })

--- a/frontend/app/src/components/settings/members/cardChrome.ts
+++ b/frontend/app/src/components/settings/members/cardChrome.ts
@@ -1,3 +1,2 @@
 export const CARD = '@container rounded-xl border border-dark-50 bg-white p-5 shadow-cards'
 export const CARD_TITLE = 'font-lato text-base font-semibold text-dark'
-export const TILE = 'flex shrink-0 items-center justify-center rounded-lg font-semibold'


### PR DESCRIPTION
The member list rendered an Avatar with a fallback only, and the detail header was a plain tile holding the initials, so a profile with an avatar_url still showed its monogram. Both now render AvatarImage and keep the monogram as the fallback for profiles without one.

The detail header keeps its square tile: size lg matches the previous size-12, and rounded-xl overrides the round default on root and fallback. TILE has no consumer left and is dropped from cardChrome.