### PR TITLE
fix: stop offering selection on the watering plan board without permission (OP#3196)

### DIFF
--- a/frontend/app/src/components/watering-plan/board/ClusterSuggestionCard.tsx
+++ b/frontend/app/src/components/watering-plan/board/ClusterSuggestionCard.tsx
@@ -5,13 +5,14 @@ import { getWateringStatusDetails } from '@/hooks/details/useDetailsForWateringS
 
 interface ClusterSuggestionCardProps {
   cluster: TreeClusterInListResponse
-  selected: boolean
-  onSelectedChange: (selected: boolean) => void
+  selected?: boolean
+  /** Omit to render the card read-only — no checkbox, no click-to-select. */
+  onSelectedChange?: (selected: boolean) => void
 }
 
 const ClusterSuggestionCard = ({
   cluster,
-  selected,
+  selected = false,
   onSelectedChange,
 }: ClusterSuggestionCardProps) => {
   const statusDetails = getWateringStatusDetails(cluster.wateringStatus)
@@ -19,17 +20,22 @@ const ClusterSuggestionCard = ({
   const toggleOnCardClick = (event: React.MouseEvent) => {
     // Link keeps navigating, checkbox already toggles itself — don't double-toggle.
     if ((event.target as HTMLElement).closest('a, [role="checkbox"]')) return
-    onSelectedChange(!selected)
+    onSelectedChange?.(!selected)
   }
 
   return (
-    <KanbanCard className="flex cursor-pointer items-start gap-3" onClick={toggleOnCardClick}>
-      <Checkbox
-        checked={selected}
-        onCheckedChange={(checked) => onSelectedChange(checked === true)}
-        aria-label={`${cluster.name} für Einsatzplan auswählen`}
-        className="mt-0.5"
-      />
+    <KanbanCard
+      className={`flex items-start gap-3 ${onSelectedChange ? 'cursor-pointer' : ''}`}
+      onClick={onSelectedChange ? toggleOnCardClick : undefined}
+    >
+      {onSelectedChange && (
+        <Checkbox
+          checked={selected}
+          onCheckedChange={(checked) => onSelectedChange(checked === true)}
+          aria-label={`${cluster.name} für Einsatzplan auswählen`}
+          className="mt-0.5"
+        />
+      )}
       <div className="min-w-0">
         <Link
           to="/treecluster/$treeclusterId"

--- a/frontend/app/src/components/watering-plan/board/SuggestionsColumn.test.tsx
+++ b/frontend/app/src/components/watering-plan/board/SuggestionsColumn.test.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { type Permissions } from '@/lib/auth/permissions'
+
+const permissions = vi.fn((): Permissions => new Set<string>())
+
+vi.mock('@/lib/auth/usePermissions', () => ({
+  usePermissions: () => permissions(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn().mockResolvedValue(undefined),
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}))
+
+const cluster = {
+  id: 'c1',
+  name: 'Am Hafen',
+  treeIds: ['t1', 't2'],
+  wateringStatus: 'bad',
+}
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+  return {
+    ...actual,
+    useQuery: () => ({ data: { data: [cluster] }, isError: false, refetch: vi.fn() }),
+  }
+})
+
+const { default: SuggestionsColumn } = await import('./SuggestionsColumn')
+
+describe('SuggestionsColumn selection gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    permissions.mockReturnValue(new Set<string>())
+  })
+
+  it('offers no selection without watering_plan:create', async () => {
+    permissions.mockReturnValue(new Set(['watering_plan:read', 'tree_cluster:read']))
+    render(<SuggestionsColumn />)
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /bündeln/i })).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('Am Hafen').closest('div')!)
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+  })
+
+  it('keeps the suggestion readable without watering_plan:create', () => {
+    permissions.mockReturnValue(new Set(['watering_plan:read', 'tree_cluster:read']))
+    render(<SuggestionsColumn />)
+
+    expect(screen.getByText('Am Hafen')).toBeInTheDocument()
+    expect(screen.getByText('2 Bäume')).toBeInTheDocument()
+  })
+
+  it('allows selecting and bundling with watering_plan:create', async () => {
+    permissions.mockReturnValue(new Set(['watering_plan:create']))
+    render(<SuggestionsColumn />)
+
+    const bundle = screen.getByRole('button', { name: /bündeln/i })
+    expect(bundle).toBeDisabled()
+
+    await userEvent.click(screen.getByRole('checkbox'))
+    expect(screen.getByRole('checkbox')).toBeChecked()
+    expect(screen.getByRole('button', { name: /bündeln/i })).toBeEnabled()
+  })
+})

--- a/frontend/app/src/components/watering-plan/board/SuggestionsColumn.tsx
+++ b/frontend/app/src/components/watering-plan/board/SuggestionsColumn.tsx
@@ -8,7 +8,7 @@ import { clusterQueries } from '@/api/queries'
 import { useWateringPlanDraft } from '@/store/form/useFormDraft'
 import type { WateringPlanForm } from '@/schema/wateringPlanSchema'
 import ClusterSuggestionCard from './ClusterSuggestionCard'
-import { Can } from '@/lib/auth/Can'
+import { useHasPermission } from '@/lib/auth/useHasPermission'
 
 const SuggestionsColumn = () => {
   const clustersQuery = useQuery(clusterQueries.suggested())
@@ -16,6 +16,7 @@ const SuggestionsColumn = () => {
   const [selected, setSelected] = useState<string[]>([])
   const draft = useWateringPlanDraft<WateringPlanForm>('create')
   const navigate = useNavigate()
+  const canBundle = useHasPermission(['watering_plan:create'])
 
   const clusters = clustersRes?.data ?? []
 
@@ -66,24 +67,22 @@ const SuggestionsColumn = () => {
           key={cluster.id}
           cluster={cluster}
           selected={selected.includes(cluster.id)}
-          onSelectedChange={(isSelected) => toggle(cluster.id, isSelected)}
+          onSelectedChange={canBundle ? (isSelected) => toggle(cluster.id, isSelected) : undefined}
         />
       ))}
-      {clusters.length > 0 && (
-        <Can permission={['watering_plan:create']}>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            disabled={selected.length === 0}
-            onClick={bundleIntoPlan}
-            className="bg-white"
-          >
-            <FolderPlus className="size-4" />
-            Zu Einsatzplan bündeln
-            {selected.length > 0 && <span className="tabular-nums">({selected.length})</span>}
-          </Button>
-        </Can>
+      {clusters.length > 0 && canBundle && (
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={selected.length === 0}
+          onClick={bundleIntoPlan}
+          className="bg-white"
+        >
+          <FolderPlus className="size-4" />
+          Zu Einsatzplan bündeln
+          {selected.length > 0 && <span className="tabular-nums">({selected.length})</span>}
+        </Button>
       )}
     </KanbanColumn>
   )

--- a/frontend/app/src/components/watering-plan/board/WateringPlanBoard.test.tsx
+++ b/frontend/app/src/components/watering-plan/board/WateringPlanBoard.test.tsx
@@ -73,4 +73,23 @@ describe('WateringPlanBoard modify gating', () => {
     render(<WateringPlanBoard />)
     expect(screen.getByTestId('assign-users')).toBeInTheDocument()
   })
+
+  it('omits the drag instruction without watering_plan:update', () => {
+    permissions.mockReturnValue(new Set(['watering_plan:read']))
+    render(<WateringPlanBoard />)
+    expect(screen.queryByText(/Ziehen Sie/)).not.toBeInTheDocument()
+    expect(screen.getByText('Aktuell ist kein Einsatz unterwegs.')).toBeInTheDocument()
+  })
+
+  it('renders planned plans as plain cards without watering_plan:update', () => {
+    permissions.mockReturnValue(new Set(['watering_plan:read']))
+    const { container } = render(<WateringPlanBoard />)
+    expect(container.querySelector('[aria-roledescription="draggable"]')).toBeNull()
+  })
+
+  it('renders planned plans as draggable cards with watering_plan:update', () => {
+    permissions.mockReturnValue(new Set(['watering_plan:update']))
+    const { container } = render(<WateringPlanBoard />)
+    expect(container.querySelector('[aria-roledescription="draggable"]')).not.toBeNull()
+  })
 })

--- a/frontend/app/src/components/watering-plan/board/WateringPlanBoard.tsx
+++ b/frontend/app/src/components/watering-plan/board/WateringPlanBoard.tsx
@@ -43,21 +43,16 @@ interface DragData {
   column: BoardColumnId
 }
 
-const DraggablePlanCard = ({
-  plan,
-  column,
-  users,
-  canModify,
-}: {
+interface PlanCardProps {
   plan: WateringPlanInList
   column: BoardColumnId
   users: User[]
-  canModify: boolean
-}) => {
+}
+
+const DraggablePlanCard = ({ plan, column, users }: PlanCardProps) => {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: plan.id,
     data: { plan, column } satisfies DragData,
-    disabled: !canModify,
   })
 
   return (
@@ -67,14 +62,19 @@ const DraggablePlanCard = ({
         users={users}
         cardState={isDragging ? 'ghost' : 'idle'}
         assignSlot={
-          column === 'planned' && canModify ? (
-            <AssignUsersPopover plan={plan} users={users} />
-          ) : undefined
+          column === 'planned' ? <AssignUsersPopover plan={plan} users={users} /> : undefined
         }
       />
     </div>
   )
 }
+
+const PlanCard = ({ canModify, ...props }: PlanCardProps & { canModify: boolean }) =>
+  canModify ? (
+    <DraggablePlanCard {...props} />
+  ) : (
+    <WateringPlanBoardCard plan={props.plan} users={props.users} />
+  )
 
 const DroppableColumn = ({
   id,
@@ -130,6 +130,7 @@ const WateringPlanBoard = () => {
 
   const { startPlan } = useWateringPlanBoardMutations()
   const canModify = useHasPermission(['watering_plan:update'])
+  const canCreate = useHasPermission(['watering_plan:create'])
   const [activeDrag, setActiveDrag] = useState<DragData | null>(null)
   const [planToCancel, setPlanToCancel] = useState<WateringPlanInList | null>(null)
   const [planToComplete, setPlanToComplete] = useState<WateringPlanInList | null>(null)
@@ -188,12 +189,13 @@ const WateringPlanBoard = () => {
           {plannedQuery.isError && <ColumnError onRetry={() => void plannedQuery.refetch()} />}
           {!plannedQuery.isError && planned.length === 0 && !activeDrag && (
             <KanbanColumnEmpty>
-              Keine geplanten Einsätze. Erstellen Sie einen neuen Einsatzplan oder bündeln Sie
-              Vorschläge.
+              {canCreate
+                ? 'Keine geplanten Einsätze. Erstellen Sie einen neuen Einsatzplan oder bündeln Sie Vorschläge.'
+                : 'Keine geplanten Einsätze.'}
             </KanbanColumnEmpty>
           )}
           {planned.map((plan) => (
-            <DraggablePlanCard
+            <PlanCard
               key={plan.id}
               plan={plan}
               column="planned"
@@ -213,11 +215,13 @@ const WateringPlanBoard = () => {
           {activeQuery.isError && <ColumnError onRetry={() => void activeQuery.refetch()} />}
           {!activeQuery.isError && active.length === 0 && !activeDrag && (
             <KanbanColumnEmpty>
-              Ziehen Sie einen geplanten Einsatz hierher, um ihn zu starten.
+              {canModify
+                ? 'Ziehen Sie einen geplanten Einsatz hierher, um ihn zu starten.'
+                : 'Aktuell ist kein Einsatz unterwegs.'}
             </KanbanColumnEmpty>
           )}
           {active.map((plan) => (
-            <DraggablePlanCard
+            <PlanCard
               key={plan.id}
               plan={plan}
               column="active"

--- a/frontend/app/src/routes/_protected/watering-plans/index.tsx
+++ b/frontend/app/src/routes/_protected/watering-plans/index.tsx
@@ -7,6 +7,7 @@ import ListPageHeader from '@/components/general/ListPageHeader'
 import WateringPlanBoard from '@/components/watering-plan/board/WateringPlanBoard'
 import { pendingLoading, prefetch } from '@/lib/router'
 import { Can } from '@/lib/auth/Can'
+import { useHasPermission } from '@/lib/auth/useHasPermission'
 
 export const Route = createFileRoute('/_protected/watering-plans/')({
   component: WateringPlans,
@@ -28,12 +29,18 @@ export const Route = createFileRoute('/_protected/watering-plans/')({
 })
 
 function WateringPlans() {
+  const canModify = useHasPermission(['watering_plan:update'])
+
   return (
     <div className="mt-6">
       <div className="container">
         <ListPageHeader
           title="Einsatzpläne"
-          description="Planen, starten und dokumentieren Sie Bewässerungsfahrten. Ziehen Sie einen Einsatz in die nächste Spalte, um seinen Status zu ändern."
+          description={
+            canModify
+              ? 'Planen, starten und dokumentieren Sie Bewässerungsfahrten. Ziehen Sie einen Einsatz in die nächste Spalte, um seinen Status zu ändern.'
+              : 'Verfolgen Sie geplante, laufende und abgeschlossene Bewässerungsfahrten.'
+          }
           action={
             <Can permission={['watering_plan:create']}>
               <ButtonLink


### PR DESCRIPTION
Viewers could tick suggestion cards and the plan cards still announced themselves as draggable buttons, although no follow-up action exists.

Suggestion cards now take their selection props only when the user holds watering_plan:create; plan cards render as plain cards without watering_plan:update, so dnd-kit no longer spreads role="button", tabIndex and aria-roledescription onto them. The copy that asks the user to drag a plan is gated the same way.