### PR TITLE
fix(frontend): measure the two-pane container when it mounts late

### DIFF
--- a/frontend/app/src/components/settings/members/MembersPage.test.tsx
+++ b/frontend/app/src/components/settings/members/MembersPage.test.tsx
@@ -90,7 +90,7 @@ vi.mock('@/lib/auth/usePermissions', () => ({ usePermissions: () => permissions(
 // panel in a Drawer, leaving both panes unqueryable.
 const isWide = vi.fn((): boolean => true)
 vi.mock('@/hooks/useContainerWiderThan', () => ({
-  useContainerWiderThan: () => ({ ref: { current: null }, isWide: isWide() }),
+  useContainerWiderThan: () => ({ ref: vi.fn(), isWide: isWide() }),
 }))
 
 const assignMutate = vi.fn()

--- a/frontend/app/src/components/settings/organization/OrganizationPage.test.tsx
+++ b/frontend/app/src/components/settings/organization/OrganizationPage.test.tsx
@@ -68,7 +68,7 @@ vi.mock('@/lib/auth/usePermissions', () => ({ usePermissions: () => permissions(
 // two-pane layout; one test flips this to exercise the Drawer branch.
 const isWide = vi.fn((): boolean => true)
 vi.mock('@/hooks/useContainerWiderThan', () => ({
-  useContainerWiderThan: () => ({ ref: { current: null }, isWide: isWide() }),
+  useContainerWiderThan: () => ({ ref: vi.fn(), isWide: isWide() }),
 }))
 
 const createMutate = vi.fn()

--- a/frontend/app/src/components/settings/roles/RolesPage.test.tsx
+++ b/frontend/app/src/components/settings/roles/RolesPage.test.tsx
@@ -43,7 +43,7 @@ vi.mock('@/lib/auth/usePermissions', () => ({ usePermissions: () => permissions(
 // to false to exercise the mobile Drawer branch.
 const isWide = vi.fn((): boolean => true)
 vi.mock('@/hooks/useContainerWiderThan', () => ({
-  useContainerWiderThan: () => ({ ref: { current: null }, isWide: isWide() }),
+  useContainerWiderThan: () => ({ ref: vi.fn(), isWide: isWide() }),
 }))
 
 const createMutate = vi.fn()

--- a/frontend/app/src/hooks/useContainerWiderThan.test.tsx
+++ b/frontend/app/src/hooks/useContainerWiderThan.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { useContainerWiderThan } from './useContainerWiderThan'
+
+const MIN_WIDTH = 900
+
+let observed: { element: Element; callback: ResizeObserverCallback }[] = []
+
+class TrackingResizeObserver {
+  constructor(private callback: ResizeObserverCallback) {}
+  observe(element: Element) {
+    observed.push({ element, callback: this.callback })
+  }
+  unobserve = vi.fn()
+  disconnect() {
+    observed = observed.filter((entry) => entry.callback !== this.callback)
+  }
+}
+
+const resizeTo = (width: number) => {
+  const entry = observed[observed.length - 1]
+  if (!entry) throw new Error('nothing is being observed')
+  act(() => {
+    entry.callback(
+      [{ target: entry.element, contentRect: { width } } as unknown as ResizeObserverEntry],
+      {} as ResizeObserver,
+    )
+  })
+}
+
+const mockWidth = (width: number) => {
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({ width } as DOMRect)
+}
+
+// The measured element only appears once `mounted` flips, mirroring a page that
+// renders a loading state before the layout it measures.
+const Probe = ({ mountedFromStart }: { mountedFromStart: boolean }) => {
+  const { ref, isWide } = useContainerWiderThan<HTMLDivElement>(MIN_WIDTH)
+  const [mounted, setMounted] = useState(mountedFromStart)
+
+  if (!mounted) {
+    return <button onClick={() => setMounted(true)}>laden</button>
+  }
+
+  return (
+    <div ref={ref} data-testid="layout">
+      {isWide ? 'two-pane' : 'drawer'}
+    </div>
+  )
+}
+
+describe('useContainerWiderThan', () => {
+  beforeEach(() => {
+    observed = []
+    globalThis.ResizeObserver = TrackingResizeObserver
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reports wide when the measured element is present in the first render', () => {
+    mockWidth(1200)
+
+    render(<Probe mountedFromStart />)
+
+    expect(screen.getByTestId('layout')).toHaveTextContent('two-pane')
+  })
+
+  it('reports wide when the measured element mounts after the first render', () => {
+    mockWidth(1200)
+
+    render(<Probe mountedFromStart={false} />)
+    act(() => {
+      screen.getByRole('button', { name: 'laden' }).click()
+    })
+
+    expect(screen.getByTestId('layout')).toHaveTextContent('two-pane')
+  })
+
+  it('switches back to the narrow layout when the element shrinks', () => {
+    mockWidth(1200)
+
+    render(<Probe mountedFromStart />)
+    expect(screen.getByTestId('layout')).toHaveTextContent('two-pane')
+
+    resizeTo(600)
+
+    expect(screen.getByTestId('layout')).toHaveTextContent('drawer')
+  })
+})

--- a/frontend/app/src/hooks/useContainerWiderThan.ts
+++ b/frontend/app/src/hooks/useContainerWiderThan.ts
@@ -1,7 +1,7 @@
-import { useLayoutEffect, useRef, useState, type RefObject } from 'react'
+import { useCallback, useState, type RefCallback } from 'react'
 
 interface ContainerWiderThan<T extends HTMLElement> {
-  ref: RefObject<T | null>
+  ref: RefCallback<T>
   isWide: boolean
 }
 
@@ -13,21 +13,25 @@ interface ContainerWiderThan<T extends HTMLElement> {
 export function useContainerWiderThan<T extends HTMLElement = HTMLDivElement>(
   minWidth: number,
 ): ContainerWiderThan<T> {
-  const ref = useRef<T | null>(null)
   const [isWide, setIsWide] = useState(false)
 
-  useLayoutEffect(() => {
-    const el = ref.current
-    if (!el) return
+  // A callback ref, not useLayoutEffect + useRef: pages render a loading state
+  // before the layout they measure, so the element is absent on the first commit
+  // and an effect that only depends on minWidth would never measure it.
+  const ref = useCallback<RefCallback<T>>(
+    (node) => {
+      if (!node) return
 
-    setIsWide(el.getBoundingClientRect().width >= minWidth)
+      setIsWide(node.getBoundingClientRect().width >= minWidth)
 
-    const observer = new ResizeObserver(([entry]) => {
-      if (entry) setIsWide(entry.contentRect.width >= minWidth)
-    })
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [minWidth])
+      const observer = new ResizeObserver(([entry]) => {
+        if (entry) setIsWide(entry.contentRect.width >= minWidth)
+      })
+      observer.observe(node)
+      return () => observer.disconnect()
+    },
+    [minWidth],
+  )
 
   return { ref, isWide }
 }


### PR DESCRIPTION
`useContainerWiderThan` measured inside a `useLayoutEffect` that only depends on `minWidth`, so it ran once after the first commit. Organization and roles pages return a loading state before the layout they measure, so the element was absent at that point and never measured again — the pages stayed on the mobile drawer layout on a direct visit or reload until a navigation warmed the query cache.

Use a callback ref instead, which measures and observes whenever the element mounts regardless of the render it first appears in.