### PR TITLE
fix(breadcrumb): render separator as sibling li (OP#1299)

### DIFF
--- a/frontend/app/src/components/layout/Breadcrumb.test.tsx
+++ b/frontend/app/src/components/layout/Breadcrumb.test.tsx
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck - ad-hoc routes are not part of the generated route tree
+import { describe, it, expect } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  createMemoryHistory,
+  RouterProvider,
+  Outlet,
+} from '@tanstack/react-router'
+
+import Breadcrumb from './Breadcrumb'
+
+const renderBreadcrumb = () => {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const treesRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: 'trees',
+    loader: () => ({ crumb: { title: 'Bäume' } }),
+    component: () => <Outlet />,
+  })
+  const treeDetailRoute = createRoute({
+    getParentRoute: () => treesRoute,
+    path: '$treeId',
+    loader: () => ({ crumb: { title: 'Eiche #1234' } }),
+    component: () => <Breadcrumb />,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([treesRoute.addChildren([treeDetailRoute])]),
+    history: createMemoryHistory({ initialEntries: ['/trees/1234'] }),
+  })
+
+  return render(<RouterProvider router={router} />)
+}
+
+describe('Breadcrumb', () => {
+  it('renders the whole trail', async () => {
+    renderBreadcrumb()
+
+    await waitFor(() => {
+      expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Bäume')).toBeInTheDocument()
+    expect(screen.getByText('Eiche #1234')).toBeInTheDocument()
+  })
+
+  it('keeps separators as siblings so the list stays valid HTML', async () => {
+    const { container } = renderBreadcrumb()
+
+    await waitFor(() => {
+      expect(screen.getByText('Eiche #1234')).toBeInTheDocument()
+    })
+
+    expect(container.querySelectorAll('li li')).toHaveLength(0)
+
+    const list = container.querySelector('ol')
+    const separators = list.querySelectorAll(':scope > li[role="presentation"]')
+    expect(separators).toHaveLength(2)
+  })
+})

--- a/frontend/app/src/components/layout/Breadcrumb.tsx
+++ b/frontend/app/src/components/layout/Breadcrumb.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react'
 import { Link } from '@tanstack/react-router'
 import { useBreadcrumbs } from '@/hooks/useBreadcrumb'
 import {
@@ -28,16 +29,18 @@ function Breadcrumb() {
           </BreadcrumbLink>
         </BreadcrumbItem>
         {breadcrumbs.map((breadcrumb, index) => (
-          <BreadcrumbItem key={breadcrumb.path}>
+          <Fragment key={breadcrumb.path}>
             <BreadcrumbSeparator />
-            {isLastItem(index) ? (
-              <BreadcrumbPage>{breadcrumb.title}</BreadcrumbPage>
-            ) : (
-              <BreadcrumbLink asChild>
-                <Link to={breadcrumb.path}>{breadcrumb.title}</Link>
-              </BreadcrumbLink>
-            )}
-          </BreadcrumbItem>
+            <BreadcrumbItem>
+              {isLastItem(index) ? (
+                <BreadcrumbPage>{breadcrumb.title}</BreadcrumbPage>
+              ) : (
+                <BreadcrumbLink asChild>
+                  <Link to={breadcrumb.path}>{breadcrumb.title}</Link>
+                </BreadcrumbLink>
+              )}
+            </BreadcrumbItem>
+          </Fragment>
         ))}
       </BreadcrumbList>
     </BreadcrumbRoot>


### PR DESCRIPTION
BreadcrumbSeparator renders an `<li role="presentation">`, but the header breadcrumb nested it inside the `<li>` of a BreadcrumbItem. React reported "In HTML, `<li>` cannot be a descendant of `<li>`" plus a hydration error on every page. Wrap each trail entry in a Fragment so separator and item are siblings under the `<ol>`, matching the shadcn structure the other call sites already use.