### PR TITLE
feat: count page views on the demo instance

### DIFF
--- a/backend/config/base.yaml
+++ b/backend/config/base.yaml
@@ -50,3 +50,6 @@ routing:
   tree_demand_liters: 80.0
 plugins:
   enabled: false
+analytics:
+  enabled: false
+  script_url: "https://analytics.progeek.de/a.js"

--- a/backend/config/demo.yaml
+++ b/backend/config/demo.yaml
@@ -24,3 +24,6 @@ auth:
   backend_client_id: "backend"
   backend_client_secret: "unused-while-auth-is-disabled"
   default_redirect_url: "https://demo.green-ecolution.de/auth/callback"
+analytics:
+  enabled: true
+  tenant_id: "ZECPeLLG8eyZ"

--- a/backend/crates/server/src/configuration.rs
+++ b/backend/crates/server/src/configuration.rs
@@ -29,6 +29,8 @@ pub struct Settings {
     pub routing: RoutingSettings,
     #[serde(default)]
     pub plugins: PluginsSettings,
+    #[serde(default)]
+    pub analytics: AnalyticsSettings,
 }
 
 #[derive(serde::Deserialize, Clone)]
@@ -191,6 +193,30 @@ fn default_tree_demand_liters() -> f64 {
 pub struct PluginsSettings {
     #[serde(default)]
     pub enabled: bool,
+}
+
+/// Page-view counting for the frontend, handed to it through the runtime
+/// config. Off by default and enabled only for the public demo instance.
+#[derive(serde::Deserialize, Clone, Default)]
+pub struct AnalyticsSettings {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub script_url: String,
+    #[serde(default)]
+    pub tenant_id: String,
+}
+
+impl AnalyticsSettings {
+    /// The script URL the frontend loads, or `None` when analytics is off or
+    /// half-configured. The tenant id has to travel in the query string: the
+    /// script reads it back off its own `src` attribute.
+    pub fn script_src(&self) -> Option<String> {
+        if !self.enabled || self.script_url.is_empty() || self.tenant_id.is_empty() {
+            return None;
+        }
+        Some(format!("{}?id={}", self.script_url, self.tenant_id))
+    }
 }
 
 #[derive(serde::Deserialize, Clone)]
@@ -487,6 +513,7 @@ impl Settings {
             watering: WateringSettings::default(),
             routing: RoutingSettings::default(),
             plugins: PluginsSettings::default(),
+            analytics: AnalyticsSettings::default(),
         }
     }
 }
@@ -709,6 +736,39 @@ mod tests {
         let settings = Settings::for_test(auth(false, None));
 
         assert!(settings.security_advisories().is_empty());
+    }
+
+    fn analytics(enabled: bool, tenant_id: &str) -> AnalyticsSettings {
+        AnalyticsSettings {
+            enabled,
+            script_url: "https://analytics.progeek.de/a.js".into(),
+            tenant_id: tenant_id.into(),
+        }
+    }
+
+    #[test]
+    fn enabled_analytics_carries_the_tenant_id_in_the_query_string() {
+        assert_eq!(
+            analytics(true, "tenant-42").script_src().as_deref(),
+            Some("https://analytics.progeek.de/a.js?id=tenant-42")
+        );
+    }
+
+    #[test]
+    fn disabled_analytics_has_no_script() {
+        assert_eq!(analytics(false, "tenant-42").script_src(), None);
+    }
+
+    /// A tenant-less script would load and then report nothing, so treat the
+    /// half-configured case as off instead of shipping a dead request.
+    #[test]
+    fn analytics_without_a_tenant_id_has_no_script() {
+        assert_eq!(analytics(true, "").script_src(), None);
+    }
+
+    #[test]
+    fn analytics_is_off_by_default() {
+        assert_eq!(AnalyticsSettings::default().script_src(), None);
     }
 
     #[test]

--- a/backend/crates/server/src/http/mod.rs
+++ b/backend/crates/server/src/http/mod.rs
@@ -17,7 +17,7 @@ use utoipa_axum::router::OpenApiRouter;
 use utoipa_swagger_ui::{SwaggerUi, oauth};
 
 use crate::{
-    configuration::{AuthSettings, CorsSettings},
+    configuration::{AnalyticsSettings, AuthSettings, CorsSettings},
     http::{
         auth::{AuthLayer, validator::TokenValidator},
         tracing::{MakeRequestUuid, REQUEST_ID_HEADER, make_span, on_response},
@@ -119,12 +119,19 @@ pub struct AppState {
 )]
 struct ApiDoc;
 
-pub fn render_frontend_config_js(auth: &AuthSettings) -> String {
-    let env = serde_json::json!({
+pub fn render_frontend_config_js(auth: &AuthSettings, analytics: &AnalyticsSettings) -> String {
+    let mut env = serde_json::json!({
         "VITE_AUTH_BYPASS": (!auth.enabled).to_string(),
         "VITE_OIDC_AUTHORITY": auth.issuer_url,
         "VITE_OIDC_CLIENT_ID": auth.frontend_client_id,
     });
+
+    // Absent rather than empty when analytics is off: the frontend loads the
+    // script only for a key that is actually there.
+    if let (Some(map), Some(src)) = (env.as_object_mut(), analytics.script_src()) {
+        map.insert("VITE_ANALYTICS_SCRIPT_URL".to_string(), src.into());
+    }
+
     format!("window._env_ = {env};\n")
 }
 
@@ -344,6 +351,57 @@ fn cors_layer(config: &CorsSettings) -> CorsLayer {
         .allow_origin(origins)
         .allow_methods(Any)
         .allow_headers(Any)
+}
+
+#[cfg(test)]
+mod frontend_config_tests {
+    use super::*;
+    use secrecy::SecretString;
+
+    fn auth() -> AuthSettings {
+        AuthSettings {
+            enabled: true,
+            issuer_url: "http://localhost/realms/green-ecolution".into(),
+            frontend_client_id: "frontend".into(),
+            backend_client_id: "backend".into(),
+            backend_client_secret: SecretString::from("secret".to_string()),
+            jwks_refresh_interval_secs: 3600,
+            jwks_refresh_timeout_secs: 5,
+            default_redirect_url: "http://localhost/cb".into(),
+            expected_audience: None,
+        }
+    }
+
+    fn rendered_env(analytics: &AnalyticsSettings) -> serde_json::Value {
+        let js = render_frontend_config_js(&auth(), analytics);
+        let json = js
+            .trim_end()
+            .trim_end_matches(';')
+            .trim_start_matches("window._env_ = ");
+        serde_json::from_str(json).expect("config.js must carry a JSON object")
+    }
+
+    #[test]
+    fn analytics_off_leaves_the_script_url_out_entirely() {
+        let env = rendered_env(&AnalyticsSettings::default());
+
+        assert!(env.get("VITE_ANALYTICS_SCRIPT_URL").is_none());
+        assert_eq!(env["VITE_OIDC_CLIENT_ID"], "frontend");
+    }
+
+    #[test]
+    fn analytics_on_exposes_the_script_url_with_the_tenant_id() {
+        let env = rendered_env(&AnalyticsSettings {
+            enabled: true,
+            script_url: "https://analytics.progeek.de/a.js".into(),
+            tenant_id: "tenant-42".into(),
+        });
+
+        assert_eq!(
+            env["VITE_ANALYTICS_SCRIPT_URL"],
+            "https://analytics.progeek.de/a.js?id=tenant-42"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/backend/crates/server/src/startup.rs
+++ b/backend/crates/server/src/startup.rs
@@ -186,7 +186,11 @@ impl Application {
                 default_limit: settings.map.nearest_tree_default_limit,
                 max_limit: settings.map.nearest_tree_max_limit,
             },
-            frontend_config_js: crate::http::render_frontend_config_js(&settings.auth).into(),
+            frontend_config_js: crate::http::render_frontend_config_js(
+                &settings.auth,
+                &settings.analytics,
+            )
+            .into(),
             start_point_service: services.start_point,
             organization_service: services.organization,
             role_service: services.role,

--- a/backend/crates/server/test/api/config_js.rs
+++ b/backend/crates/server/test/api/config_js.rs
@@ -32,3 +32,15 @@ async fn get_config_js_content_type_is_javascript() {
         .unwrap_or("");
     assert!(content_type.contains("javascript"));
 }
+
+/// Analytics is demo-only, so the shipped default must not hand the frontend
+/// a script to load.
+#[tokio::test]
+async fn get_config_js_omits_analytics_by_default() {
+    let app = spawn_app().await;
+
+    let response = app.get("/api/config.js").await;
+    let body = response.text().await.expect("failed to read body");
+
+    assert!(!body.contains("VITE_ANALYTICS_SCRIPT_URL"));
+}

--- a/frontend/app/src/lib/analytics.test.ts
+++ b/frontend/app/src/lib/analytics.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { startAnalytics } from './analytics'
+
+const SCRIPT_URL = 'https://analytics.example/a.js?id=tenant-42'
+
+function fakeRouter() {
+  const listeners: (() => void)[] = []
+  return {
+    subscribe: (_event: 'onResolved', listener: () => void) => {
+      listeners.push(listener)
+      return vi.fn()
+    },
+    resolve: () => listeners.forEach((l) => l()),
+  }
+}
+
+function setRuntimeEnv(env: Record<string, string> | undefined) {
+  Object.defineProperty(window, '_env_', { value: env, configurable: true, writable: true })
+}
+
+function injectedScript() {
+  return document.head.querySelector<HTMLScriptElement>(`script[src="${SCRIPT_URL}"]`)
+}
+
+/** Stands in for a.js: defines window.a, reports nothing on its own. */
+function loadScript() {
+  const pageView = vi.fn()
+  window.a = { pageView, trackEvent: vi.fn() }
+  injectedScript()?.dispatchEvent(new Event('load'))
+  return pageView
+}
+
+afterEach(() => {
+  setRuntimeEnv(undefined)
+  delete window.a
+  injectedScript()?.remove()
+})
+
+describe('startAnalytics', () => {
+  it('loads nothing without a configured script url', () => {
+    setRuntimeEnv({})
+    const router = fakeRouter()
+
+    startAnalytics(router)
+
+    expect(injectedScript()).toBeNull()
+    expect(() => router.resolve()).not.toThrow()
+  })
+
+  it('injects the script with the tenant id intact', () => {
+    setRuntimeEnv({ VITE_ANALYTICS_SCRIPT_URL: SCRIPT_URL })
+
+    startAnalytics(fakeRouter())
+
+    expect(injectedScript()?.src).toBe(SCRIPT_URL)
+  })
+
+  it('reports a view for every resolved navigation', () => {
+    setRuntimeEnv({ VITE_ANALYTICS_SCRIPT_URL: SCRIPT_URL })
+    const router = fakeRouter()
+    startAnalytics(router)
+    const pageView = loadScript()
+
+    router.resolve()
+    router.resolve()
+
+    expect(pageView).toHaveBeenCalledTimes(2)
+  })
+
+  it('still reports the initial view that resolved before the script loaded', () => {
+    setRuntimeEnv({ VITE_ANALYTICS_SCRIPT_URL: SCRIPT_URL })
+    const router = fakeRouter()
+    startAnalytics(router)
+
+    router.resolve()
+    const pageView = loadScript()
+
+    expect(pageView).toHaveBeenCalledTimes(1)
+  })
+
+  it('collapses views held before the load into a single report', () => {
+    setRuntimeEnv({ VITE_ANALYTICS_SCRIPT_URL: SCRIPT_URL })
+    const router = fakeRouter()
+    startAnalytics(router)
+
+    router.resolve()
+    router.resolve()
+    const pageView = loadScript()
+
+    expect(pageView).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not report anything when nothing navigated before the load', () => {
+    setRuntimeEnv({ VITE_ANALYTICS_SCRIPT_URL: SCRIPT_URL })
+    startAnalytics(fakeRouter())
+
+    const pageView = loadScript()
+
+    expect(pageView).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/app/src/lib/analytics.ts
+++ b/frontend/app/src/lib/analytics.ts
@@ -1,0 +1,56 @@
+import { readAnalyticsScriptUrl } from '@/lib/auth/runtimeConfig'
+
+interface AnalyticsApi {
+  pageView: () => void
+  trackEvent: (name: string, properties?: Record<string, unknown>) => void
+}
+
+declare global {
+  interface Window {
+    a?: AnalyticsApi
+  }
+}
+
+interface RouterLike {
+  subscribe: (event: 'onResolved', listener: () => void) => () => void
+}
+
+/**
+ * Loads the page-view counter and reports one view per resolved navigation.
+ * No-op unless the backend handed us a script URL, which only the demo
+ * instance does.
+ *
+ * The script reads its tenant id back off its own `src`, so it has to be a
+ * real element rather than an imported module.
+ */
+export function startAnalytics(router: RouterLike): void {
+  const src = readAnalyticsScriptUrl()
+  if (!src) return
+
+  // The script only defines `window.a`; it never reports the initial view by
+  // itself. Since it loads deferred, the first navigation usually resolves
+  // before it exists — hold that view and send it once it does. Collapsing
+  // several held views into one is correct: the report reads the current URL
+  // at call time, so only the last one would have been distinguishable.
+  let heldView = false
+  const reportView = () => {
+    if (window.a) {
+      window.a.pageView()
+    } else {
+      heldView = true
+    }
+  }
+
+  const script = document.createElement('script')
+  script.src = src
+  script.defer = true
+  script.addEventListener('load', () => {
+    if (heldView) {
+      heldView = false
+      window.a?.pageView()
+    }
+  })
+  document.head.append(script)
+
+  router.subscribe('onResolved', reportView)
+}

--- a/frontend/app/src/lib/auth/runtimeConfig.ts
+++ b/frontend/app/src/lib/auth/runtimeConfig.ts
@@ -2,6 +2,7 @@ interface RuntimeEnv {
   VITE_AUTH_BYPASS?: string
   VITE_OIDC_AUTHORITY?: string
   VITE_OIDC_CLIENT_ID?: string
+  VITE_ANALYTICS_SCRIPT_URL?: string
 }
 
 function runtimeEnv(): RuntimeEnv {
@@ -18,4 +19,13 @@ export function readOidcAuthority(): string | undefined {
 
 export function readOidcClientId(): string | undefined {
   return runtimeEnv().VITE_OIDC_CLIENT_ID ?? import.meta.env.VITE_OIDC_CLIENT_ID
+}
+
+/**
+ * Runtime-only on purpose, with no build-time fallback: which instance is
+ * measured is a deployment decision, and a baked-in value would follow the
+ * shared image into every other environment.
+ */
+export function readAnalyticsScriptUrl(): string | undefined {
+  return runtimeEnv().VITE_ANALYTICS_SCRIPT_URL
 }

--- a/frontend/app/src/main.tsx
+++ b/frontend/app/src/main.tsx
@@ -11,6 +11,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { getAuthSession } from '@/lib/auth/session'
 import { AuthSessionProvider } from '@/lib/auth/AuthSessionProvider'
 import { pendingLoading } from '@/lib/router'
+import { startAnalytics } from '@/lib/analytics'
 import { I18nextProvider } from 'react-i18next'
 import { createI18n } from '@/lib/i18n'
 import { UiTextBridge } from '@/lib/i18n/UiTextBridge'
@@ -47,6 +48,8 @@ const router = createRouter({
   defaultPreloadStaleTime: 30_000,
   scrollRestoration: true,
 })
+
+startAnalytics(router)
 
 declare module '@tanstack/react-router' {
   interface Register {


### PR DESCRIPTION
## Problem
We want usage data from the public demo instance, but the frontend image is shared across all environments. A static script tag in index.html would load the counter locally and in production too.

## Solution
The switch lives in the backend configuration and reaches the frontend through the existing runtime config. `analytics` (enabled, script_url, tenant_id) is on in demo.yaml only, and `render_frontend_config_js` puts the resulting URL into `window._env_` as `VITE_ANALYTICS_SCRIPT_URL` — the key is absent rather than empty when analytics is off, so the frontend loads the script only for a value that is actually there. A missing tenant id counts as off.

`lib/analytics.ts` injects the script and reports one view per resolved navigation. Two traits of the script shape this: it reads its tenant id back off its own `src`, so it has to be a real element, and it reports no initial view by itself. Since it loads deferred, the first navigation usually resolves before it exists, so that view is held and sent once the script has loaded.
