### PR TITLE
feat: choose the organization when creating a watering group (OP#3203)

### DIFF
--- a/backend/.sqlx/query-5aab27fe7b78b6a97d3c65c428caf0e61ec1e9aa548c14c0c111a56126369675.json
+++ b/backend/.sqlx/query-5aab27fe7b78b6a97d3c65c428caf0e61ec1e9aa548c14c0c111a56126369675.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, latitude, longitude, number,\n                      watering_status AS \"watering_status: WateringStatus\",\n                      (sensor_id IS NOT NULL) AS \"has_sensor!: bool\"\n            FROM trees\n            WHERE ($1::watering_status[] = '{}' OR watering_status = ANY($1))\n              AND ($2::int[] = '{}' OR planting_year = ANY($2))\n              AND ($3::text IS NULL OR provider = $3)\n              AND ($4::bool IS NULL\n                   OR ($4 = true AND tree_cluster_id IS NOT NULL)\n                   OR ($4 = false AND tree_cluster_id IS NULL))\n              AND ($5::bool IS FALSE\n                   OR ST_Intersects(\n                       geometry,\n                       ST_MakeEnvelope($6, $7, $8, $9, 4326)\n                   ))\n              AND ($10::uuid[] IS NULL OR organization_id = ANY($10))\n            ORDER BY id",
+  "query": "SELECT id, latitude, longitude, number, organization_id,\n                      watering_status AS \"watering_status: WateringStatus\",\n                      (sensor_id IS NOT NULL) AS \"has_sensor!: bool\"\n            FROM trees\n            WHERE ($1::watering_status[] = '{}' OR watering_status = ANY($1))\n              AND ($2::int[] = '{}' OR planting_year = ANY($2))\n              AND ($3::text IS NULL OR provider = $3)\n              AND ($4::bool IS NULL\n                   OR ($4 = true AND tree_cluster_id IS NOT NULL)\n                   OR ($4 = false AND tree_cluster_id IS NULL))\n              AND ($5::bool IS FALSE\n                   OR ST_Intersects(\n                       geometry,\n                       ST_MakeEnvelope($6, $7, $8, $9, 4326)\n                   ))\n              AND ($10::uuid[] IS NULL OR organization_id = ANY($10))\n            ORDER BY id",
   "describe": {
     "columns": [
       {
@@ -25,6 +25,11 @@
       },
       {
         "ordinal": 4,
+        "name": "organization_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 5,
         "name": "watering_status: WateringStatus",
         "type_info": {
           "Custom": {
@@ -42,7 +47,7 @@
         }
       },
       {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "has_sensor!: bool",
         "type_info": "Bool"
       }
@@ -87,8 +92,9 @@
       false,
       false,
       false,
+      false,
       null
     ]
   },
-  "hash": "cbaff8af55c76126015469988b041da7e9759b75539de2502c0b5820381f6646"
+  "hash": "5aab27fe7b78b6a97d3c65c428caf0e61ec1e9aa548c14c0c111a56126369675"
 }

--- a/backend/crates/domain/src/tree/marker.rs
+++ b/backend/crates/domain/src/tree/marker.rs
@@ -4,8 +4,10 @@ use crate::shared::watering_status::WateringStatus;
 
 /// Lightweight projection of a tree intended for map markers.
 ///
-/// Carries only what the marker layer renders: position, status, label, and
-/// whether a sensor exists. It is *not* an aggregate hydration target.
+/// Carries only what the marker layer renders: position, status, label,
+/// whether a sensor exists, and the owning organization — the cluster forms
+/// need it to tell selectable trees from foreign ones. It is *not* an
+/// aggregate hydration target.
 #[derive(Debug, Clone)]
 pub struct TreeMarker {
     pub id: Uuid,
@@ -14,4 +16,5 @@ pub struct TreeMarker {
     pub watering_status: WateringStatus,
     pub tree_number: String,
     pub has_sensor: bool,
+    pub organization_id: Uuid,
 }

--- a/backend/crates/domain/src/tree/mod.rs
+++ b/backend/crates/domain/src/tree/mod.rs
@@ -101,6 +101,10 @@ pub struct TreeSearchQuery {
     pub bbox: Option<BoundingBox>,
     /// Case-insensitive text filter on tree number or species.
     pub q: Option<String>,
+    /// Narrows the result to one owning organization. Independent of
+    /// `visible`: the caller asks for a single org, `visible` decides whether
+    /// they are allowed to see it at all.
+    pub organization_id: Option<Id<Organization>>,
     /// Which organizations may see the result. Callers must set this per
     /// request; defaults to unrestricted for internal consumers (e.g. event
     /// handlers).

--- a/backend/crates/server/src/http/v1/dto/tree.rs
+++ b/backend/crates/server/src/http/v1/dto/tree.rs
@@ -233,6 +233,10 @@ pub struct TreeMarkerResponse {
     #[schema(example = "T-2024-0042")]
     pub number: String,
     pub has_sensor: bool,
+    /// Owning organization. Lets the cluster forms tell selectable trees from
+    /// foreign ones without a second request.
+    #[schema(example = "0190a8e9-7c4f-7000-8000-000000000000")]
+    pub organization_id: uuid::Uuid,
 }
 
 impl From<&TreeMarker> for TreeMarkerResponse {
@@ -244,6 +248,7 @@ impl From<&TreeMarker> for TreeMarkerResponse {
             watering_status: m.watering_status.into(),
             number: m.tree_number.clone(),
             has_sensor: m.has_sensor,
+            organization_id: m.organization_id,
         }
     }
 }
@@ -267,6 +272,10 @@ pub struct TreeMarkerQueryParams {
     /// Repeatable: `?watering_status=good&watering_status=bad`.
     #[serde(default)]
     pub watering_status: Vec<WateringStatus>,
+    /// Restricts the markers to trees owned by this organization.
+    #[param(example = "0190a8e9-7c4f-7000-8000-000000000000", nullable)]
+    #[serde(default)]
+    pub organization_id: Option<uuid::Uuid>,
 }
 
 impl TreeMarkerQueryParams {

--- a/backend/crates/server/src/http/v1/tree.rs
+++ b/backend/crates/server/src/http/v1/tree.rs
@@ -458,6 +458,7 @@ pub async fn list_tree_markers(
         has_cluster: params.has_cluster,
         planting_years,
         bbox: Some(bbox),
+        organization_id: params.organization_id.map(Id::new),
         visible,
         ..Default::default()
     };

--- a/backend/crates/server/src/infra/pg_tree.rs
+++ b/backend/crates/server/src/infra/pg_tree.rs
@@ -9,6 +9,7 @@ use domain::{
     Id, RepositoryError,
     authorization::Visibility,
     cluster::TreeCluster,
+    organization::Organization,
     sensor::SensorId,
     shared::{
         coordinates::Coordinate,
@@ -21,6 +22,24 @@ use domain::{
         TreeViewWithDistance, TreeWriter,
     },
 };
+
+/// Organization scope of a tree query: the orgs the caller may see, narrowed
+/// by the single org the caller asked for.
+///
+/// Folded into one id list on purpose. `sqlx::query!` only accepts a literal,
+/// so a shared SQL fragment is impossible; keeping the scope out of the SQL
+/// leaves every tree query with the same single `organization_id = ANY($n)`
+/// predicate and this function as the only place the rule lives. Requesting an
+/// invisible org yields an empty list, i.e. no rows rather than an error.
+fn org_scope_ids(visible: Visibility, requested: Option<Id<Organization>>) -> Option<Vec<RawId>> {
+    let requested = requested.map(|id| id.value());
+    match (visible.into_raw_ids(), requested) {
+        (None, None) => None,
+        (None, Some(org)) => Some(vec![org]),
+        (Some(visible), None) => Some(visible),
+        (Some(visible), Some(org)) => Some(visible.into_iter().filter(|id| *id == org).collect()),
+    }
+}
 
 pub struct PgTreeRepository {
     pool: PgPool,
@@ -307,7 +326,7 @@ impl TreeReader for PgTreeRepository {
         let limit = i64::try_from(pagination.limit()).unwrap_or(i64::MAX);
         let offset = i64::try_from(pagination.offset()).unwrap_or(i64::MAX);
         let q_pattern: Option<String> = query.q.as_deref().map(|s| format!("%{}%", like_escape(s)));
-        let visible_ids = query.visible.clone().into_raw_ids();
+        let scope_ids = org_scope_ids(query.visible.clone(), query.organization_id);
 
         let total = sqlx::query_scalar!(
             r#"SELECT COUNT(*) AS "count!: i64" FROM trees
@@ -322,7 +341,7 @@ impl TreeReader for PgTreeRepository {
             provider.as_deref(),
             query.has_cluster,
             q_pattern.as_deref(),
-            visible_ids.as_deref(),
+            scope_ids.as_deref(),
         )
         .fetch_one(&self.pool)
         .await? as u64;
@@ -351,7 +370,7 @@ impl TreeReader for PgTreeRepository {
             provider.as_deref(),
             query.has_cluster,
             q_pattern.as_deref(),
-            visible_ids.as_deref(),
+            scope_ids.as_deref(),
             limit,
             offset,
         )
@@ -376,10 +395,10 @@ impl TreeReader for PgTreeRepository {
             .collect();
         let provider = query.provider.as_ref().map(|p| p.as_str().to_string());
         let bbox = query.bbox;
-        let visible_ids = query.visible.into_raw_ids();
+        let scope_ids = org_scope_ids(query.visible, query.organization_id);
 
         let rows = sqlx::query!(
-            r#"SELECT id, latitude, longitude, number,
+            r#"SELECT id, latitude, longitude, number, organization_id,
                       watering_status AS "watering_status: WateringStatus",
                       (sensor_id IS NOT NULL) AS "has_sensor!: bool"
             FROM trees
@@ -405,7 +424,7 @@ impl TreeReader for PgTreeRepository {
             bbox.map(|b| b.sw_lat()),
             bbox.map(|b| b.ne_lng()),
             bbox.map(|b| b.ne_lat()),
-            visible_ids.as_deref(),
+            scope_ids.as_deref(),
         )
         .fetch_all(&self.pool)
         .await?;
@@ -419,6 +438,7 @@ impl TreeReader for PgTreeRepository {
                 watering_status: row.watering_status,
                 tree_number: row.number,
                 has_sensor: row.has_sensor,
+                organization_id: row.organization_id,
             })
             .collect())
     }
@@ -627,5 +647,42 @@ impl TreeWriter for PgTreeRepository {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    fn org(n: u128) -> Id<Organization> {
+        Id::new(uuid::Uuid::from_u128(n))
+    }
+
+    fn only(ids: &[u128]) -> Visibility {
+        Visibility::Only(ids.iter().map(|n| org(*n)).collect::<BTreeSet<_>>())
+    }
+
+    #[test]
+    fn unrestricted_without_request_does_not_filter() {
+        assert_eq!(org_scope_ids(Visibility::Unrestricted, None), None);
+    }
+
+    #[test]
+    fn unrestricted_with_request_filters_to_that_org() {
+        let ids = org_scope_ids(Visibility::Unrestricted, Some(org(7)));
+        assert_eq!(ids, Some(vec![org(7).value()]));
+    }
+
+    #[test]
+    fn request_narrows_the_visible_orgs() {
+        let ids = org_scope_ids(only(&[1, 2]), Some(org(2))).unwrap();
+        assert_eq!(ids, vec![org(2).value()]);
+    }
+
+    #[test]
+    fn requesting_an_invisible_org_matches_nothing() {
+        let ids = org_scope_ids(only(&[1, 2]), Some(org(9))).unwrap();
+        assert!(ids.is_empty());
     }
 }

--- a/backend/crates/server/test/api/scoping_tree.rs
+++ b/backend/crates/server/test/api/scoping_tree.rs
@@ -16,10 +16,13 @@ fn tree_payload(org: Option<&str>) -> serde_json::Value {
     p
 }
 
-#[tokio::test]
-async fn create_tree_stores_explicit_organization() {
-    let app = spawn_app().await;
-    // demo bypass: unrestricted, explicit org wins
+fn numbered_tree_payload(number: &str, org: Option<&str>) -> serde_json::Value {
+    let mut p = tree_payload(org);
+    p["number"] = json!(number);
+    p
+}
+
+async fn insert_tbz_org(app: &crate::helpers::TestApp) {
     sqlx::query!(
         "INSERT INTO organizations (id, parent_id, name) VALUES ($1, '01980000-0000-7000-8000-000000000001', 'TBZ')",
         uuid::Uuid::parse_str(TBZ_ORG).unwrap()
@@ -27,6 +30,13 @@ async fn create_tree_stores_explicit_organization() {
     .execute(&app.db_pool)
     .await
     .unwrap();
+}
+
+#[tokio::test]
+async fn create_tree_stores_explicit_organization() {
+    let app = spawn_app().await;
+    // demo bypass: unrestricted, explicit org wins
+    insert_tbz_org(&app).await;
     let resp = app
         .post_json("/api/v1/trees", &tree_payload(Some(TBZ_ORG)))
         .await;
@@ -60,4 +70,57 @@ async fn create_tree_requires_create_permission_in_target_org() {
         .await
         .unwrap();
     assert_eq!(resp.status(), 403);
+}
+
+#[tokio::test]
+async fn tree_markers_can_be_filtered_by_organization() {
+    let app = spawn_app().await;
+    insert_tbz_org(&app).await;
+
+    let resp = app
+        .post_json("/api/v1/trees", &numbered_tree_payload("SCOPE-M-001", None))
+        .await;
+    assert_eq!(resp.status(), 201);
+    let resp = app
+        .post_json(
+            "/api/v1/trees",
+            &numbered_tree_payload("SCOPE-M-002", Some(TBZ_ORG)),
+        )
+        .await;
+    assert_eq!(resp.status(), 201);
+
+    let resp = app
+        .get(&format!(
+            "/api/v1/trees/markers?bbox=54.78,9.40,54.81,9.46&organization_id={TBZ_ORG}"
+        ))
+        .await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let data = body["data"].as_array().unwrap();
+    assert_eq!(data.len(), 1);
+    assert_eq!(data[0]["number"], "SCOPE-M-002");
+}
+
+#[tokio::test]
+async fn tree_markers_carry_their_organization() {
+    let app = spawn_app().await;
+    insert_tbz_org(&app).await;
+
+    let resp = app
+        .post_json(
+            "/api/v1/trees",
+            &numbered_tree_payload("SCOPE-M-003", Some(TBZ_ORG)),
+        )
+        .await;
+    assert_eq!(resp.status(), 201);
+
+    // Unfiltered: the cluster forms need the org per marker to dim foreign trees.
+    let resp = app
+        .get("/api/v1/trees/markers?bbox=54.78,9.40,54.81,9.46")
+        .await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let data = body["data"].as_array().unwrap();
+    assert_eq!(data.len(), 1);
+    assert_eq!(data[0]["organization_id"], TBZ_ORG);
 }

--- a/frontend/app/src/api/queries.ts
+++ b/frontend/app/src/api/queries.ts
@@ -86,6 +86,7 @@ export interface TreeMarkersFilters {
   hasCluster?: boolean
   plantingYears?: number[]
   wateringStatuses?: WateringStatus[]
+  organizationId?: string
 }
 
 /** Partial key matching every sensor list page; use for broad invalidation. */
@@ -198,6 +199,7 @@ export const treeQueries = {
           hasCluster: params.hasCluster,
           plantingYears: params.plantingYears,
           wateringStatuses: params.wateringStatuses,
+          organizationId: params.organizationId,
         },
       ],
       queryFn: () =>
@@ -206,6 +208,7 @@ export const treeQueries = {
           hasCluster: params.hasCluster,
           plantingYear: params.plantingYears,
           wateringStatus: params.wateringStatuses,
+          organizationId: params.organizationId,
         } satisfies ListTreeMarkersRequest),
       placeholderData: keepPreviousData,
       staleTime: 30_000,

--- a/frontend/app/src/components/general/form/ForeignTreeDialog.test.tsx
+++ b/frontend/app/src/components/general/form/ForeignTreeDialog.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ForeignTreeDialog from './ForeignTreeDialog'
+
+const baseProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  organizationName: 'Betriebshof',
+  blockedReason: 'In dieser Organisation darfst du keine Gruppe anlegen.',
+  selectedTreeCount: 0,
+  onConfirm: vi.fn(),
+}
+
+describe('ForeignTreeDialog', () => {
+  it('offers the switch and names the organization', () => {
+    render(<ForeignTreeDialog {...baseProps} canSwitch />)
+
+    expect(screen.getByRole('heading', { name: /organisation wechseln/i })).toBeInTheDocument()
+    expect(screen.getByText(/gehört der Organisation Betriebshof/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /wechseln/i })).toBeInTheDocument()
+  })
+
+  it('warns about the trees a switch would discard', () => {
+    render(<ForeignTreeDialog {...baseProps} canSwitch selectedTreeCount={3} />)
+
+    expect(screen.getByText(/ausgewählten Bäume \(3\) werden dabei verworfen/i)).toBeInTheDocument()
+  })
+
+  it('says nothing about discarding when nothing is selected', () => {
+    render(<ForeignTreeDialog {...baseProps} canSwitch />)
+
+    expect(screen.queryByText(/verworfen/i)).not.toBeInTheDocument()
+  })
+
+  it('states the reason instead of offering a switch when blocked', () => {
+    render(<ForeignTreeDialog {...baseProps} canSwitch={false} />)
+
+    expect(screen.getByRole('heading', { name: /nicht auswählbar/i })).toBeInTheDocument()
+    expect(screen.getByText(/darfst du keine Gruppe anlegen/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /wechseln/i })).not.toBeInTheDocument()
+  })
+
+  it('falls back to a generic owner when the name is unknown', () => {
+    render(<ForeignTreeDialog {...baseProps} canSwitch organizationName={undefined} />)
+
+    expect(screen.getByText(/gehört einer anderen Organisation/i)).toBeInTheDocument()
+  })
+
+  it('confirms the switch', async () => {
+    const onConfirm = vi.fn()
+    render(<ForeignTreeDialog {...baseProps} canSwitch onConfirm={onConfirm} />)
+
+    await userEvent.click(screen.getByRole('button', { name: /wechseln/i }))
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/app/src/components/general/form/ForeignTreeDialog.tsx
+++ b/frontend/app/src/components/general/form/ForeignTreeDialog.tsx
@@ -1,0 +1,77 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@green-ecolution/ui'
+import { MoveRight, X } from 'lucide-react'
+
+interface ForeignTreeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Name of the tree's organization; undefined when it is not resolvable. */
+  organizationName?: string
+  /** Whether the group may move to that organization. */
+  canSwitch: boolean
+  /** Shown instead of the switch offer when `canSwitch` is false. */
+  blockedReason: string
+  /** Trees that switching would drop from the current selection. */
+  selectedTreeCount: number
+  onConfirm: () => void
+}
+
+const describe = ({
+  organizationName,
+  canSwitch,
+  blockedReason,
+  selectedTreeCount,
+}: Pick<
+  ForeignTreeDialogProps,
+  'organizationName' | 'canSwitch' | 'blockedReason' | 'selectedTreeCount'
+>) => {
+  const owner = organizationName
+    ? `Dieser Baum gehört der Organisation ${organizationName}.`
+    : 'Dieser Baum gehört einer anderen Organisation.'
+
+  if (!canSwitch) {
+    return `${owner} Eine Bewässerungsgruppe darf nur Bäume ihrer eigenen Organisation enthalten. ${blockedReason}`
+  }
+
+  const consequence =
+    selectedTreeCount > 0
+      ? ` Die bisher ausgewählten Bäume (${selectedTreeCount}) werden dabei verworfen, weil eine Gruppe nur Bäume einer Organisation enthalten darf.`
+      : ''
+
+  return `${owner} Soll die Gruppe für diese Organisation angelegt werden?${consequence}`
+}
+
+const ForeignTreeDialog = (props: ForeignTreeDialogProps) => (
+  <AlertDialog open={props.open} onOpenChange={props.onOpenChange}>
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle>
+          {props.canSwitch ? 'Organisation wechseln?' : 'Baum nicht auswählbar'}
+        </AlertDialogTitle>
+        <AlertDialogDescription>{describe(props)}</AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel>
+          {props.canSwitch ? 'Abbrechen' : 'Verstanden'}
+          <X />
+        </AlertDialogCancel>
+        {props.canSwitch && (
+          <AlertDialogAction onClick={props.onConfirm}>
+            Wechseln
+            <MoveRight className="icon-arrow-animate" />
+          </AlertDialogAction>
+        )}
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+)
+
+export default ForeignTreeDialog

--- a/frontend/app/src/components/general/form/FormForTreecluster.test.tsx
+++ b/frontend/app/src/components/general/form/FormForTreecluster.test.tsx
@@ -8,7 +8,7 @@ import { clusterDraftResolver } from '@green-ecolution/domain-wasm'
 import { ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Toaster } from '@green-ecolution/ui'
-import { SoilCondition } from '@green-ecolution/backend-client'
+import { SoilCondition, type OrganizationResponse } from '@green-ecolution/backend-client'
 
 function TestWrapper({
   children,
@@ -277,5 +277,83 @@ describe('soil texture dialog integration', () => {
         /Lt2 – schwach toniger Lehm/,
       ),
     ).toBeInTheDocument()
+  })
+})
+
+describe('organization field', () => {
+  const mockOnSubmit = vi.fn()
+
+  const orgs = [
+    { id: 'tbz', name: 'Betriebshof', parentId: 'root', memberCount: 0 },
+    { id: 'extern', name: 'Extern A', parentId: 'tbz', memberCount: 0 },
+  ] as unknown as OrganizationResponse[]
+
+  it('stays hidden when only one organization qualifies', () => {
+    render(
+      <TestWrapper defaultValues={{ ...defaultFormValues, organizationId: 'tbz' }}>
+        <FormForTreecluster
+          displayError={false}
+          onSubmit={mockOnSubmit}
+          organizations={orgs.slice(0, 1)}
+        />
+      </TestWrapper>,
+    )
+
+    expect(screen.queryByRole('combobox', { name: /organisation/i })).not.toBeInTheDocument()
+  })
+
+  it('lists exactly the passed organizations and marks the current one', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <TestWrapper defaultValues={{ ...defaultFormValues, organizationId: 'tbz' }}>
+        <FormForTreecluster displayError={false} onSubmit={mockOnSubmit} organizations={orgs} />
+      </TestWrapper>,
+    )
+
+    const select = screen.getByRole('combobox', { name: /organisation/i })
+    expect(within(select).getByText('Betriebshof')).toBeInTheDocument()
+
+    await user.click(select)
+    const listbox = await screen.findByRole('listbox')
+    expect(within(listbox).getByText('Betriebshof')).toBeInTheDocument()
+    expect(within(listbox).getByText('Extern A')).toBeInTheDocument()
+    expect(within(listbox).getAllByRole('option')).toHaveLength(2)
+  })
+
+  it('reports the picked organization to the owner instead of writing it itself', async () => {
+    const user = userEvent.setup()
+    const onOrganizationChange = vi.fn()
+
+    render(
+      <TestWrapper defaultValues={{ ...defaultFormValues, organizationId: 'tbz' }}>
+        <FormForTreecluster
+          displayError={false}
+          onSubmit={mockOnSubmit}
+          organizations={orgs}
+          onOrganizationChange={onOrganizationChange}
+        />
+      </TestWrapper>,
+    )
+
+    await user.click(screen.getByRole('combobox', { name: /organisation/i }))
+    await user.click(within(await screen.findByRole('listbox')).getByText('Extern A'))
+
+    expect(onOrganizationChange).toHaveBeenCalledWith('extern')
+  })
+
+  it('names the trees dropped by an organization change', () => {
+    render(
+      <TestWrapper defaultValues={{ ...defaultFormValues, organizationId: 'extern' }}>
+        <FormForTreecluster
+          displayError={false}
+          onSubmit={mockOnSubmit}
+          organizations={orgs}
+          discardedTreeCount={2}
+        />
+      </TestWrapper>,
+    )
+
+    expect(screen.getByText(/2 bereits ausgewählte Bäume/i)).toBeInTheDocument()
   })
 })

--- a/frontend/app/src/components/general/form/FormForTreecluster.tsx
+++ b/frontend/app/src/components/general/form/FormForTreecluster.tsx
@@ -10,6 +10,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@green-ecolution/ui'
+import type { OrganizationResponse } from '@green-ecolution/backend-client'
 import { Controller, SubmitHandler, useFormContext, useFormState } from 'react-hook-form'
 import { SoilConditionOptions } from '@/hooks/details/useDetailsForSoilCondition'
 import { TreeclusterForm } from '@/schema/treeclusterSchema'
@@ -27,12 +28,18 @@ interface FormForTreeClusterProps {
   onBlur?: () => void
   fullWidth?: boolean
   emptyHint?: string
+  /** Selectable owning organizations; the field stays hidden below two. */
+  organizations?: OrganizationResponse[]
+  onOrganizationChange?: (organizationId: string) => void
+  /** Trees dropped by the last organization change. */
+  discardedTreeCount?: number
 }
 
 const FormForTreecluster = (props: FormForTreeClusterProps) => {
   const { handleSubmit, register, control } = useFormContext<TreeclusterForm>()
   const { isValid, errors } = useFormState({ control })
   const [soilDialogOpen, setSoilDialogOpen] = useState(false)
+  const organizations = props.organizations ?? []
 
   return (
     <form
@@ -46,6 +53,39 @@ const FormForTreecluster = (props: FormForTreeClusterProps) => {
       onBlur={props.onBlur}
     >
       <div className={props.fullWidth ? 'flex shrink-0 flex-col gap-y-6' : 'flex flex-col gap-y-6'}>
+        {organizations.length > 1 && (
+          <Controller
+            name="organizationId"
+            control={control}
+            render={({ field }) => (
+              <div className="flex flex-col gap-y-2">
+                <Label htmlFor="organizationId">
+                  Organisation
+                  <span className="text-destructive ml-1">*</span>
+                </Label>
+                <Combobox
+                  id="organizationId"
+                  options={organizations.map((org) => ({ value: org.id, label: org.name }))}
+                  value={field.value}
+                  onChange={props.onOrganizationChange ?? field.onChange}
+                  placeholder="Wähle eine Organisation aus"
+                  searchPlaceholder="Organisation suchen…"
+                />
+                <p className="text-sm text-dark-600">
+                  Die Gruppe gehört anschließend dieser Organisation. Auswählbar sind nur deren
+                  Bäume.
+                </p>
+                {(props.discardedTreeCount ?? 0) > 0 && (
+                  <p className="text-sm text-destructive">
+                    {props.discardedTreeCount === 1
+                      ? 'Ein bereits ausgewählter Baum gehört einer anderen Organisation und wurde entfernt.'
+                      : `${props.discardedTreeCount} bereits ausgewählte Bäume gehören einer anderen Organisation und wurden entfernt.`}
+                  </p>
+                )}
+              </div>
+            )}
+          />
+        )}
         <FormField label="Name" error={errors.name?.message} required {...register('name')} />
         <FormField
           label="Adresse"

--- a/frontend/app/src/components/map-gl/layers/useSelectableTreeLayer.test.ts
+++ b/frontend/app/src/components/map-gl/layers/useSelectableTreeLayer.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import type { TreeMarkerResponse } from '@green-ecolution/backend-client'
+import { toFC } from './useSelectableTreeLayer'
+
+const marker = (id: string, organizationId: string) =>
+  ({
+    id,
+    latitude: 54.79,
+    longitude: 9.44,
+    wateringStatus: 'good',
+    number: id,
+    hasSensor: false,
+    organizationId,
+  }) as TreeMarkerResponse
+
+const trees = [marker('own', 'tbz'), marker('foreign', 'extern')]
+
+describe('toFC', () => {
+  it('marks trees of other organizations as unselectable but keeps them', () => {
+    const features = toFC(trees, new Set(), 'tbz').features
+
+    expect(features).toHaveLength(2)
+    expect(features[0].properties).toMatchObject({ id: 'own', selectable: true })
+    expect(features[1].properties).toMatchObject({ id: 'foreign', selectable: false })
+  })
+
+  it('carries the organization so a click can name it', () => {
+    const features = toFC(trees, new Set(), 'tbz').features
+
+    expect(features[1].properties?.organizationId).toBe('extern')
+  })
+
+  it('makes everything selectable when no organization is set', () => {
+    const features = toFC(trees, new Set(), undefined).features
+
+    expect(features.every((f) => f.properties?.selectable)).toBe(true)
+  })
+
+  it('keeps the selected flag independent of selectability', () => {
+    const features = toFC(trees, new Set(['own']), 'tbz').features
+
+    expect(features[0].properties?.selected).toBe(true)
+    expect(features[1].properties?.selected).toBe(false)
+  })
+})

--- a/frontend/app/src/components/map-gl/layers/useSelectableTreeLayer.ts
+++ b/frontend/app/src/components/map-gl/layers/useSelectableTreeLayer.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import type { GeoJSONSource, MapLayerMouseEvent } from 'maplibre-gl'
+import type { ExpressionSpecification, GeoJSONSource, MapLayerMouseEvent } from 'maplibre-gl'
 import type { FeatureCollection, Point } from 'geojson'
 import type { TreeMarkerResponse } from '@green-ecolution/backend-client'
 import { treeQueries } from '@/api/queries'
@@ -18,23 +18,60 @@ import useViewportBBox from '../hooks/useViewportBBox'
 import { isMapAlive } from '../mapReady'
 import { usePointerCursor } from './usePointerCursor'
 
+// Opacity of trees that belong to another organization.
+const UNSELECTABLE_DIM: ExpressionSpecification = [
+  'case',
+  ['boolean', ['get', 'selectable'], true],
+  1,
+  0.3,
+]
+
+export interface ForeignTree {
+  id: string
+  organizationId: string
+}
+
 export interface UseSelectableTreeLayerOptions {
   selectedIds: string[]
   onToggle: (treeId: string) => void
+  /** Trees of other organizations stay visible but unselectable, because a
+   *  cluster must not mix organizations. Undefined makes everything
+   *  selectable. */
+  organizationId?: string
+  /** Called instead of `onToggle` when a tree of another organization is
+   *  clicked. Without it such a click does nothing. */
+  onForeignTree?: (tree: ForeignTree) => void
 }
 
-const toFC = (trees: TreeMarkerResponse[], selected: Set<string>): FeatureCollection<Point> => ({
+export const toFC = (
+  trees: TreeMarkerResponse[],
+  selected: Set<string>,
+  organizationId?: string,
+): FeatureCollection<Point> => ({
   type: 'FeatureCollection',
   features: trees.map((t) => ({
     type: 'Feature',
     geometry: { type: 'Point', coordinates: [t.longitude, t.latitude] },
-    properties: { id: t.id, status: t.wateringStatus, selected: selected.has(t.id) },
+    properties: {
+      id: t.id,
+      status: t.wateringStatus,
+      selected: selected.has(t.id),
+      organizationId: t.organizationId,
+      selectable: !organizationId || t.organizationId === organizationId,
+    },
   })),
 })
 
-const useSelectableTreeLayer = ({ selectedIds, onToggle }: UseSelectableTreeLayerOptions) => {
+const useSelectableTreeLayer = ({
+  selectedIds,
+  onToggle,
+  organizationId,
+  onForeignTree,
+}: UseSelectableTreeLayerOptions) => {
   const map = useMaplibreMap()
   const bbox = useViewportBBox()
+  // Deliberately unfiltered: foreign trees are drawn as dimmed context so the
+  // map does not look empty when the chosen organization owns nothing here.
   const { data } = useQuery(treeQueries.markers({ bbox }))
   const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds])
 
@@ -57,6 +94,9 @@ const useSelectableTreeLayer = ({ selectedIds, onToggle }: UseSelectableTreeLaye
           'circle-color': STATUS_COLOR_EXPRESSION,
           'circle-stroke-width': 1.5,
           'circle-stroke-color': '#ffffff',
+          // Foreign trees stay on the map as context, but visibly out of reach.
+          'circle-opacity': UNSELECTABLE_DIM,
+          'circle-stroke-opacity': UNSELECTABLE_DIM,
         },
       })
     }
@@ -70,7 +110,11 @@ const useSelectableTreeLayer = ({ selectedIds, onToggle }: UseSelectableTreeLaye
           id: LAYERS.selectTreeIcon,
           type: 'symbol',
           source: SOURCES.selectTrees,
-          filter: ['!', ['boolean', ['get', 'selected'], false]],
+          filter: [
+            'all',
+            ['!', ['boolean', ['get', 'selected'], false]],
+            ['boolean', ['get', 'selectable'], true],
+          ],
           layout: {
             'icon-image': TREE_ICON_IMAGE,
             'icon-size': ['interpolate', ['linear'], ['zoom'], 13, 0.38, 17, 0.52, 22, 0.7],
@@ -125,22 +169,29 @@ const useSelectableTreeLayer = ({ selectedIds, onToggle }: UseSelectableTreeLaye
 
   useEffect(() => {
     if (!isMapAlive(map)) return
-    map.getSource<GeoJSONSource>(SOURCES.selectTrees)?.setData(toFC(data?.data ?? [], selectedSet))
-  }, [map, data, selectedSet])
+    map
+      .getSource<GeoJSONSource>(SOURCES.selectTrees)
+      ?.setData(toFC(data?.data ?? [], selectedSet, organizationId))
+  }, [map, data, selectedSet, organizationId])
 
   usePointerCursor(LAYERS.selectTreePoints)
 
   useEffect(() => {
     const onClick = (e: MapLayerMouseEvent) => {
-      const feature = e.features?.[0]
-      if (!feature) return
-      onToggle(feature.properties?.id as string)
+      const properties = e.features?.[0]?.properties
+      if (!properties) return
+      const id = properties.id as string
+      if (properties.selectable === false) {
+        onForeignTree?.({ id, organizationId: properties.organizationId as string })
+        return
+      }
+      onToggle(id)
     }
     map.on('click', LAYERS.selectTreePoints, onClick)
     return () => {
       map.off('click', LAYERS.selectTreePoints, onClick)
     }
-  }, [map, onToggle])
+  }, [map, onToggle, onForeignTree])
 }
 
 export default useSelectableTreeLayer

--- a/frontend/app/src/hooks/form/useClusterOrganizationSelection.test.tsx
+++ b/frontend/app/src/hooks/form/useClusterOrganizationSelection.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, waitFor } from '@testing-library/react'
+import { useForm } from 'react-hook-form'
+import { renderHookWithClient } from '@/test/utils'
+import type { TreeclusterForm } from '@/schema/treeclusterSchema'
+
+const getMe = vi.fn()
+const listOrganizations = vi.fn()
+
+vi.mock('@/api/backendApi', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/api/backendApi')>()),
+  userApi: { getMe: () => getMe() as unknown },
+  organizationApi: { listOrganizations: () => listOrganizations() as unknown },
+}))
+
+const canReadOrganizations = vi.fn(() => true)
+vi.mock('@/lib/auth/useHasPermission', () => ({
+  useHasPermission: () => canReadOrganizations(),
+}))
+
+vi.mock('@/lib/auth/runtimeConfig', () => ({ readAuthBypass: () => false }))
+
+const { useClusterOrganizationSelection } = await import('./useClusterOrganizationSelection')
+
+const orgs = [
+  { id: 'root', name: 'Green Ecolution', parentId: null, memberCount: 0 },
+  { id: 'tbz', name: 'Betriebshof', parentId: 'root', memberCount: 0 },
+  { id: 'extern', name: 'Extern A', parentId: 'tbz', memberCount: 0 },
+]
+
+const me = (organizationId: string | null, roleOrg: string | null, permissions: string[]) => ({
+  id: 'u1',
+  organization: organizationId ? orgs.find((o) => o.id === organizationId) : null,
+  roles: [{ id: 'r1', name: 'Rolle', organizationId: roleOrg, permissions }],
+})
+
+const renderSelection = (initialTreeIds: string[] = []) =>
+  renderHookWithClient(() => {
+    const form = useForm<TreeclusterForm>({ defaultValues: { treeIds: initialTreeIds } })
+    return { form, selection: useClusterOrganizationSelection(form) }
+  })
+
+describe('useClusterOrganizationSelection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    canReadOrganizations.mockReturnValue(true)
+    listOrganizations.mockResolvedValue(orgs)
+    getMe.mockResolvedValue(me('root', 'root', ['tree_cluster:create']))
+  })
+
+  it('preselects the users own organization', async () => {
+    const { result } = renderSelection()
+
+    await waitFor(() => expect(result.current.selection.organizationId).toBe('root'))
+  })
+
+  it('offers only organizations the user may create clusters in', async () => {
+    getMe.mockResolvedValue(me('root', 'tbz', ['tree_cluster:create']))
+    const { result } = renderSelection()
+
+    await waitFor(() => expect(result.current.selection.organizations).toHaveLength(2))
+    expect(result.current.selection.organizations.map((o) => o.id)).toEqual(['tbz', 'extern'])
+  })
+
+  it('falls back to the only candidate when the own organization grants nothing', async () => {
+    getMe.mockResolvedValue(me('root', 'extern', ['tree_cluster:create']))
+    const { result } = renderSelection()
+
+    await waitFor(() => expect(result.current.selection.organizationId).toBe('extern'))
+  })
+
+  it('stays empty and preselects nothing without organization:read', async () => {
+    canReadOrganizations.mockReturnValue(false)
+    const { result } = renderSelection()
+
+    await waitFor(() => expect(getMe).toHaveBeenCalled())
+    expect(result.current.selection.organizations).toEqual([])
+    expect(result.current.selection.organizationId).toBeUndefined()
+  })
+
+  it('discards already selected trees when the organization changes', async () => {
+    const { result } = renderSelection(['t1', 't2'])
+    await waitFor(() => expect(result.current.selection.organizationId).toBe('root'))
+
+    act(() => result.current.selection.changeOrganization('tbz'))
+
+    await waitFor(() => expect(result.current.selection.organizationId).toBe('tbz'))
+    expect(result.current.form.getValues('treeIds')).toEqual([])
+    expect(result.current.selection.discardedTreeCount).toBe(2)
+  })
+
+  it('names any visible organization, also one it cannot create in', async () => {
+    getMe.mockResolvedValue(me('root', 'extern', ['tree_cluster:create']))
+    const { result } = renderSelection()
+
+    await waitFor(() => expect(result.current.selection.organizationId).toBe('extern'))
+    expect(result.current.selection.nameOf('tbz')).toBe('Betriebshof')
+    expect(result.current.selection.canCreateIn('tbz')).toBe(false)
+    expect(result.current.selection.canCreateIn('extern')).toBe(true)
+  })
+
+  it('keeps the tree selection when the same organization is picked again', async () => {
+    const { result } = renderSelection(['t1'])
+    await waitFor(() => expect(result.current.selection.organizationId).toBe('root'))
+
+    act(() => result.current.selection.changeOrganization('root'))
+
+    expect(result.current.form.getValues('treeIds')).toEqual(['t1'])
+    expect(result.current.selection.discardedTreeCount).toBe(0)
+  })
+})

--- a/frontend/app/src/hooks/form/useClusterOrganizationSelection.ts
+++ b/frontend/app/src/hooks/form/useClusterOrganizationSelection.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useWatch, type UseFormReturn } from 'react-hook-form'
+import type { OrganizationResponse } from '@green-ecolution/backend-client'
+import { organizationQueries, userQueries } from '@/api/queries'
+import { byOrgName, orgsWithPermission } from '@/lib/auth/organizationScope'
+import { readAuthBypass } from '@/lib/auth/runtimeConfig'
+import { useHasPermission } from '@/lib/auth/useHasPermission'
+import type { TreeclusterForm } from '@/schema/treeclusterSchema'
+
+export interface ClusterOrganizationSelection {
+  /** Organizations the user may create a cluster in, empty when unknown. */
+  organizations: OrganizationResponse[]
+  organizationId?: string
+  changeOrganization: (organizationId: string) => void
+  /** Trees dropped by the last organization change; 0 once nothing was lost. */
+  discardedTreeCount: number
+  /** Name of any visible organization, not just a selectable one — a tree on
+   *  the map may belong to one the user cannot create in. */
+  nameOf: (organizationId: string) => string | undefined
+  canCreateIn: (organizationId: string) => boolean
+}
+
+/**
+ * Owns the organization a new cluster is created in.
+ *
+ * The candidate list needs the organization tree, which requires
+ * `organization:read`. Without it the list stays empty, the picker is hidden
+ * and no `organizationId` is sent — the backend then falls back to the
+ * caller's own organization, exactly as before.
+ */
+export function useClusterOrganizationSelection(
+  form: UseFormReturn<TreeclusterForm>,
+): ClusterOrganizationSelection {
+  const bypass = readAuthBypass()
+  const canReadOrganizations = useHasPermission(['organization:read'])
+  const { data: me } = useQuery(userQueries.me())
+  const { data: orgs } = useQuery({
+    ...organizationQueries.list(),
+    enabled: canReadOrganizations,
+  })
+
+  const organizations = useMemo(() => {
+    if (!orgs) return []
+    // Bypass mirrors the backend's unrestricted mode: every visible org counts.
+    if (bypass) return [...orgs].sort(byOrgName)
+    return orgsWithPermission(orgs, me?.roles ?? [], 'tree_cluster:create')
+  }, [orgs, me, bypass])
+
+  const organizationId = useWatch({ control: form.control, name: 'organizationId' })
+  const [discardedTreeCount, setDiscardedTreeCount] = useState(0)
+
+  // Preselect the user's own organization. Falls back to the first candidate so
+  // holding the right only in a sub-organization still needs no interaction.
+  useEffect(() => {
+    if (organizationId || organizations.length === 0) return
+    const own = organizations.find((org) => org.id === me?.organization?.id)
+    form.setValue('organizationId', (own ?? organizations[0]).id)
+  }, [organizationId, organizations, me, form])
+
+  const changeOrganization = useCallback(
+    (next: string) => {
+      // Re-picking the current organization must not wipe the tree selection.
+      if (!next || next === form.getValues('organizationId')) return
+
+      const abandoned = form.getValues('treeIds') ?? []
+      form.setValue('organizationId', next, { shouldValidate: true, shouldDirty: true })
+      // Selection was restricted to the previous organization, so every marked
+      // tree belongs to a foreign one now.
+      if (abandoned.length > 0) {
+        form.setValue('treeIds', [], { shouldValidate: true, shouldDirty: true })
+      }
+      setDiscardedTreeCount(abandoned.length)
+    },
+    [form],
+  )
+
+  const nameOf = useCallback((id: string) => orgs?.find((org) => org.id === id)?.name, [orgs])
+
+  const canCreateIn = useCallback(
+    (id: string) => organizations.some((org) => org.id === id),
+    [organizations],
+  )
+
+  return {
+    organizations,
+    organizationId,
+    changeOrganization,
+    discardedTreeCount,
+    nameOf,
+    canCreateIn,
+  }
+}

--- a/frontend/app/src/lib/auth/organizationScope.test.ts
+++ b/frontend/app/src/lib/auth/organizationScope.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import type { OrganizationResponse, RoleResponse } from '@green-ecolution/backend-client'
+import { orgsWithPermission } from './organizationScope'
+
+// Root ─ TBZ ─ Extern, plus a sibling tenant that shares no ancestry with TBZ.
+const orgs = [
+  { id: 'root', name: 'Green Ecolution', parentId: null, memberCount: 0 },
+  { id: 'tbz', name: 'TBZ', parentId: 'root', memberCount: 0 },
+  { id: 'extern', name: 'Extern A', parentId: 'tbz', memberCount: 0 },
+  { id: 'other', name: 'Andere Stadt', parentId: 'root', memberCount: 0 },
+] as unknown as OrganizationResponse[]
+
+const role = (organizationId: string | null, permissions: string[]): RoleResponse =>
+  ({ id: `role-${organizationId}`, name: 'Rolle', organizationId, permissions }) as RoleResponse
+
+describe('orgsWithPermission', () => {
+  it('includes the role organization and its whole subtree', () => {
+    const result = orgsWithPermission(
+      orgs,
+      [role('tbz', ['tree_cluster:create'])],
+      'tree_cluster:create',
+    )
+
+    expect(result.map((o) => o.id)).toEqual(['extern', 'tbz'])
+  })
+
+  it('ignores roles that lack the permission', () => {
+    const result = orgsWithPermission(
+      orgs,
+      [role('tbz', ['tree_cluster:read'])],
+      'tree_cluster:create',
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it('ignores template roles without an organization', () => {
+    const result = orgsWithPermission(
+      orgs,
+      [role(null, ['tree_cluster:create'])],
+      'tree_cluster:create',
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it('never grants upwards from the role organization', () => {
+    const result = orgsWithPermission(
+      orgs,
+      [role('extern', ['tree_cluster:create'])],
+      'tree_cluster:create',
+    )
+
+    expect(result.map((o) => o.id)).toEqual(['extern'])
+  })
+
+  it('unions overlapping subtrees without duplicates', () => {
+    const result = orgsWithPermission(
+      orgs,
+      [role('tbz', ['tree_cluster:create']), role('extern', ['tree_cluster:create'])],
+      'tree_cluster:create',
+    )
+
+    expect(result.map((o) => o.id)).toEqual(['extern', 'tbz'])
+  })
+
+  it('drops organizations the caller cannot see at all', () => {
+    // The org list is already scoped by the backend; a grant for an absent org
+    // must not conjure it back into the picker.
+    const visible = orgs.filter((o) => o.id !== 'other')
+    const result = orgsWithPermission(
+      visible,
+      [role('other', ['tree_cluster:create'])],
+      'tree_cluster:create',
+    )
+
+    expect(result).toEqual([])
+  })
+})

--- a/frontend/app/src/lib/auth/organizationScope.ts
+++ b/frontend/app/src/lib/auth/organizationScope.ts
@@ -1,0 +1,33 @@
+import type { OrganizationResponse, RoleResponse } from '@green-ecolution/backend-client'
+import { buildTree, flatten } from '@/components/settings/organization/organizationTree'
+import type { Permission } from './permissions'
+
+export const byOrgName = (a: OrganizationResponse, b: OrganizationResponse): number =>
+  a.name.localeCompare(b.name, 'de')
+
+/**
+ * Organizations in which the user holds `permission`.
+ *
+ * A role grants its permissions for the owning organization *and* its whole
+ * subtree, so each matching role contributes the subtree below its own org.
+ * Roles without an organization are templates: delivered by migration, never
+ * assignable, and therefore no grant.
+ */
+export function orgsWithPermission(
+  orgs: OrganizationResponse[],
+  roles: RoleResponse[],
+  permission: Permission,
+): OrganizationResponse[] {
+  const granted = new Map<string, OrganizationResponse>()
+
+  for (const role of roles) {
+    if (!role.organizationId) continue
+    if (!role.permissions.includes(permission)) continue
+
+    const subtree = buildTree(orgs, role.organizationId)
+    if (!subtree) continue
+    for (const org of flatten(subtree)) granted.set(org.id, org)
+  }
+
+  return [...granted.values()].sort(byOrgName)
+}

--- a/frontend/app/src/routes/_protected/map/treecluster/edit/$treeclusterId/index.tsx
+++ b/frontend/app/src/routes/_protected/map/treecluster/edit/$treeclusterId/index.tsx
@@ -1,19 +1,23 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { FormProvider, useWatch, type DefaultValues, type SubmitHandler } from 'react-hook-form'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import type { TreeResponse } from '@green-ecolution/backend-client'
-import { clusterQueries } from '@/api/queries'
+import { clusterQueries, organizationQueries } from '@/api/queries'
 import { TreeclusterForm } from '@/schema/treeclusterSchema'
 import { entityNotFound, forbiddenErrorComponent, requirePermission } from '@/lib/router'
+import { useHasPermission } from '@/lib/auth/useHasPermission'
 import FormForTreecluster from '@/components/general/form/FormForTreecluster'
+import ForeignTreeDialog from '@/components/general/form/ForeignTreeDialog'
 import UnsavedChangesDialog from '@/components/general/form/UnsavedChangesDialog'
 import { useTreeClusterForm } from '@/hooks/form/useTreeClusterForm'
 import MapPanel from '@/components/map-gl/MapPanel'
 import { useMaplibreMap } from '@/components/map-gl/MapContext'
 import { isMapAlive } from '@/components/map-gl/mapReady'
 import useClusterBoundaryLayer from '@/components/map-gl/layers/useClusterBoundaryLayer'
-import useSelectableTreeLayer from '@/components/map-gl/layers/useSelectableTreeLayer'
+import useSelectableTreeLayer, {
+  type ForeignTree,
+} from '@/components/map-gl/layers/useSelectableTreeLayer'
 
 export const Route = createFileRoute('/_protected/map/treecluster/edit/$treeclusterId/')({
   component: EditClusterOnMap,
@@ -72,6 +76,13 @@ function EditClusterOnMap() {
     },
   )
   const treeIds = useWatch({ control: form.control, name: 'treeIds' }) ?? []
+  const [foreignTree, setForeignTree] = useState<ForeignTree | null>(null)
+  const canReadOrganizations = useHasPermission(['organization:read'])
+  // Only needed to name the organization in the dialog, so it waits for a click.
+  const { data: organizations } = useQuery({
+    ...organizationQueries.list(),
+    enabled: canReadOrganizations && foreignTree !== null,
+  })
 
   const toggleTree = useCallback(
     (id: string) => {
@@ -83,7 +94,14 @@ function EditClusterOnMap() {
   )
 
   useClusterBoundaryLayer({ interactive: false })
-  useSelectableTreeLayer({ selectedIds: treeIds, onToggle: toggleTree })
+  // The cluster's organization is fixed here, so only its own trees may join.
+  // Foreign ones stay visible but dimmed; clicking one explains why.
+  useSelectableTreeLayer({
+    selectedIds: treeIds,
+    onToggle: toggleTree,
+    organizationId: cluster.organizationId,
+    onForeignTree: setForeignTree,
+  })
 
   const onSubmit: SubmitHandler<TreeclusterForm> = (data) => {
     mutate({ ...data, treeIds: data.treeIds ?? [] })
@@ -99,7 +117,8 @@ function EditClusterOnMap() {
     <>
       <MapPanel title="Bewässerungsgruppe bearbeiten" onClose={handleCancel}>
         <p className="mb-5 shrink-0 text-sm text-dark-600">
-          Klicke Bäume auf der Karte an, um sie der Gruppe hinzuzufügen oder zu entfernen.
+          Klicke Bäume auf der Karte an, um sie der Gruppe hinzuzufügen oder zu entfernen. Blass
+          dargestellte Bäume gehören einer anderen Organisation.
         </p>
         <FormProvider {...form}>
           <FormForTreecluster
@@ -112,6 +131,18 @@ function EditClusterOnMap() {
           />
         </FormProvider>
       </MapPanel>
+
+      <ForeignTreeDialog
+        open={foreignTree !== null}
+        onOpenChange={(open) => !open && setForeignTree(null)}
+        organizationName={
+          organizations?.find((org) => org.id === foreignTree?.organizationId)?.name
+        }
+        canSwitch={false}
+        blockedReason="Die Organisation einer bestehenden Gruppe lässt sich hier nicht wechseln."
+        selectedTreeCount={treeIds.length}
+        onConfirm={() => setForeignTree(null)}
+      />
 
       <UnsavedChangesDialog blocker={navigationBlocker} />
     </>

--- a/frontend/app/src/routes/_protected/map/treecluster/new/index.tsx
+++ b/frontend/app/src/routes/_protected/map/treecluster/new/index.tsx
@@ -1,15 +1,19 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { FormProvider, useWatch, type DefaultValues, type SubmitHandler } from 'react-hook-form'
 import { SoilCondition } from '@/api/backendApi'
 import { TreeclusterForm } from '@/schema/treeclusterSchema'
 import FormForTreecluster from '@/components/general/form/FormForTreecluster'
+import ForeignTreeDialog from '@/components/general/form/ForeignTreeDialog'
 import UnsavedChangesDialog from '@/components/general/form/UnsavedChangesDialog'
 import { useTreeClusterForm } from '@/hooks/form/useTreeClusterForm'
+import { useClusterOrganizationSelection } from '@/hooks/form/useClusterOrganizationSelection'
 import { forbiddenErrorComponent, requirePermission } from '@/lib/router'
 import MapPanel from '@/components/map-gl/MapPanel'
 import useClusterBoundaryLayer from '@/components/map-gl/layers/useClusterBoundaryLayer'
-import useSelectableTreeLayer from '@/components/map-gl/layers/useSelectableTreeLayer'
+import useSelectableTreeLayer, {
+  type ForeignTree,
+} from '@/components/map-gl/layers/useSelectableTreeLayer'
 
 export const Route = createFileRoute('/_protected/map/treecluster/new/')({
   component: NewClusterOnMap,
@@ -31,6 +35,15 @@ function NewClusterOnMap() {
     },
   )
   const treeIds = useWatch({ control: form.control, name: 'treeIds' }) ?? []
+  const {
+    organizations,
+    organizationId,
+    changeOrganization,
+    discardedTreeCount,
+    nameOf,
+    canCreateIn,
+  } = useClusterOrganizationSelection(form)
+  const [foreignTree, setForeignTree] = useState<ForeignTree | null>(null)
 
   const toggleTree = useCallback(
     (id: string) => {
@@ -41,8 +54,22 @@ function NewClusterOnMap() {
     [form],
   )
 
+  // Switching drops the previous selection, so the clicked tree is re-added
+  // afterwards — it is the reason the user switched in the first place.
+  const adoptForeignTree = () => {
+    if (!foreignTree) return
+    changeOrganization(foreignTree.organizationId)
+    form.setValue('treeIds', [foreignTree.id], { shouldValidate: true, shouldDirty: true })
+    setForeignTree(null)
+  }
+
   useClusterBoundaryLayer({ interactive: false })
-  useSelectableTreeLayer({ selectedIds: treeIds, onToggle: toggleTree })
+  useSelectableTreeLayer({
+    selectedIds: treeIds,
+    onToggle: toggleTree,
+    organizationId,
+    onForeignTree: setForeignTree,
+  })
 
   const onSubmit: SubmitHandler<TreeclusterForm> = (data) => {
     mutate({ ...data, treeIds: data.treeIds ?? [] })
@@ -58,7 +85,8 @@ function NewClusterOnMap() {
     <>
       <MapPanel title="Neue Bewässerungsgruppe" onClose={handleCancel}>
         <p className="mb-5 shrink-0 text-sm text-dark-600">
-          Klicke Bäume auf der Karte an, um sie der Gruppe hinzuzufügen oder zu entfernen.
+          Klicke Bäume auf der Karte an, um sie der Gruppe hinzuzufügen oder zu entfernen. Blass
+          dargestellte Bäume gehören einer anderen Organisation.
         </p>
         <FormProvider {...form}>
           <FormForTreecluster
@@ -68,9 +96,22 @@ function NewClusterOnMap() {
             onBlur={saveDraft}
             fullWidth
             emptyHint="Klicke einen Baum auf der Karte an, um ihn zur Liste hinzuzufügen."
+            organizations={organizations}
+            onOrganizationChange={changeOrganization}
+            discardedTreeCount={discardedTreeCount}
           />
         </FormProvider>
       </MapPanel>
+
+      <ForeignTreeDialog
+        open={foreignTree !== null}
+        onOpenChange={(open) => !open && setForeignTree(null)}
+        organizationName={foreignTree ? nameOf(foreignTree.organizationId) : undefined}
+        canSwitch={foreignTree ? canCreateIn(foreignTree.organizationId) : false}
+        blockedReason="In dieser Organisation darfst du keine Gruppe anlegen."
+        selectedTreeCount={treeIds.length}
+        onConfirm={adoptForeignTree}
+      />
 
       <UnsavedChangesDialog blocker={navigationBlocker} />
     </>

--- a/frontend/packages/backend-client/api-docs.json
+++ b/frontend/packages/backend-client/api-docs.json
@@ -2683,6 +2683,20 @@
                 "$ref": "#/components/schemas/WateringStatus"
               }
             }
+          },
+          {
+            "name": "organization_id",
+            "in": "query",
+            "description": "Restricts the markers to trees owned by this organization.",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "example": "0190a8e9-7c4f-7000-8000-000000000000"
           }
         ],
         "responses": {
@@ -7799,7 +7813,8 @@
           "longitude",
           "watering_status",
           "number",
-          "has_sensor"
+          "has_sensor",
+          "organization_id"
         ],
         "properties": {
           "has_sensor": {
@@ -7827,6 +7842,12 @@
           "number": {
             "type": "string",
             "example": "T-2024-0042"
+          },
+          "organization_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Owning organization. Lets the cluster forms tell selectable trees from\nforeign ones without a second request.",
+            "example": "0190a8e9-7c4f-7000-8000-000000000000"
           },
           "watering_status": {
             "$ref": "#/components/schemas/WateringStatus"

--- a/frontend/packages/backend-client/src/apis/TreesApi.ts
+++ b/frontend/packages/backend-client/src/apis/TreesApi.ts
@@ -70,6 +70,7 @@ export interface ListTreeMarkersRequest {
     hasCluster?: boolean | null;
     plantingYear?: Array<number>;
     wateringStatus?: Array<WateringStatus>;
+    organizationId?: string | null;
 }
 
 export interface ListTreesRequest {
@@ -369,6 +370,10 @@ export class TreesApi extends runtime.BaseAPI {
 
         if (requestParameters['wateringStatus'] != null) {
             queryParameters['watering_status'] = requestParameters['wateringStatus'];
+        }
+
+        if (requestParameters['organizationId'] != null) {
+            queryParameters['organization_id'] = requestParameters['organizationId'];
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/frontend/packages/backend-client/src/models/TreeMarkerResponse.ts
+++ b/frontend/packages/backend-client/src/models/TreeMarkerResponse.ts
@@ -58,6 +58,13 @@ export interface TreeMarkerResponse {
      */
     number: string;
     /**
+     * Owning organization. Lets the cluster forms tell selectable trees from
+     * foreign ones without a second request.
+     * @type {string}
+     * @memberof TreeMarkerResponse
+     */
+    organizationId: string;
+    /**
      * 
      * @type {WateringStatus}
      * @memberof TreeMarkerResponse
@@ -76,6 +83,7 @@ export function instanceOfTreeMarkerResponse(value: object): value is TreeMarker
     if (!('latitude' in value) || value['latitude'] === undefined) return false;
     if (!('longitude' in value) || value['longitude'] === undefined) return false;
     if (!('number' in value) || value['number'] === undefined) return false;
+    if (!('organizationId' in value) || value['organizationId'] === undefined) return false;
     if (!('wateringStatus' in value) || value['wateringStatus'] === undefined) return false;
     return true;
 }
@@ -95,6 +103,7 @@ export function TreeMarkerResponseFromJSONTyped(json: any, ignoreDiscriminator: 
         'latitude': json['latitude'],
         'longitude': json['longitude'],
         'number': json['number'],
+        'organizationId': json['organization_id'],
         'wateringStatus': WateringStatusFromJSON(json['watering_status']),
     };
 }
@@ -115,6 +124,7 @@ export function TreeMarkerResponseToJSONTyped(value?: TreeMarkerResponse | null,
         'latitude': value['latitude'],
         'longitude': value['longitude'],
         'number': value['number'],
+        'organization_id': value['organizationId'],
         'watering_status': WateringStatusToJSON(value['wateringStatus']),
     };
 }

--- a/frontend/packages/domain-wasm/src/types.ts
+++ b/frontend/packages/domain-wasm/src/types.ts
@@ -23,6 +23,8 @@ export interface TreeclusterForm {
   description: string
   soilCondition: string
   treeIds: string[]
+  /** Owning organization. Only sent on create; the backend defaults to the caller's org. */
+  organizationId?: string
 }
 
 export interface VehicleForm {


### PR DESCRIPTION
A watering group and all its trees must belong to the same organization, but the frontend never sent an organization_id, so a group always landed in the creator's org and picking trees of a sub-organization failed.

The target organization is now an explicit field in the create form, listing only organizations the user holds tree_cluster:create in and preselected with their own. On the map every visible tree stays drawn; only those of the chosen organization are selectable, the rest are dimmed
and offer to move the group to their organization instead.

Tree markers gained their organization so the forms can tell the two apart, and TreeSearchQuery gained an organization filter that #3205 will point at the tree_access view.