### PR TITLE
fix(frontend): offer only valid status transitions in the watering plan status dialog (OP#1298)

### DIFF
--- a/frontend/app/src/components/watering-plan/WateringPlanStatusUpdate.test.tsx
+++ b/frontend/app/src/components/watering-plan/WateringPlanStatusUpdate.test.tsx
@@ -1,12 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Suspense, type ReactNode } from 'react'
+import { Toaster } from '@green-ecolution/ui'
 import { WateringPlanStatus } from '@green-ecolution/backend-client'
 import type { WateringPlan } from '@/api/backendApi'
-import { FinishedWateringPlan, CancelWateringPlan } from './WateringPlanStatusUpdate'
+import WateringPlanStatusUpdate, {
+  FinishedWateringPlan,
+  CancelWateringPlan,
+} from './WateringPlanStatusUpdate'
 
 vi.mock('../general/cards/SelectedCard', () => ({
   default: ({ id }: { id: string }) => <div data-testid={`selected-card-${id}`}>Cluster {id}</div>,
+}))
+
+const getWateringPlan = vi.fn<(...args: unknown[]) => Promise<unknown>>()
+const updateWateringPlan = vi.fn<(...args: unknown[]) => Promise<unknown>>()
+vi.mock('@/api/backendApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/backendApi')>()
+  return {
+    ...actual,
+    wateringPlanApi: {
+      ...actual.wateringPlanApi,
+      getWateringPlan: (...args: unknown[]) => getWateringPlan(...args),
+      updateWateringPlan: (...args: unknown[]) => updateWateringPlan(...args),
+    },
+  }
+})
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn().mockResolvedValue(undefined),
+  useRouter: () => ({ invalidate: vi.fn().mockResolvedValue(undefined) }),
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
 }))
 
 const PLAN_ID = '0190a8e9-7c4f-7000-8000-000000000001'
@@ -112,5 +137,58 @@ describe('CancelWateringPlan', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /speichern/i })).toBeEnabled()
     })
+  })
+})
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false, throwOnError: false } },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Suspense fallback={<p>lädt</p>}>{children}</Suspense>
+      <Toaster />
+    </QueryClientProvider>
+  )
+}
+
+describe('WateringPlanStatusUpdate — Nicht angetreten', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getWateringPlan.mockResolvedValue(mockLoadedData)
+  })
+
+  const selectNotCompleted = async (user: ReturnType<typeof userEvent.setup>) => {
+    render(<WateringPlanStatusUpdate wateringPlanId={PLAN_ID} />, { wrapper: createWrapper() })
+
+    const trigger = await screen.findByRole('combobox', { name: /status des einsatzes/i })
+    await user.click(trigger)
+    await user.click(await screen.findByRole('option', { name: /nicht angetreten/i }))
+  }
+
+  it('asks for a reason instead of saving straight away', async () => {
+    const user = userEvent.setup()
+    await selectNotCompleted(user)
+
+    const textarea = await screen.findByPlaceholderText(/warum wurde der einsatz nicht angetreten/i)
+    expect(textarea).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /speichern/i })).toBeDisabled()
+  })
+
+  it('submits the reason as cancellationNote', async () => {
+    const user = userEvent.setup()
+    updateWateringPlan.mockResolvedValueOnce({ ...mockLoadedData })
+    await selectNotCompleted(user)
+
+    const textarea = await screen.findByPlaceholderText(/warum wurde der einsatz nicht angetreten/i)
+    await user.type(textarea, 'Fahrzeug defekt')
+    await user.click(screen.getByRole('button', { name: /speichern/i }))
+
+    await waitFor(() => expect(updateWateringPlan).toHaveBeenCalledTimes(1))
+    const [payload] = updateWateringPlan.mock.calls[0] as [
+      { wateringPlanUpdateRequest: { status: string; cancellationNote: string } },
+    ]
+    expect(payload.wateringPlanUpdateRequest.status).toBe(WateringPlanStatus.NotCompeted)
+    expect(payload.wateringPlanUpdateRequest.cancellationNote).toBe('Fahrzeug defekt')
   })
 })

--- a/frontend/app/src/components/watering-plan/WateringPlanStatusUpdate.tsx
+++ b/frontend/app/src/components/watering-plan/WateringPlanStatusUpdate.tsx
@@ -8,7 +8,7 @@ import { Droplet, MoveRight } from 'lucide-react'
 import FormError from '../general/form/FormError'
 import {
   getWateringPlanStatusDetails,
-  WateringPlanStatusOptions,
+  getWateringPlanStatusTransitionOptions,
 } from '@/hooks/details/useDetailsForWateringPlanStatus'
 import { Badge, TextareaField, FormField, SelectField, Button } from '@green-ecolution/ui'
 import {
@@ -35,6 +35,7 @@ const WateringPlanStatusUpdate = ({ wateringPlanId }: WateringPlanStatusUpdatePr
   const invalidate = useInvalidateAggregates()
   const showToast = createToast()
   const statusDetails = getWateringPlanStatusDetails(loadedData.status)
+  const statusOptions = getWateringPlanStatusTransitionOptions(loadedData.status)
   const [selectedStatus, setSelectedStatus] = useState(statusDetails)
 
   const { mutate, isError, error } = useMutation({
@@ -89,6 +90,16 @@ const WateringPlanStatusUpdate = ({ wateringPlanId }: WateringPlanStatusUpdatePr
         })
       }
 
+      const onSubmitNotCompleted: SubmitHandler<WateringPlanCancelForm> = (data) => {
+        mutate({
+          ...loadedData,
+          status: WateringPlanStatus.NotCompeted,
+          cancellationNote: data.cancellationNote,
+          transporterId: loadedData.transporter.id,
+          treeClusterIds: loadedData.treeclusters.map((cluster) => cluster.id),
+        })
+      }
+
       const onSubmitOtherStatus = (status: WateringPlanStatus) => {
         mutate({
           ...loadedData,
@@ -99,7 +110,16 @@ const WateringPlanStatusUpdate = ({ wateringPlanId }: WateringPlanStatusUpdatePr
       }
       switch (status) {
         case 'canceled':
-          return <CancelWateringPlan onSubmit={onSubmitCancel} />
+          return <CancelWateringPlan onSubmit={onSubmitCancel} className="mt-6 md:w-1/2" />
+        case WateringPlanStatus.NotCompeted:
+          return (
+            <CancelWateringPlan
+              onSubmit={onSubmitNotCompleted}
+              className="mt-6 md:w-1/2"
+              label="Grund des Nichtantritts"
+              placeholder="Warum wurde der Einsatz nicht angetreten?"
+            />
+          )
         case 'finished':
           return (
             <FinishedWateringPlan
@@ -148,21 +168,30 @@ const WateringPlanStatusUpdate = ({ wateringPlanId }: WateringPlanStatusUpdatePr
       </FormPageHeader>
 
       <section className="mt-10">
-        <div className="flex flex-col gap-y-6 md:w-1/2">
-          <SelectField
-            id="status"
-            label="Status des Einsatzes"
-            placeholder="Wählen Sie einen Status aus"
-            required
-            value={selectedStatus.value}
-            onValueChange={(value) => {
-              setSelectedStatus(getWateringPlanStatusDetails(value))
-            }}
-            options={WateringPlanStatusOptions}
-          />
-        </div>
-        {formByStatus(selectedStatus.value)}
-        <FormError show={isError} error={error?.message} />
+        {statusOptions.length === 0 ? (
+          <p className="text-dark-600 md:w-1/2">
+            Dieser Einsatzplan ist abgeschlossen. Sein Status kann nicht mehr geändert werden.
+          </p>
+        ) : (
+          <>
+            <div className="flex flex-col gap-y-6 md:w-1/2">
+              <SelectField
+                id="status"
+                label="Status des Einsatzes"
+                placeholder="Wähle einen Status aus"
+                required
+                value={selectedStatus.value}
+                description={selectedStatus.description}
+                onValueChange={(value) => {
+                  setSelectedStatus(getWateringPlanStatusDetails(value))
+                }}
+                options={statusOptions}
+              />
+            </div>
+            {formByStatus(selectedStatus.value)}
+            <FormError show={isError} error={error?.message} />
+          </>
+        )}
       </section>
     </>
   )
@@ -172,12 +201,16 @@ interface CancelPlanProps {
   onSubmit: SubmitHandler<WateringPlanCancelForm>
   submitLabel?: string
   className?: string
+  label?: string
+  placeholder?: string
 }
 
 export const CancelWateringPlan = ({
   onSubmit,
   submitLabel = 'Speichern',
   className = 'md:w-1/2',
+  label = 'Grund des Abbruchs',
+  placeholder = 'Warum wurde der Einsatz abgebrochen?',
 }: CancelPlanProps) => {
   const {
     register,
@@ -191,8 +224,8 @@ export const CancelWateringPlan = ({
   return (
     <form className={className} onSubmit={handleSubmit(onSubmit)}>
       <TextareaField
-        placeholder="Warum wurde der Einsatz abgebrochen?"
-        label="Grund des Abbruchs"
+        placeholder={placeholder}
+        label={label}
         error={errors.cancellationNote?.message}
         required
         {...register('cancellationNote')}

--- a/frontend/app/src/hooks/details/useDetailsForWateringPlanStatus.test.ts
+++ b/frontend/app/src/hooks/details/useDetailsForWateringPlanStatus.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { WateringPlanStatus } from '@green-ecolution/backend-client'
+import { getWateringPlanStatusTransitionOptions } from './useDetailsForWateringPlanStatus'
+
+const valuesFor = (status: WateringPlanStatus) =>
+  getWateringPlanStatusTransitionOptions(status).map((option) => option.value)
+
+describe('getWateringPlanStatusTransitionOptions', () => {
+  it('offers start and cancel from a planned plan', () => {
+    expect(valuesFor(WateringPlanStatus.Planned)).toEqual([
+      WateringPlanStatus.Planned,
+      WateringPlanStatus.Active,
+      WateringPlanStatus.Canceled,
+    ])
+  })
+
+  it('offers revert, finish, fail and cancel from an active plan', () => {
+    expect(valuesFor(WateringPlanStatus.Active)).toEqual([
+      WateringPlanStatus.Active,
+      WateringPlanStatus.Planned,
+      WateringPlanStatus.Finished,
+      WateringPlanStatus.NotCompeted,
+      WateringPlanStatus.Canceled,
+    ])
+  })
+
+  it.each([
+    WateringPlanStatus.Finished,
+    WateringPlanStatus.Canceled,
+    WateringPlanStatus.NotCompeted,
+    WateringPlanStatus.Unknown,
+  ])('offers no transition out of the terminal status %s', (status) => {
+    expect(valuesFor(status)).toEqual([])
+  })
+
+  it('never offers "unknown" as a target', () => {
+    for (const status of Object.values(WateringPlanStatus)) {
+      expect(valuesFor(status)).not.toContain(WateringPlanStatus.Unknown)
+    }
+  })
+
+  it('carries the label and colour from the status catalogue', () => {
+    const [current, next] = getWateringPlanStatusTransitionOptions(WateringPlanStatus.Planned)
+    expect(current.label).toBe('Geplant')
+    expect(next.label).toBe('Aktiv')
+  })
+})

--- a/frontend/app/src/hooks/details/useDetailsForWateringPlanStatus.ts
+++ b/frontend/app/src/hooks/details/useDetailsForWateringPlanStatus.ts
@@ -49,6 +49,35 @@ export const WateringPlanStatusOptions: {
 
 export const getWateringPlanStatusDetails = createEnumLookup(WateringPlanStatusOptions)
 
+/**
+ * Mirrors the transition table the backend enforces in `update_watering_plan`.
+ * Keep in sync — an entry missing here is unreachable in the UI, an extra one
+ * only fails after submit with `InvalidStateTransition`.
+ */
+const wateringPlanStatusTransitions: Record<WateringPlanStatus, WateringPlanStatus[]> = {
+  [WateringPlanStatus.Planned]: [WateringPlanStatus.Active, WateringPlanStatus.Canceled],
+  [WateringPlanStatus.Active]: [
+    WateringPlanStatus.Planned,
+    WateringPlanStatus.Finished,
+    WateringPlanStatus.NotCompeted,
+    WateringPlanStatus.Canceled,
+  ],
+  [WateringPlanStatus.Finished]: [],
+  [WateringPlanStatus.Canceled]: [],
+  [WateringPlanStatus.NotCompeted]: [],
+  [WateringPlanStatus.Unknown]: [],
+}
+
+/**
+ * Selectable statuses for a plan in `current`: the unchanged status first, then
+ * its valid targets. Empty for terminal statuses, where the plan cannot move on.
+ */
+export const getWateringPlanStatusTransitionOptions = (current: WateringPlanStatus) => {
+  const targets = wateringPlanStatusTransitions[current] ?? []
+  if (targets.length === 0) return []
+  return [current, ...targets].map(getWateringPlanStatusDetails)
+}
+
 export const showWateringPlanStatusButton = (wateringPlan: WateringPlan): boolean => {
   return (
     wateringPlan.status !== WateringPlanStatus.NotCompeted &&


### PR DESCRIPTION
The status dropdown listed all six statuses, including "Unbekannt" and transitions the backend rejects, so an invalid choice only failed after submit with InvalidStateTransition.

Derive the selectable statuses from the plan's current status via a transition table mirroring the backend handler, and show an explanatory note instead of a dead form for terminal statuses.

Also add the missing reason field for "Nicht angetreten": the transition requires a cancellation_note just like "Abgebrochen", but fell through to the plain save button and could never succeed.
