### PR TITLE
fix(backend): close the second self-lockout path through role definitions (OP#3133)

### DIFF
--- a/backend/.sqlx/query-089caf6c036ca56a0e7932b9e9657375f797c80699b8c7c062732385b38eb7d8.json
+++ b/backend/.sqlx/query-089caf6c036ca56a0e7932b9e9657375f797c80699b8c7c062732385b38eb7d8.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO roles (id, organization_id, name, permissions)\n               VALUES (gen_random_uuid(), $1, $2, $3) RETURNING id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "089caf6c036ca56a0e7932b9e9657375f797c80699b8c7c062732385b38eb7d8"
+}

--- a/backend/.sqlx/query-296b32403dfaf54641577b3f09f72fd6d8928d388accf3cd08d2bd573f09283c.json
+++ b/backend/.sqlx/query-296b32403dfaf54641577b3f09f72fd6d8928d388accf3cd08d2bd573f09283c.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT permissions FROM roles WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "permissions",
+        "type_info": "TextArray"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "296b32403dfaf54641577b3f09f72fd6d8928d388accf3cd08d2bd573f09283c"
+}

--- a/backend/.sqlx/query-391a8cfddf473249a735f11b743a20c26394b914dfae46cf727dab8bef0c0910.json
+++ b/backend/.sqlx/query-391a8cfddf473249a735f11b743a20c26394b914dfae46cf727dab8bef0c0910.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) FROM roles WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "391a8cfddf473249a735f11b743a20c26394b914dfae46cf727dab8bef0c0910"
+}

--- a/backend/crates/server/src/http/v1/error.rs
+++ b/backend/crates/server/src/http/v1/error.rs
@@ -111,6 +111,7 @@ impl IntoResponse for ServiceError {
             | ServiceError::Role(_)
             | ServiceError::OrganizationNotEmpty
             | ServiceError::CannotChangeOwnAccess
+            | ServiceError::CannotRevokeOwnAdministration
             | ServiceError::SensorBoundToTree
             | ServiceError::TreeInCluster) => error_response(StatusCode::CONFLICT, e.to_string()),
             // Not a conflict with stored state: the request combines two

--- a/backend/crates/server/src/http/v1/role.rs
+++ b/backend/crates/server/src/http/v1/role.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::{
     http::{AppState, auth::extractor::AuthUserExtractor, v1::scope::resolve_target_org},
-    service::ServiceError,
+    service::{ServiceError, authorization::RoleChange},
 };
 use domain::{
     Id,
@@ -242,7 +242,7 @@ pub async fn get_role(
 #[utoipa::path(patch, path = "/roles/{role_id}", tag = "Roles",
     operation_id = "updateRole",
     summary = "Replace a role's name, description and permissions",
-    description = "Templates cannot be modified (409). Requires role:update in the role's organization, plus a permission set that does not exceed the caller's own grants.",
+    description = "Templates cannot be modified (409). Requires role:update in the role's organization, plus a permission set that does not exceed the caller's own grants. A change that would leave the caller without role:update or user:update in their own organization is rejected (409).",
     params(("role_id" = Uuid, Path, description = "Role id")),
     request_body = RoleUpdateRequest,
     responses(
@@ -251,7 +251,7 @@ pub async fn get_role(
         (status = 401, description = "Unauthorized"),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "Not found"),
-        (status = 409, description = "Templates are immutable, or name conflicts"),
+        (status = 409, description = "Templates are immutable, the name conflicts, or the change would revoke the caller's own administration rights"),
         (status = 500, description = "Internal server error"),
     )
 )]
@@ -279,6 +279,15 @@ pub async fn update_role(
             .require_superset(user.id, &permissions, org)
             .await?;
     }
+    state
+        .authorization_service
+        .ensure_administration_survives(
+            user.id,
+            state.user_service.organization_of(user.id).await?,
+            id,
+            RoleChange::PermissionsReplacedWith(&permissions),
+        )
+        .await?;
     let description = req
         .description
         .filter(|s| !s.is_empty())
@@ -294,14 +303,14 @@ pub async fn update_role(
 #[utoipa::path(delete, path = "/roles/{role_id}", tag = "Roles",
     operation_id = "deleteRole",
     summary = "Delete a role",
-    description = "Templates cannot be deleted (409). Requires role:delete in the role's organization.",
+    description = "Templates cannot be deleted (409). Requires role:delete in the role's organization. Deleting a role that carries the caller's own role:update or user:update in their organization is rejected (409).",
     params(("role_id" = Uuid, Path, description = "Role id")),
     responses(
         (status = 204, description = "Deleted"),
         (status = 401, description = "Unauthorized"),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "Not found"),
-        (status = 409, description = "Templates are immutable"),
+        (status = 409, description = "Templates are immutable, or the deletion would revoke the caller's own administration rights"),
         (status = 500, description = "Internal server error"),
     )
 )]
@@ -323,6 +332,15 @@ pub async fn delete_role(
             )
             .await?;
     }
+    state
+        .authorization_service
+        .ensure_administration_survives(
+            user.id,
+            state.user_service.organization_of(user.id).await?,
+            id,
+            RoleChange::Deleted,
+        )
+        .await?;
     state.role_service.delete(id).await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/backend/crates/server/src/service/authorization.rs
+++ b/backend/crates/server/src/service/authorization.rs
@@ -5,12 +5,38 @@ use uuid::Uuid;
 
 use domain::{
     Id,
-    authorization::{AccessContext, EffectivePermissions, Permission, Visibility},
+    authorization::{
+        AccessContext, Action, EffectivePermissions, Permission, Resource, Visibility,
+    },
     organization::{Organization, OrganizationReader},
-    role::RoleReader,
+    role::{Role, RoleReader},
 };
 
 use super::{AuthError, ServiceError};
+
+/// A pending change to a role definition, expressed as what the role would
+/// still grant afterwards.
+#[derive(Debug, Clone, Copy)]
+pub enum RoleChange<'a> {
+    PermissionsReplacedWith(&'a BTreeSet<Permission>),
+    Deleted,
+}
+
+/// What the caller must keep in their own organization to stay able to repair
+/// their own access: editing a role they already hold, and handing roles to
+/// people. Losing either is irreversible on one's own account, because
+/// `require_superset` refuses to grant back a permission the caller no longer
+/// holds.
+const SELF_ADMINISTRATION: [Permission; 2] = [
+    Permission {
+        resource: Resource::Role,
+        action: Action::Update,
+    },
+    Permission {
+        resource: Resource::User,
+        action: Action::Update,
+    },
+];
 
 /// The single place that answers "may user X do P in org O". Handlers call
 /// this before invoking the domain services (Oskar lesson: scope evaluation
@@ -84,6 +110,64 @@ impl AuthorizationService {
 
     pub fn enforced(&self) -> bool {
         self.enforced
+    }
+
+    /// Rejects a change to a role definition that would leave the caller
+    /// without the rights to administer roles and members in their own
+    /// organization.
+    ///
+    /// `ensure_not_self` (OP#3121) closes this dead end for role
+    /// *assignments*; the definition is the second way in. Emptying or
+    /// deleting the last role one holds strips the same rights, and the
+    /// account is then only repairable at the database.
+    ///
+    /// Editing a role one holds stays allowed as long as the two rights in
+    /// `SELF_ADMINISTRATION` survive — a blanket "hands off your own role"
+    /// would block legitimate maintenance.
+    #[tracing::instrument(level = "debug", skip_all, fields(user.id = %user_id, role.id = %role_id))]
+    pub async fn ensure_administration_survives(
+        &self,
+        user_id: Uuid,
+        own_org: Option<Id<Organization>>,
+        role_id: Id<Role>,
+        change: RoleChange<'_>,
+    ) -> Result<(), ServiceError> {
+        if !self.enforced || user_id.is_nil() {
+            return Ok(());
+        }
+        let Some(own_org) = own_org else {
+            return Ok(());
+        };
+        let roles = self.role_reader.roles_for_user(user_id).await?;
+        if !roles.iter().any(|r| r.id == role_id) {
+            return Ok(());
+        }
+        let grants = roles
+            .into_iter()
+            .filter_map(|r| {
+                let permissions = if r.id == role_id {
+                    match change {
+                        RoleChange::Deleted => return None,
+                        RoleChange::PermissionsReplacedWith(p) => p.clone(),
+                    }
+                } else {
+                    r.permissions().clone()
+                };
+                r.organization_id().map(|org| (org, permissions))
+            })
+            .collect();
+        let after = AccessContext {
+            permissions: EffectivePermissions::from_grants(grants),
+            hierarchy: self.org_reader.hierarchy().await?,
+        };
+        if SELF_ADMINISTRATION
+            .iter()
+            .all(|p| after.allows_in(*p, own_org))
+        {
+            Ok(())
+        } else {
+            Err(ServiceError::CannotRevokeOwnAdministration)
+        }
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(user.id = %user_id))]
@@ -175,8 +259,12 @@ mod tests {
     }
 
     fn role_in(org: Id<Organization>, perms: &[Permission]) -> Role {
+        role_with_id(Id::new_v7(), org, perms)
+    }
+
+    fn role_with_id(id: Id<Role>, org: Id<Organization>, perms: &[Permission]) -> Role {
         Role::reconstitute(RoleSnapshot {
-            id: Uuid::now_v7(),
+            id: id.value(),
             organization_id: Some(org.value()),
             name: "Testrolle".into(),
             description: None,
@@ -187,6 +275,30 @@ mod tests {
 
     fn tree_read() -> Permission {
         Permission::new(Resource::Tree, Action::Read)
+    }
+
+    fn role_update() -> Permission {
+        Permission::new(Resource::Role, Action::Update)
+    }
+
+    fn user_update() -> Permission {
+        Permission::new(Resource::User, Action::Update)
+    }
+
+    /// Two-level tree plus a service whose only user is `user`.
+    fn guard_setup(
+        org: Id<Organization>,
+        root: Id<Organization>,
+        by_user: Vec<(Uuid, Role)>,
+        enforced: bool,
+    ) -> AuthorizationService {
+        AuthorizationService::new(
+            Arc::new(StubOrgs {
+                pairs: vec![(root, None), (org, Some(root))],
+            }),
+            Arc::new(StubRoles { by_user }),
+            enforced,
+        )
     }
 
     #[tokio::test]
@@ -275,5 +387,208 @@ mod tests {
                 .unwrap(),
             domain::authorization::Visibility::Unrestricted
         );
+    }
+
+    #[tokio::test]
+    async fn emptying_your_own_last_admin_role_is_rejected() {
+        let (root, org, role_id, user) = (Id::new_v7(), Id::new_v7(), Id::new_v7(), Uuid::now_v7());
+        let svc = guard_setup(
+            org,
+            root,
+            vec![(
+                user,
+                role_with_id(role_id, org, &[role_update(), user_update()]),
+            )],
+            true,
+        );
+
+        let emptied = BTreeSet::from([tree_read()]);
+        let result = svc
+            .ensure_administration_survives(
+                user,
+                Some(org),
+                role_id,
+                RoleChange::PermissionsReplacedWith(&emptied),
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ServiceError::CannotRevokeOwnAdministration)
+        ));
+    }
+
+    #[tokio::test]
+    async fn dropping_only_user_update_is_rejected_too() {
+        let (root, org, role_id, user) = (Id::new_v7(), Id::new_v7(), Id::new_v7(), Uuid::now_v7());
+        let svc = guard_setup(
+            org,
+            root,
+            vec![(
+                user,
+                role_with_id(role_id, org, &[role_update(), user_update()]),
+            )],
+            true,
+        );
+
+        let without_user_update = BTreeSet::from([role_update()]);
+        let result = svc
+            .ensure_administration_survives(
+                user,
+                Some(org),
+                role_id,
+                RoleChange::PermissionsReplacedWith(&without_user_update),
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ServiceError::CannotRevokeOwnAdministration)
+        ));
+    }
+
+    #[tokio::test]
+    async fn deleting_your_own_last_admin_role_is_rejected() {
+        let (root, org, role_id, user) = (Id::new_v7(), Id::new_v7(), Id::new_v7(), Uuid::now_v7());
+        let svc = guard_setup(
+            org,
+            root,
+            vec![(
+                user,
+                role_with_id(role_id, org, &[role_update(), user_update()]),
+            )],
+            true,
+        );
+
+        let result = svc
+            .ensure_administration_survives(user, Some(org), role_id, RoleChange::Deleted)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ServiceError::CannotRevokeOwnAdministration)
+        ));
+    }
+
+    #[tokio::test]
+    async fn pruning_unrelated_permissions_stays_allowed() {
+        let (root, org, role_id, user) = (Id::new_v7(), Id::new_v7(), Id::new_v7(), Uuid::now_v7());
+        let svc = guard_setup(
+            org,
+            root,
+            vec![(
+                user,
+                role_with_id(role_id, org, &[role_update(), user_update(), tree_read()]),
+            )],
+            true,
+        );
+
+        let kept = BTreeSet::from([role_update(), user_update()]);
+        let result = svc
+            .ensure_administration_survives(
+                user,
+                Some(org),
+                role_id,
+                RoleChange::PermissionsReplacedWith(&kept),
+            )
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn a_second_role_carrying_the_rights_allows_the_change() {
+        let (root, org, role_id, user) = (Id::new_v7(), Id::new_v7(), Id::new_v7(), Uuid::now_v7());
+        let svc = guard_setup(
+            org,
+            root,
+            vec![
+                (
+                    user,
+                    role_with_id(role_id, org, &[role_update(), user_update()]),
+                ),
+                (user, role_in(org, &[role_update(), user_update()])),
+            ],
+            true,
+        );
+
+        let result = svc
+            .ensure_administration_survives(user, Some(org), role_id, RoleChange::Deleted)
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn a_grant_from_the_parent_organization_keeps_the_change_allowed() {
+        let (root, org, role_id, user) = (Id::new_v7(), Id::new_v7(), Id::new_v7(), Uuid::now_v7());
+        let svc = guard_setup(
+            org,
+            root,
+            vec![
+                (
+                    user,
+                    role_with_id(role_id, org, &[role_update(), user_update()]),
+                ),
+                (user, role_in(root, &[role_update(), user_update()])),
+            ],
+            true,
+        );
+
+        let result = svc
+            .ensure_administration_survives(user, Some(org), role_id, RoleChange::Deleted)
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn a_role_the_caller_does_not_hold_is_not_guarded() {
+        let (root, org, foreign_role, user) =
+            (Id::new_v7(), Id::new_v7(), Id::new_v7(), Uuid::now_v7());
+        let svc = guard_setup(
+            org,
+            root,
+            vec![(user, role_in(org, &[role_update(), user_update()]))],
+            true,
+        );
+
+        let result = svc
+            .ensure_administration_survives(user, Some(org), foreign_role, RoleChange::Deleted)
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn a_caller_without_an_organization_is_not_guarded() {
+        let (root, org, role_id, user) = (Id::new_v7(), Id::new_v7(), Id::new_v7(), Uuid::now_v7());
+        let svc = guard_setup(
+            org,
+            root,
+            vec![(
+                user,
+                role_with_id(role_id, org, &[role_update(), user_update()]),
+            )],
+            true,
+        );
+
+        let result = svc
+            .ensure_administration_survives(user, None, role_id, RoleChange::Deleted)
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn demo_bypass_skips_the_guard() {
+        let (root, org, role_id) = (Id::new_v7(), Id::new_v7(), Id::new_v7());
+        let svc = guard_setup(org, root, vec![], false);
+
+        let result = svc
+            .ensure_administration_survives(Uuid::nil(), Some(org), role_id, RoleChange::Deleted)
+            .await;
+
+        assert!(result.is_ok());
     }
 }

--- a/backend/crates/server/src/service/mod.rs
+++ b/backend/crates/server/src/service/mod.rs
@@ -54,6 +54,8 @@ pub enum ServiceError {
     MissingOrganization,
     #[error("a user cannot change their own roles or organization")]
     CannotChangeOwnAccess,
+    #[error("this change would remove your own right to administer roles and members")]
+    CannotRevokeOwnAdministration,
 }
 
 /// Which cross-aggregate organization rule a request violated.

--- a/backend/crates/server/test/api/roles.rs
+++ b/backend/crates/server/test/api/roles.rs
@@ -162,3 +162,181 @@ async fn update_and_delete_work_for_org_roles_but_not_templates() {
         409
     );
 }
+
+/// Real-auth harness for the self-lockout guard (OP#3133). The demo bypass
+/// grants unrestricted access, so these cases only exist with `auth.enabled`.
+mod self_lockout {
+    use crate::{auth_helpers::spawn_with_auth, organizations::ROOT_ORG_ID};
+    use serde_json::json;
+    use uuid::Uuid;
+
+    /// Seeds an org under root, a role carrying `permissions`, and a user in
+    /// that org holding it. Returns (org_id, role_id, token).
+    async fn seed_user_holding(
+        harness: &crate::auth_helpers::AuthHarness,
+        app: &crate::helpers::TestApp,
+        org_name: &str,
+        permissions: &[&str],
+    ) -> (Uuid, Uuid, String) {
+        let org_id: Uuid = sqlx::query_scalar!(
+            r#"INSERT INTO organizations (id, parent_id, name) VALUES (gen_random_uuid(), $1::uuid, $2) RETURNING id"#,
+            Uuid::parse_str(ROOT_ORG_ID).unwrap(),
+            org_name
+        )
+        .fetch_one(&app.db_pool)
+        .await
+        .unwrap();
+        let role_id = insert_role(app, org_id, "Org-Admin", permissions).await;
+        let user_id = Uuid::new_v4();
+        sqlx::query!(
+            r#"INSERT INTO user_profiles (id, organization_id) VALUES ($1, $2)"#,
+            user_id,
+            org_id
+        )
+        .execute(&app.db_pool)
+        .await
+        .unwrap();
+        sqlx::query!(
+            r#"INSERT INTO role_assignments (user_id, role_id) VALUES ($1, $2)"#,
+            user_id,
+            role_id
+        )
+        .execute(&app.db_pool)
+        .await
+        .unwrap();
+        let token = harness.sign_token(json!({ "sub": user_id.to_string() }));
+        (org_id, role_id, token)
+    }
+
+    async fn insert_role(
+        app: &crate::helpers::TestApp,
+        org_id: Uuid,
+        name: &str,
+        permissions: &[&str],
+    ) -> Uuid {
+        let permissions: Vec<String> = permissions.iter().map(|p| (*p).to_string()).collect();
+        sqlx::query_scalar!(
+            r#"INSERT INTO roles (id, organization_id, name, permissions)
+               VALUES (gen_random_uuid(), $1, $2, $3) RETURNING id"#,
+            org_id,
+            name,
+            &permissions
+        )
+        .fetch_one(&app.db_pool)
+        .await
+        .unwrap()
+    }
+
+    async fn permissions_of(app: &crate::helpers::TestApp, role_id: Uuid) -> Vec<String> {
+        sqlx::query_scalar!(r#"SELECT permissions FROM roles WHERE id = $1"#, role_id)
+            .fetch_one(&app.db_pool)
+            .await
+            .unwrap()
+    }
+
+    async fn patch_role(
+        app: &crate::helpers::TestApp,
+        token: &str,
+        role_id: Uuid,
+        name: &str,
+        permissions: &[&str],
+    ) -> reqwest::Response {
+        reqwest::Client::new()
+            .patch(format!("{}/api/v1/roles/{role_id}", app.address))
+            .bearer_auth(token)
+            .json(&json!({ "name": name, "description": null, "permissions": permissions }))
+            .send()
+            .await
+            .unwrap()
+    }
+
+    const ADMIN: [&str; 4] = ["role:update", "role:delete", "user:update", "tree:read"];
+
+    #[tokio::test]
+    async fn emptying_your_own_administration_role_returns_409() {
+        let (harness, app) = spawn_with_auth().await;
+        let (_org, role_id, token) = seed_user_holding(&harness, &app, "TBZ", &ADMIN).await;
+
+        let resp = patch_role(&app, &token, role_id, "Org-Admin", &["tree:read"]).await;
+
+        assert_eq!(resp.status(), 409);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(
+            body["error"],
+            "this change would remove your own right to administer roles and members"
+        );
+
+        // Side-effect assertion: the role must be untouched.
+        let after = permissions_of(&app, role_id).await;
+        assert!(after.contains(&"role:update".to_string()));
+        assert!(after.contains(&"user:update".to_string()));
+    }
+
+    #[tokio::test]
+    async fn deleting_your_own_administration_role_returns_409() {
+        let (harness, app) = spawn_with_auth().await;
+        let (_org, role_id, token) = seed_user_holding(&harness, &app, "TBZ", &ADMIN).await;
+
+        let resp = reqwest::Client::new()
+            .delete(format!("{}/api/v1/roles/{role_id}", app.address))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 409);
+
+        // Side-effect assertion: the role must still exist.
+        let still_there: Option<i64> =
+            sqlx::query_scalar!(r#"SELECT COUNT(*) FROM roles WHERE id = $1"#, role_id)
+                .fetch_one(&app.db_pool)
+                .await
+                .unwrap();
+        assert_eq!(still_there, Some(1));
+    }
+
+    #[tokio::test]
+    async fn maintaining_your_own_role_stays_allowed() {
+        let (harness, app) = spawn_with_auth().await;
+        let (_org, role_id, token) = seed_user_holding(&harness, &app, "TBZ", &ADMIN).await;
+
+        // Renamed and stripped of an unrelated permission, but still
+        // administering: the guard must not block this.
+        let resp = patch_role(
+            &app,
+            &token,
+            role_id,
+            "Verwaltung Nord",
+            &["role:update", "user:update"],
+        )
+        .await;
+
+        assert_eq!(resp.status(), 200);
+        assert_eq!(permissions_of(&app, role_id).await.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn editing_a_role_you_do_not_hold_stays_allowed() {
+        let (harness, app) = spawn_with_auth().await;
+        let (org, _own_role, token) = seed_user_holding(&harness, &app, "TBZ", &ADMIN).await;
+        let other = insert_role(&app, org, "Gießtrupp", &["tree:read"]).await;
+
+        let resp = patch_role(&app, &token, other, "Gießtrupp", &[]).await;
+
+        assert_eq!(resp.status(), 200);
+        assert!(permissions_of(&app, other).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn missing_role_update_still_returns_403_not_409() {
+        let (harness, app) = spawn_with_auth().await;
+        // No role:update at all, so the authorization check must fire before
+        // the self-lockout guard ever runs.
+        let (_org, role_id, token) =
+            seed_user_holding(&harness, &app, "TBZ", &["role:read", "user:update"]).await;
+
+        let resp = patch_role(&app, &token, role_id, "Org-Admin", &[]).await;
+
+        assert_eq!(resp.status(), 403);
+    }
+}

--- a/frontend/packages/backend-client/api-docs.json
+++ b/frontend/packages/backend-client/api-docs.json
@@ -1514,7 +1514,7 @@
           "Roles"
         ],
         "summary": "Delete a role",
-        "description": "Templates cannot be deleted (409). Requires role:delete in the role's organization.",
+        "description": "Templates cannot be deleted (409). Requires role:delete in the role's organization. Deleting a role that carries the caller's own role:update or user:update in their organization is rejected (409).",
         "operationId": "deleteRole",
         "parameters": [
           {
@@ -1542,7 +1542,7 @@
             "description": "Not found"
           },
           "409": {
-            "description": "Templates are immutable"
+            "description": "Templates are immutable, or the deletion would revoke the caller's own administration rights"
           },
           "500": {
             "description": "Internal server error"
@@ -1554,7 +1554,7 @@
           "Roles"
         ],
         "summary": "Replace a role's name, description and permissions",
-        "description": "Templates cannot be modified (409). Requires role:update in the role's organization, plus a permission set that does not exceed the caller's own grants.",
+        "description": "Templates cannot be modified (409). Requires role:update in the role's organization, plus a permission set that does not exceed the caller's own grants. A change that would leave the caller without role:update or user:update in their own organization is rejected (409).",
         "operationId": "updateRole",
         "parameters": [
           {
@@ -1602,7 +1602,7 @@
             "description": "Not found"
           },
           "409": {
-            "description": "Templates are immutable, or name conflicts"
+            "description": "Templates are immutable, the name conflicts, or the change would revoke the caller's own administration rights"
           },
           "500": {
             "description": "Internal server error"

--- a/frontend/packages/backend-client/src/apis/RolesApi.ts
+++ b/frontend/packages/backend-client/src/apis/RolesApi.ts
@@ -105,7 +105,7 @@ export class RolesApi extends runtime.BaseAPI {
     }
 
     /**
-     * Templates cannot be deleted (409). Requires role:delete in the role\'s organization.
+     * Templates cannot be deleted (409). Requires role:delete in the role\'s organization. Deleting a role that carries the caller\'s own role:update or user:update in their organization is rejected (409).
      * Delete a role
      */
     async deleteRoleRaw(requestParameters: DeleteRoleRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
@@ -135,7 +135,7 @@ export class RolesApi extends runtime.BaseAPI {
     }
 
     /**
-     * Templates cannot be deleted (409). Requires role:delete in the role\'s organization.
+     * Templates cannot be deleted (409). Requires role:delete in the role\'s organization. Deleting a role that carries the caller\'s own role:update or user:update in their organization is rejected (409).
      * Delete a role
      */
     async deleteRole(requestParameters: DeleteRoleRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
@@ -312,7 +312,7 @@ export class RolesApi extends runtime.BaseAPI {
     }
 
     /**
-     * Templates cannot be modified (409). Requires role:update in the role\'s organization, plus a permission set that does not exceed the caller\'s own grants.
+     * Templates cannot be modified (409). Requires role:update in the role\'s organization, plus a permission set that does not exceed the caller\'s own grants. A change that would leave the caller without role:update or user:update in their own organization is rejected (409).
      * Replace a role\'s name, description and permissions
      */
     async updateRoleRaw(requestParameters: UpdateRoleRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<RoleResponse>> {
@@ -352,7 +352,7 @@ export class RolesApi extends runtime.BaseAPI {
     }
 
     /**
-     * Templates cannot be modified (409). Requires role:update in the role\'s organization, plus a permission set that does not exceed the caller\'s own grants.
+     * Templates cannot be modified (409). Requires role:update in the role\'s organization, plus a permission set that does not exceed the caller\'s own grants. A change that would leave the caller without role:update or user:update in their own organization is rejected (409).
      * Replace a role\'s name, description and permissions
      */
     async updateRole(requestParameters: UpdateRoleRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<RoleResponse> {


### PR DESCRIPTION
The assignment guard from OP#3121 stops a user from touching their own role assignments, but the role *definition* was left open: emptying or deleting the last role one holds strips the same rights, leaving an account only repairable at the database.

PATCH and DELETE /roles/{id} now simulate the caller's own grants after the change and reject it when role:update or user:update would no longer hold in their organization. Editing a role one holds stays allowed as long as those two survive, so legitimate maintenance is unaffected. Missing permissions still return 403, the rejected change 409.
