### PR TITLE
fix(backend): release the contact person on an organization change (OP#3101)

### DIFF
--- a/backend/crates/domain/src/organization/mod.rs
+++ b/backend/crates/domain/src/organization/mod.rs
@@ -80,6 +80,19 @@ impl Organization {
         self.contact_person
     }
 
+    /// Drops the reference if `person` is the current contact person. A person
+    /// who leaves the organization must not stay its contact — the FK only
+    /// covers profile deletion, not a change of membership. Returns whether
+    /// anything changed so the caller can skip the write.
+    pub fn release_contact_person(&mut self, person: Uuid) -> bool {
+        if self.contact_person == Some(person) {
+            self.contact_person = None;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Replaces the whole editable set. Only the rename is worth an event —
     /// nothing reacts to address or contact-person changes.
     pub fn replace_details(
@@ -188,6 +201,29 @@ mod tests {
         assert_eq!(o.contact_person(), Some(person));
         o.replace_details(name, None, None).unwrap();
         assert_eq!(o.contact_person(), None);
+    }
+
+    #[test]
+    fn releasing_the_contact_person_clears_the_reference_once() {
+        let mut o = org(Some(Id::new_v7()));
+        let name = same_name(&o);
+        let person = uuid::Uuid::now_v7();
+        o.replace_details(name, None, Some(person)).unwrap();
+
+        assert!(o.release_contact_person(person));
+        assert_eq!(o.contact_person(), None);
+        assert!(!o.release_contact_person(person));
+    }
+
+    #[test]
+    fn releasing_someone_else_leaves_the_contact_person_alone() {
+        let mut o = org(Some(Id::new_v7()));
+        let name = same_name(&o);
+        let person = uuid::Uuid::now_v7();
+        o.replace_details(name, None, Some(person)).unwrap();
+
+        assert!(!o.release_contact_person(uuid::Uuid::now_v7()));
+        assert_eq!(o.contact_person(), Some(person));
     }
 
     #[test]

--- a/backend/crates/server/src/service/user_service.rs
+++ b/backend/crates/server/src/service/user_service.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use domain::{
     Id, RepositoryError,
     authorization::Visibility,
-    organization::{Organization, OrganizationReader, OrganizationView},
+    organization::{Organization, OrganizationReader, OrganizationView, OrganizationWriter},
     role::{Role, RoleError, RoleReader, RoleView, RoleWriter},
     shared::{
         email::Email,
@@ -48,6 +48,7 @@ pub struct UserService {
     role_reader: Arc<dyn RoleReader>,
     role_writer: Arc<dyn RoleWriter>,
     org_reader: Arc<dyn OrganizationReader>,
+    org_writer: Arc<dyn OrganizationWriter>,
     enabled: bool,
 }
 
@@ -60,6 +61,7 @@ impl UserService {
         role_reader: Arc<dyn RoleReader>,
         role_writer: Arc<dyn RoleWriter>,
         org_reader: Arc<dyn OrganizationReader>,
+        org_writer: Arc<dyn OrganizationWriter>,
         enabled: bool,
     ) -> Self {
         Self {
@@ -69,6 +71,7 @@ impl UserService {
             role_reader,
             role_writer,
             org_reader,
+            org_writer,
             enabled,
         }
     }
@@ -244,6 +247,8 @@ impl UserService {
         user_id: Uuid,
         org: Id<Organization>,
     ) -> Result<UserView, ServiceError> {
+        self.release_contact_person_of_previous_org(user_id, org)
+            .await?;
         self.profile_writer.set_organization(user_id, org).await?;
         let identity = self.identity_for(user_id).await?;
         self.attach_views(vec![identity])
@@ -251,6 +256,29 @@ impl UserService {
             .into_iter()
             .next()
             .ok_or_else(|| RepositoryError::NotFound.into())
+    }
+
+    /// A contact person must belong to the organization it represents, so
+    /// leaving means giving up that role. The reference is dropped before the
+    /// move: a failure between the two writes then costs a contact person
+    /// instead of leaving a member-less one behind.
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn release_contact_person_of_previous_org(
+        &self,
+        user_id: Uuid,
+        target: Id<Organization>,
+    ) -> Result<(), ServiceError> {
+        let Some(previous) = self.organization_of(user_id).await? else {
+            return Ok(());
+        };
+        if previous == target {
+            return Ok(());
+        }
+        let mut org = self.org_reader.by_id(previous).await?;
+        if org.release_contact_person(user_id) {
+            self.org_writer.save(&org).await?;
+        }
+        Ok(())
     }
 
     /// The target user's organization, if any. Returns `None` for legacy users
@@ -659,9 +687,14 @@ mod tests {
         }
         async fn organizations_for(
             &self,
-            _ids: &[Uuid],
+            ids: &[Uuid],
         ) -> Result<Vec<(Uuid, Id<Organization>)>, RepositoryError> {
-            Ok(Vec::new())
+            let members = self.members.lock().unwrap();
+            Ok(members
+                .iter()
+                .flat_map(|(org, users)| users.iter().map(move |user| (*user, *org)))
+                .filter(|(user, _)| ids.contains(user))
+                .collect())
         }
     }
 
@@ -753,6 +786,55 @@ mod tests {
     #[derive(Default)]
     struct StubOrgs {
         member_count_queries: AtomicUsize,
+        rows: Mutex<HashMap<Id<Organization>, Organization>>,
+        saves: AtomicUsize,
+    }
+
+    impl StubOrgs {
+        fn insert(&self, id: Id<Organization>, contact_person: Option<Uuid>) {
+            self.rows
+                .lock()
+                .unwrap()
+                .insert(id, org_row(id, contact_person));
+        }
+        fn contact_person_of(&self, id: Id<Organization>) -> Option<Uuid> {
+            self.rows
+                .lock()
+                .unwrap()
+                .get(&id)
+                .and_then(Organization::contact_person)
+        }
+    }
+
+    fn org_row(id: Id<Organization>, contact_person: Option<Uuid>) -> Organization {
+        Organization::reconstitute(OrganizationSnapshot {
+            id: id.value(),
+            parent_id: Some(Uuid::now_v7()),
+            name: "Testorg".into(),
+            street: None,
+            postal_code: None,
+            city: None,
+            contact_person_id: contact_person,
+        })
+    }
+
+    #[async_trait::async_trait]
+    impl OrganizationWriter for StubOrgs {
+        async fn save_new(
+            &self,
+            _draft: domain::organization::OrganizationDraft,
+            _templates: Vec<Role>,
+        ) -> Result<Organization, RepositoryError> {
+            Err(RepositoryError::NotFound)
+        }
+        async fn save(&self, org: &Organization) -> Result<(), RepositoryError> {
+            self.saves.fetch_add(1, Ordering::Relaxed);
+            self.rows.lock().unwrap().insert(org.id, org.clone());
+            Ok(())
+        }
+        async fn delete(&self, _id: Id<Organization>) -> Result<(), RepositoryError> {
+            Ok(())
+        }
     }
 
     #[async_trait::async_trait]
@@ -761,14 +843,17 @@ mod tests {
             Ok(Vec::new())
         }
         async fn by_id(&self, id: Id<Organization>) -> Result<Organization, RepositoryError> {
-            Ok(Organization::reconstitute(OrganizationSnapshot {
-                id: id.value(),
-                parent_id: None,
-                name: "Testorg".into(),
-                street: None,
-                postal_code: None,
-                city: None,
-                contact_person_id: None,
+            let rows = self.rows.lock().unwrap();
+            Ok(rows.get(&id).cloned().unwrap_or_else(|| {
+                Organization::reconstitute(OrganizationSnapshot {
+                    id: id.value(),
+                    parent_id: None,
+                    name: "Testorg".into(),
+                    street: None,
+                    postal_code: None,
+                    city: None,
+                    contact_person_id: None,
+                })
             }))
         }
         async fn hierarchy(&self) -> Result<OrgHierarchy, RepositoryError> {
@@ -811,6 +896,7 @@ mod tests {
             profiles,
             roles.clone(),
             roles,
+            orgs.clone(),
             orgs,
             true,
         )
@@ -924,6 +1010,46 @@ mod tests {
             .expect("organization present after register");
         assert_eq!(organization.id, org);
         assert_eq!(organization.name.as_str(), "Testorg");
+    }
+
+    #[tokio::test]
+    async fn moving_the_contact_person_releases_the_old_organizations_reference() {
+        let user = Uuid::now_v7();
+        let (old_org, new_org) = (Id::new_v7(), Id::new_v7());
+        let profiles = Arc::new(InMemoryProfiles::default());
+        profiles.add_member(old_org, user);
+        let orgs = Arc::new(StubOrgs::default());
+        orgs.insert(old_org, Some(user));
+        let svc = service_with_orgs(
+            Arc::new(StubIdentityRepo::new(vec![identity(user, "jdoe")])),
+            profiles,
+            orgs.clone(),
+        );
+
+        svc.set_organization(user, new_org).await.unwrap();
+
+        assert_eq!(orgs.contact_person_of(old_org), None);
+    }
+
+    #[tokio::test]
+    async fn moving_a_member_leaves_a_different_contact_person_untouched() {
+        let (user, contact) = (Uuid::now_v7(), Uuid::now_v7());
+        let (old_org, new_org) = (Id::new_v7(), Id::new_v7());
+        let profiles = Arc::new(InMemoryProfiles::default());
+        profiles.add_member(old_org, user);
+        profiles.add_member(old_org, contact);
+        let orgs = Arc::new(StubOrgs::default());
+        orgs.insert(old_org, Some(contact));
+        let svc = service_with_orgs(
+            Arc::new(StubIdentityRepo::new(vec![identity(user, "jdoe")])),
+            profiles,
+            orgs.clone(),
+        );
+
+        svc.set_organization(user, new_org).await.unwrap();
+
+        assert_eq!(orgs.contact_person_of(old_org), Some(contact));
+        assert_eq!(orgs.saves.load(Ordering::Relaxed), 0);
     }
 
     #[tokio::test]

--- a/backend/crates/server/src/startup.rs
+++ b/backend/crates/server/src/startup.rs
@@ -118,6 +118,7 @@ impl Application {
             repos.role_reader.clone(),
             repos.role_writer.clone(),
             repos.organization_reader.clone(),
+            repos.organization_writer.clone(),
             settings.auth.enabled,
         ));
         let event_bus = build_event_bus(&repos);

--- a/backend/crates/server/test/api/organizations.rs
+++ b/backend/crates/server/test/api/organizations.rs
@@ -343,6 +343,38 @@ async fn update_returns_the_raw_contact_person_id() {
     );
 }
 
+/// A contact person who changes organization must not stay referenced: the FK
+/// on `contact_person_id` only fires when the profile is deleted, not when its
+/// membership moves.
+#[tokio::test]
+async fn moving_the_contact_person_away_clears_the_reference() {
+    let app = spawn_app().await;
+    let org_id = create_org(&app, "Kontaktstelle").await;
+    let elsewhere = create_org(&app, "Betriebshof Sued").await;
+    let member = seed_profile_in(&app, &org_id).await;
+    app.put_json(
+        &format!("/api/v1/organizations/{org_id}"),
+        &serde_json::json!({ "name": "Kontaktstelle", "contact_person_id": member }),
+    )
+    .await;
+
+    let resp = app
+        .patch_json(
+            &format!("/api/v1/users/{member}/organization"),
+            &serde_json::json!({ "organization_id": elsewhere }),
+        )
+        .await;
+    assert_eq!(resp.status(), 200);
+
+    let stored: Option<Uuid> =
+        sqlx::query_scalar("SELECT contact_person_id FROM organizations WHERE id = $1")
+            .bind(Uuid::parse_str(&org_id).unwrap())
+            .fetch_one(&app.db_pool)
+            .await
+            .unwrap();
+    assert_eq!(stored, None);
+}
+
 /// The uuid-that-does-not-exist case only proves that no membership row was
 /// found; this one proves `ensure_member` compares organizations.
 #[tokio::test]


### PR DESCRIPTION
A contact person must belong to the organization it represents, but moving a user only rewrote user_profiles.organization_id. The FK on organizations.contact_person_id fires when the profile is deleted, not when its membership moves, so the reference stayed behind and the detail endpoint kept resolving a person who no longer belonged there.

The old organization now drops the reference before the move: a failure between the two writes then costs a contact person instead of leaving a member-less one behind.
