### PR TITLE
fix(frontend): recover from an aborted Keycloak handover (OP#3476)

### DIFF
--- a/frontend/app/src/lib/auth/handover.test.ts
+++ b/frontend/app/src/lib/auth/handover.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { startSigninHandover, startSignoutHandover } from './handover'
+
+// Mirrors a committed navigation: the document is gone, so nothing ever settles.
+const never = () => new Promise<void>(() => undefined)
+
+const visibility = (state: DocumentVisibilityState) => {
+  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+const settled = (promise: Promise<void>) =>
+  Promise.race([promise.then(() => true), Promise.resolve().then(() => false)])
+
+afterEach(() => {
+  visibility('visible')
+  vi.restoreAllMocks()
+})
+
+describe('startSigninHandover', () => {
+  it('resolves when the redirect promise itself resolves without leaving the page', async () => {
+    const session = { signinRedirect: vi.fn(() => Promise.resolve()) }
+
+    await expect(startSigninHandover(session, '/map')).resolves.toBeUndefined()
+    expect(session.signinRedirect).toHaveBeenCalledWith({ returnTo: '/map' })
+  })
+
+  it('resolves on a bfcache restore even though the redirect promise never settles', async () => {
+    const session = { signinRedirect: vi.fn(never) }
+    const handover = startSigninHandover(session, '/map')
+
+    expect(await settled(handover)).toBe(false)
+
+    window.dispatchEvent(new Event('pageshow'))
+
+    await expect(handover).resolves.toBeUndefined()
+  })
+
+  it('resolves when the visitor returns from a closed custom tab', async () => {
+    const session = { signinRedirect: vi.fn(never) }
+    const handover = startSigninHandover(session, '/map')
+
+    visibility('hidden')
+    expect(await settled(handover)).toBe(false)
+
+    visibility('visible')
+
+    await expect(handover).resolves.toBeUndefined()
+  })
+
+  it('resolves instead of rejecting when the redirect fails', async () => {
+    const session = { signinRedirect: vi.fn(() => Promise.reject(new Error('no authority'))) }
+
+    await expect(startSigninHandover(session, '/map')).resolves.toBeUndefined()
+  })
+
+  it('stops listening once it has resolved', async () => {
+    const remove = vi.spyOn(window, 'removeEventListener')
+    const session = { signinRedirect: vi.fn(() => Promise.resolve()) }
+
+    await startSigninHandover(session, '/map')
+
+    expect(remove).toHaveBeenCalledWith('pageshow', expect.any(Function))
+  })
+})
+
+describe('startSignoutHandover', () => {
+  it('resolves on a bfcache restore even though the redirect promise never settles', async () => {
+    const session = { signoutRedirect: vi.fn(never) }
+    const handover = startSignoutHandover(session)
+
+    expect(await settled(handover)).toBe(false)
+
+    window.dispatchEvent(new Event('pageshow'))
+
+    await expect(handover).resolves.toBeUndefined()
+  })
+})

--- a/frontend/app/src/lib/auth/handover.ts
+++ b/frontend/app/src/lib/auth/handover.ts
@@ -1,0 +1,39 @@
+import type { AuthSession } from './session'
+
+/**
+ * Starts an OIDC redirect and resolves only when the visitor is still here --
+ * the handover was aborted (custom tab closed, back gesture) or the redirect
+ * itself failed. A real navigation tears the document down, so nothing resolves
+ * and the caller never continues.
+ *
+ * oidc-client-ts settles its navigate promise on `pageshow`, which covers a
+ * bfcache restore. A standalone PWA never navigates at all -- the authority
+ * opens in a custom tab -- so page visibility is the only signal left there.
+ */
+function startHandover(redirect: () => Promise<void>): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const done = () => {
+      window.removeEventListener('pageshow', done)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      resolve()
+    }
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') done()
+    }
+
+    window.addEventListener('pageshow', done)
+    document.addEventListener('visibilitychange', onVisibilityChange)
+
+    // A failed redirect (missing OIDC config) must not strand the caller either.
+    redirect().then(done, done)
+  })
+}
+
+export const startSigninHandover = (
+  session: Pick<AuthSession, 'signinRedirect'>,
+  returnTo: string,
+): Promise<void> => startHandover(() => session.signinRedirect({ returnTo }))
+
+export const startSignoutHandover = (
+  session: Pick<AuthSession, 'signoutRedirect'>,
+): Promise<void> => startHandover(() => session.signoutRedirect())

--- a/frontend/app/src/main.tsx
+++ b/frontend/app/src/main.tsx
@@ -10,6 +10,7 @@ import ErrorFallback from './components/layout/ErrorFallback'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { getAuthSession } from '@/lib/auth/session'
 import { AuthSessionProvider } from '@/lib/auth/AuthSessionProvider'
+import { pendingLoading } from '@/lib/router'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -33,6 +34,9 @@ const router = createRouter({
     <ErrorFallback error={error} resetErrorBoundary={reset} />
   ),
   defaultNotFoundComponent: () => <NotFound />,
+  // A pending match without this renders null, so a loader that never settles
+  // leaves a blank page behind. Only shows past defaultPendingMs (1s).
+  defaultPendingComponent: pendingLoading('Wird geladen …'),
   defaultPreload: 'intent',
   defaultPreloadStaleTime: 30_000,
   scrollRestoration: true,

--- a/frontend/app/src/routes/_protected.tsx
+++ b/frontend/app/src/routes/_protected.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { userQueries } from '@/api/queries'
+import { startSigninHandover } from '@/lib/auth/handover'
 import { readAuthBypass } from '@/lib/auth/runtimeConfig'
 
 export const Route = createFileRoute('/_protected')({
@@ -11,7 +12,10 @@ export const Route = createFileRoute('/_protected')({
       if (preload) {
         throw redirect({ to: '/' })
       }
-      await context.auth.signinRedirect({ returnTo: location.pathname + location.searchStr })
+      await startSigninHandover(context.auth, location.pathname + location.searchStr)
+      // Still here, so the handover was aborted. Falling through would query /me
+      // unauthenticated and strand the visitor on an error page.
+      throw redirect({ to: '/', replace: true })
     }
     // Nav entries and child guards read permissions synchronously from the
     // cache, so the user has to be resolved before anything inside renders.

--- a/frontend/app/src/routes/authRedirectGuards.test.ts
+++ b/frontend/app/src/routes/authRedirectGuards.test.ts
@@ -16,9 +16,11 @@ const { Route: ProtectedRoute } = await import('./_protected')
 const { Route: LoginRoute } = await import('./login')
 const { Route: LogoutRoute } = await import('./logout')
 
+const ensureQueryData = vi.fn(() => Promise.resolve({}))
+
 const anonymousContext = {
   auth: { isAuthenticated: () => Promise.resolve(false), signinRedirect },
-  queryClient: { ensureQueryData: vi.fn(() => Promise.resolve({})) },
+  queryClient: { ensureQueryData },
 }
 
 const location = { pathname: '/map', searchStr: '' }
@@ -32,6 +34,9 @@ const beforeLoad = (route: HookRoute, opts: Record<string, unknown>) =>
   (route.options.beforeLoad as AsyncHook)(opts)
 const loader = (route: HookRoute, opts: Record<string, unknown>) =>
   (route.options.loader as AsyncHook)(opts)
+
+const redirectTarget = (thrown: unknown) =>
+  isRedirect(thrown) ? (thrown.options as { to?: string; replace?: boolean }) : undefined
 
 describe('auth redirect guards ignore route preloading', () => {
   it('does not hand an anonymous visitor to Keycloak when _protected is preloaded', async () => {
@@ -54,7 +59,7 @@ describe('auth redirect guards ignore route preloading', () => {
       context: anonymousContext,
       location,
       preload: false,
-    })
+    }).catch(() => undefined)
 
     expect(signinRedirect).toHaveBeenCalledWith({ returnTo: '/map' })
   })
@@ -70,7 +75,7 @@ describe('auth redirect guards ignore route preloading', () => {
   it('starts the login flow on a real navigation to /login', async () => {
     signinRedirect.mockClear()
 
-    await loader(LoginRoute, { deps: { redirect: '/map' }, preload: false })
+    await loader(LoginRoute, { deps: { redirect: '/map' }, preload: false }).catch(() => undefined)
 
     expect(signinRedirect).toHaveBeenCalledWith({ returnTo: '/map' })
   })
@@ -86,8 +91,43 @@ describe('auth redirect guards ignore route preloading', () => {
   it('signs the user out on a real navigation to /logout', async () => {
     signoutRedirect.mockClear()
 
-    await beforeLoad(LogoutRoute, { preload: false })
+    await beforeLoad(LogoutRoute, { preload: false }).catch(() => undefined)
 
     expect(signoutRedirect).toHaveBeenCalled()
+  })
+})
+
+// An aborted Keycloak handover -- custom tab closed, back gesture -- returns the
+// visitor to a live SPA. These routes render nothing, so they have to navigate
+// away instead of resolving into a blank page.
+describe('auth redirect guards recover from an aborted handover', () => {
+  it('sends the visitor to the start page when /login is abandoned', async () => {
+    const thrown = await loader(LoginRoute, {
+      deps: { redirect: '/map' },
+      preload: false,
+    }).catch((error: unknown) => error)
+
+    expect(redirectTarget(thrown)).toMatchObject({ to: '/', replace: true })
+  })
+
+  it('sends the visitor to the start page when the _protected handover is abandoned', async () => {
+    ensureQueryData.mockClear()
+
+    const thrown = await beforeLoad(ProtectedRoute, {
+      context: anonymousContext,
+      location,
+      preload: false,
+    }).catch((error: unknown) => error)
+
+    expect(redirectTarget(thrown)).toMatchObject({ to: '/', replace: true })
+    expect(ensureQueryData).not.toHaveBeenCalled()
+  })
+
+  it('sends the visitor to the start page when /logout is abandoned', async () => {
+    const thrown = await beforeLoad(LogoutRoute, { preload: false }).catch(
+      (error: unknown) => error,
+    )
+
+    expect(redirectTarget(thrown)).toMatchObject({ to: '/', replace: true })
   })
 })

--- a/frontend/app/src/routes/login.tsx
+++ b/frontend/app/src/routes/login.tsx
@@ -1,6 +1,7 @@
 import { getAuthSession } from '@/lib/auth/session'
+import { startSigninHandover } from '@/lib/auth/handover'
 import { sanitizeReturnTo } from '@/lib/auth/redirect'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 import { z } from 'zod'
 
 const loginSchema = z.object({
@@ -10,11 +11,14 @@ const loginSchema = z.object({
 export const Route = createFileRoute('/login')({
   validateSearch: loginSchema,
   loaderDeps: ({ search: { redirect } }) => ({ redirect }),
-  loader: async ({ deps: { redirect }, preload }) => {
+  loader: async ({ deps: { redirect: returnTo }, preload }) => {
     // A hover-triggered preload must not leave the page; only a real click may.
     if (preload) {
       return
     }
-    await getAuthSession().signinRedirect({ returnTo: sanitizeReturnTo(redirect) })
+    await startSigninHandover(getAuthSession(), sanitizeReturnTo(returnTo))
+    // Still here, so the handover was aborted. This route renders nothing, so
+    // without leaving it the visitor would be looking at a blank page.
+    throw redirect({ to: '/', replace: true })
   },
 })

--- a/frontend/app/src/routes/logout.tsx
+++ b/frontend/app/src/routes/logout.tsx
@@ -1,5 +1,6 @@
 import { getAuthSession } from '@/lib/auth/session'
-import { createFileRoute } from '@tanstack/react-router'
+import { startSignoutHandover } from '@/lib/auth/handover'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/logout')({
   beforeLoad: async ({ preload }) => {
@@ -7,6 +8,8 @@ export const Route = createFileRoute('/logout')({
     if (preload) {
       return
     }
-    await getAuthSession().signoutRedirect()
+    await startSignoutHandover(getAuthSession())
+    // Still here, so the handover was aborted; this route renders nothing.
+    throw redirect({ to: '/', replace: true })
   },
 })


### PR DESCRIPTION
Returning to the SPA without finishing the login left a blank page that only a manual reload cleared. Two paths ended in a rendered null:

In a standalone PWA the authority opens in a custom tab, so the document never navigates and the `pageshow` that oidc-client-ts resolves its navigate promise on never fires. The awaited signinRedirect hung forever, the match stayed pending, and renderPending returned null because no pendingComponent was set anywhere.

On a bfcache restore `pageshow` does fire, so signinRedirect resolved and the /login loader finished -- but /login has no component, so MatchInner fell back to an Outlet, which renders null on a leaf route. In _protected the resolved await fell through to an unauthenticated /me query instead.

startSigninHandover/startSignoutHandover now race the redirect against `pageshow` and a return to visibility, so they resolve only when the visitor is still here. The guards then leave for the start page, which already offers the login button.

defaultPendingComponent guards the same class of bug elsewhere: past defaultPendingMs a stuck loader shows a spinner instead of nothing.