### PR TITLE
fix(frontend): only start the auth redirect on a click, not on hover (OP#1124)

### DIFF
--- a/frontend/app/src/routes/_protected.tsx
+++ b/frontend/app/src/routes/_protected.tsx
@@ -1,10 +1,16 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 import { userQueries } from '@/api/queries'
 import { readAuthBypass } from '@/lib/auth/runtimeConfig'
 
 export const Route = createFileRoute('/_protected')({
-  beforeLoad: async ({ context, location }) => {
+  beforeLoad: async ({ context, location, preload }) => {
     if (!(await context.auth.isAuthenticated())) {
+      // Hovering a protected link preloads this route. Handing the visitor over
+      // to Keycloak here would navigate without a click, so bail out instead --
+      // a preload must never have side effects.
+      if (preload) {
+        throw redirect({ to: '/' })
+      }
       await context.auth.signinRedirect({ returnTo: location.pathname + location.searchStr })
     }
     // Nav entries and child guards read permissions synchronously from the

--- a/frontend/app/src/routes/authRedirectGuards.test.ts
+++ b/frontend/app/src/routes/authRedirectGuards.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+import { isRedirect } from '@tanstack/react-router'
+
+const signinRedirect = vi.fn(() => Promise.resolve())
+const signoutRedirect = vi.fn(() => Promise.resolve())
+
+vi.mock('@/lib/auth/session', () => ({
+  getAuthSession: () => ({ signinRedirect, signoutRedirect }),
+}))
+
+vi.mock('@/api/queries', () => ({
+  userQueries: { me: () => ({ queryKey: ['me'], queryFn: () => Promise.resolve({}) }) },
+}))
+
+const { Route: ProtectedRoute } = await import('./_protected')
+const { Route: LoginRoute } = await import('./login')
+const { Route: LogoutRoute } = await import('./logout')
+
+const anonymousContext = {
+  auth: { isAuthenticated: () => Promise.resolve(false), signinRedirect },
+  queryClient: { ensureQueryData: vi.fn(() => Promise.resolve({})) },
+}
+
+const location = { pathname: '/map', searchStr: '' }
+
+type AsyncHook = (opts: Record<string, unknown>) => Promise<unknown>
+interface HookRoute {
+  options: { beforeLoad?: unknown; loader?: unknown }
+}
+
+const beforeLoad = (route: HookRoute, opts: Record<string, unknown>) =>
+  (route.options.beforeLoad as AsyncHook)(opts)
+const loader = (route: HookRoute, opts: Record<string, unknown>) =>
+  (route.options.loader as AsyncHook)(opts)
+
+describe('auth redirect guards ignore route preloading', () => {
+  it('does not hand an anonymous visitor to Keycloak when _protected is preloaded', async () => {
+    signinRedirect.mockClear()
+
+    const thrown = await beforeLoad(ProtectedRoute, {
+      context: anonymousContext,
+      location,
+      preload: true,
+    }).catch((error: unknown) => error)
+
+    expect(signinRedirect).not.toHaveBeenCalled()
+    expect(isRedirect(thrown)).toBe(true)
+  })
+
+  it('hands an anonymous visitor to Keycloak on a real navigation into _protected', async () => {
+    signinRedirect.mockClear()
+
+    await beforeLoad(ProtectedRoute, {
+      context: anonymousContext,
+      location,
+      preload: false,
+    })
+
+    expect(signinRedirect).toHaveBeenCalledWith({ returnTo: '/map' })
+  })
+
+  it('does not start the login flow when /login is preloaded', async () => {
+    signinRedirect.mockClear()
+
+    await loader(LoginRoute, { deps: { redirect: undefined }, preload: true })
+
+    expect(signinRedirect).not.toHaveBeenCalled()
+  })
+
+  it('starts the login flow on a real navigation to /login', async () => {
+    signinRedirect.mockClear()
+
+    await loader(LoginRoute, { deps: { redirect: '/map' }, preload: false })
+
+    expect(signinRedirect).toHaveBeenCalledWith({ returnTo: '/map' })
+  })
+
+  it('does not sign the user out when /logout is preloaded', async () => {
+    signoutRedirect.mockClear()
+
+    await beforeLoad(LogoutRoute, { preload: true })
+
+    expect(signoutRedirect).not.toHaveBeenCalled()
+  })
+
+  it('signs the user out on a real navigation to /logout', async () => {
+    signoutRedirect.mockClear()
+
+    await beforeLoad(LogoutRoute, { preload: false })
+
+    expect(signoutRedirect).toHaveBeenCalled()
+  })
+})

--- a/frontend/app/src/routes/login.tsx
+++ b/frontend/app/src/routes/login.tsx
@@ -10,7 +10,11 @@ const loginSchema = z.object({
 export const Route = createFileRoute('/login')({
   validateSearch: loginSchema,
   loaderDeps: ({ search: { redirect } }) => ({ redirect }),
-  loader: async ({ deps: { redirect } }) => {
+  loader: async ({ deps: { redirect }, preload }) => {
+    // A hover-triggered preload must not leave the page; only a real click may.
+    if (preload) {
+      return
+    }
     await getAuthSession().signinRedirect({ returnTo: sanitizeReturnTo(redirect) })
   },
 })

--- a/frontend/app/src/routes/logout.tsx
+++ b/frontend/app/src/routes/logout.tsx
@@ -2,7 +2,11 @@ import { getAuthSession } from '@/lib/auth/session'
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/logout')({
-  beforeLoad: async () => {
+  beforeLoad: async ({ preload }) => {
+    // A hover-triggered preload must not leave the page; only a real click may.
+    if (preload) {
+      return
+    }
     await getAuthSession().signoutRedirect()
   },
 })


### PR DESCRIPTION
The router runs with defaultPreload: 'intent', so hovering a Link executes the target route's beforeLoad. _protected.beforeLoad started the Keycloak flow as a side effect instead of throwing a redirect, which left the page without a click -- visible on the start page, where the QuickLinks render regardless of the login state.

Guard the redirecting hooks with the preload flag the router passes in, so the guards themselves are prefetch-safe instead of relying on every call site remembering preload={false}. /login and /logout get the same treatment.