### PR TITLE
fix(frontend): keep the error page cable above the text

### DIFF
--- a/frontend/app/src/components/layout/ErrorFallback.tsx
+++ b/frontend/app/src/components/layout/ErrorFallback.tsx
@@ -50,12 +50,12 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({ error, resetErrorBoundary
   const t = getI18n().t
 
   return (
-    <div className="relative">
-      <figure aria-hidden="true" className="absolute top-0 inset-x-0 z-0">
-        <Lottie className="h-[50vh]" animationData={cableAnimation} />
+    <div>
+      <figure aria-hidden="true">
+        <Lottie className="h-[40vh] max-h-96" animationData={cableAnimation} />
       </figure>
-      <div className="mt-[45vh] mx-auto max-w-208 sm:mt-[50vh] xl:max-w-screen-lg">
-        <section className="my-28 px-4 md:px-6 lg:my-36 xl:my-52">
+      <div className="mx-auto max-w-208 xl:max-w-screen-lg">
+        <section className="mb-28 px-4 md:px-6 lg:mb-36">
           <h1 className="font-lato font-bold text-4xl mb-4 lg:mb-6 lg:text-5xl lg:text-center xl:text-6xl">
             {t('navigation:errorFallback.title')}
           </h1>

--- a/frontend/app/src/components/layout/NotFound.tsx
+++ b/frontend/app/src/components/layout/NotFound.tsx
@@ -11,11 +11,11 @@ function NotFound() {
 
   return (
     <>
-      <figure aria-hidden="true" className="absolute top-0 inset-x-0 z-0">
-        <Lottie className="h-[50vh]" animationData={cableAnimation} />
+      <figure aria-hidden="true">
+        <Lottie className="h-[40vh] max-h-96" animationData={cableAnimation} />
       </figure>
-      <div className="mt-[45vh] mx-auto max-w-208 sm:mt-[50vh] xl:max-w-screen-lg">
-        <section className="my-28 px-4 md:px-6 lg:my-36 xl:my-52">
+      <div className="mx-auto max-w-208 xl:max-w-screen-lg">
+        <section className="mb-28 px-4 md:px-6 lg:mb-36">
           <h1 className="font-lato font-bold text-4xl mb-4 lg:mb-6 lg:text-5xl lg:text-center xl:text-6xl">
             {t('notFound.title')}
           </h1>


### PR DESCRIPTION
The cable illustration was absolutely positioned at top-0 inside a wrapper whose only child carried a 50vh top margin. With no padding or border on the wrapper, that margin collapsed out of it, so the wrapper -- and with it the illustration -- started at the headline instead of the top of the page: the cable ran through the text and the plug floated in the middle of the screen.

Put the illustration in normal flow above the content and cap its height so a tall viewport no longer blows it up.