### PR TITLE
feat(frontend): drag an active watering plan back to planned (OP#3614)

### DIFF
--- a/frontend/app/src/components/watering-plan/board/WateringPlanBoard.drag.test.tsx
+++ b/frontend/app/src/components/watering-plan/board/WateringPlanBoard.drag.test.tsx
@@ -1,0 +1,139 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+vi.mock('@/lib/auth/usePermissions', () => ({
+  usePermissions: () => new Set(['watering_plan:update']),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn().mockResolvedValue(undefined),
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}))
+
+const activePlan = {
+  id: 'p1',
+  date: new Date().toISOString(),
+  treeclusters: [],
+  status: 'active',
+  userIds: [],
+  totalWaterRequired: 0,
+  transporter: { numberPlate: 'TEST-1' },
+}
+
+interface DragData {
+  plan: typeof activePlan
+  column: 'planned' | 'active' | 'done'
+}
+interface DragStartEvent {
+  active: { data: { current: DragData } }
+}
+type DragEndEvent = DragStartEvent & { over: { id: string } | null }
+
+// dnd-kit needs the DOM rects a real drag measures, which jsdom does not provide;
+// the mock hands the test the DndContext callbacks so a drop can be replayed.
+const notRendered = () => {
+  throw new Error('DndContext has not rendered yet')
+}
+const dnd: {
+  onDragStart: (event: DragStartEvent) => void
+  onDragEnd: (event: DragEndEvent) => void
+} = { onDragStart: notRendered, onDragEnd: notRendered }
+const droppableCalls: { id: string; disabled: boolean }[] = []
+
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({
+    children,
+    onDragStart,
+    onDragEnd,
+  }: {
+    children: ReactNode
+    onDragStart: (event: DragStartEvent) => void
+    onDragEnd: (event: DragEndEvent) => void
+  }) => {
+    dnd.onDragStart = onDragStart
+    dnd.onDragEnd = onDragEnd
+    return <>{children}</>
+  },
+  DragOverlay: ({ children }: { children: ReactNode }) => <>{children}</>,
+  KeyboardSensor: {},
+  PointerSensor: {},
+  useSensor: () => ({}),
+  useSensors: () => [],
+  useDraggable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    isDragging: false,
+  }),
+  useDroppable: ({ id, disabled }: { id: string; disabled: boolean }) => {
+    droppableCalls.push({ id, disabled })
+    return { setNodeRef: vi.fn(), isOver: false }
+  },
+}))
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+  return {
+    ...actual,
+    useQuery: (opts: { queryKey: unknown[] }) => {
+      const key = JSON.stringify(opts.queryKey)
+      if (key.includes('active')) return { data: { data: [activePlan] }, isError: false }
+      return { data: { data: [] }, isError: false }
+    },
+    useInfiniteQuery: () => ({
+      data: { pages: [{ data: [], pagination: { totalRecords: 0 } }] },
+      isError: false,
+      hasNextPage: false,
+      fetchNextPage: vi.fn(),
+    }),
+  }
+})
+
+const revertStart = { mutate: vi.fn() }
+const startPlan = { mutate: vi.fn() }
+vi.mock('@/hooks/useWateringPlanBoardMutations', () => ({
+  useWateringPlanBoardMutations: () => ({ revertStart, startPlan }),
+}))
+
+vi.mock('./AssignUsersPopover', () => ({ default: () => <div /> }))
+
+const { default: WateringPlanBoard } = await import('./WateringPlanBoard')
+
+const drag: DragStartEvent = {
+  active: { data: { current: { plan: activePlan, column: 'active' } } },
+}
+const lastDroppableCall = (id: string) => droppableCalls.filter((call) => call.id === id).pop()
+
+describe('dragging a plan from Unterwegs back to Geplant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    droppableCalls.length = 0
+  })
+
+  it('offers Geplant as an active drop target', () => {
+    render(<WateringPlanBoard />)
+    act(() => dnd.onDragStart(drag))
+
+    expect(lastDroppableCall('planned')?.disabled).toBe(false)
+    expect(screen.getByLabelText('Geplant').className).not.toContain('opacity-40')
+  })
+
+  it('shows the undo-start drop hint on the Geplant column', () => {
+    render(<WateringPlanBoard />)
+    act(() => dnd.onDragStart(drag))
+
+    expect(screen.getByText('Start zurücknehmen')).toBeInTheDocument()
+  })
+
+  it('reverts the start when the card is dropped on Geplant', () => {
+    render(<WateringPlanBoard />)
+    act(() => dnd.onDragStart(drag))
+    act(() => dnd.onDragEnd({ ...drag, over: { id: 'planned' } }))
+
+    expect(revertStart.mutate).toHaveBeenCalledWith(activePlan)
+    expect(startPlan.mutate).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/app/src/components/watering-plan/board/WateringPlanBoard.test.tsx
+++ b/frontend/app/src/components/watering-plan/board/WateringPlanBoard.test.tsx
@@ -46,7 +46,10 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
 })
 
 vi.mock('@/hooks/useWateringPlanBoardMutations', () => ({
-  useWateringPlanBoardMutations: () => ({ startPlan: { mutate: vi.fn() } }),
+  useWateringPlanBoardMutations: () => ({
+    startPlan: { mutate: vi.fn() },
+    revertStart: { mutate: vi.fn() },
+  }),
 }))
 
 // AssignUsersPopover is watering_plan:update only; render a marker we can assert on.

--- a/frontend/app/src/components/watering-plan/board/WateringPlanBoard.tsx
+++ b/frontend/app/src/components/watering-plan/board/WateringPlanBoard.tsx
@@ -133,7 +133,7 @@ const WateringPlanBoard = () => {
   const { data: plannedRes } = plannedQuery
   const { data: activeRes } = activeQuery
 
-  const { startPlan } = useWateringPlanBoardMutations()
+  const { startPlan, revertStart } = useWateringPlanBoardMutations()
   const canModify = useHasPermission(['watering_plan:update'])
   const canCreate = useHasPermission(['watering_plan:create'])
   const { t } = useTranslation('wateringPlan')
@@ -170,6 +170,9 @@ const WateringPlanBoard = () => {
         break
       case 'complete':
         setPlanToComplete(drag.plan)
+        break
+      case 'revertStart':
+        revertStart.mutate(drag.plan)
         break
       case null:
         break

--- a/frontend/app/src/lib/wateringPlanBoard.test.ts
+++ b/frontend/app/src/lib/wateringPlanBoard.test.ts
@@ -35,10 +35,10 @@ describe('dropActionFor', () => {
     expect(dropActionFor('planned', 'active')).toBe('start')
     expect(dropActionFor('planned', 'done')).toBe('cancel')
     expect(dropActionFor('active', 'done')).toBe('complete')
+    expect(dropActionFor('active', 'planned')).toBe('revertStart')
   })
 
   it('rejects everything else', () => {
-    expect(dropActionFor('active', 'planned')).toBeNull()
     expect(dropActionFor('done', 'active')).toBeNull()
     expect(dropActionFor('done', 'planned')).toBeNull()
     expect(dropActionFor('planned', 'planned')).toBeNull()
@@ -50,5 +50,6 @@ describe('dropHintFor', () => {
     expect(dropHintFor('start', t)).toBe('Einsatzplan starten')
     expect(dropHintFor('cancel', t)).toBe('Einsatzplan abbrechen')
     expect(dropHintFor('complete', t)).toBe('Einsatzplan abschließen')
+    expect(dropHintFor('revertStart', t)).toBe('Start zurücknehmen')
   })
 })

--- a/frontend/app/src/lib/wateringPlanBoard.ts
+++ b/frontend/app/src/lib/wateringPlanBoard.ts
@@ -22,12 +22,13 @@ export function columnForStatus(status: WateringPlanStatus): BoardColumnId {
   }
 }
 
-export type DropAction = 'start' | 'cancel' | 'complete'
+export type DropAction = 'start' | 'cancel' | 'complete' | 'revertStart'
 
 export function dropActionFor(from: BoardColumnId, to: BoardColumnId): DropAction | null {
   if (from === 'planned' && to === 'active') return 'start'
   if (from === 'planned' && to === 'done') return 'cancel'
   if (from === 'active' && to === 'done') return 'complete'
+  if (from === 'active' && to === 'planned') return 'revertStart'
   return null
 }
 
@@ -42,5 +43,7 @@ export function dropHintFor(action: DropAction, t: TFunction<'wateringPlan'>): s
       return t('board.dropHint.cancel')
     case 'complete':
       return t('board.dropHint.complete')
+    case 'revertStart':
+      return t('board.dropHint.revertStart')
   }
 }

--- a/frontend/app/src/locales/de/wateringPlan.json
+++ b/frontend/app/src/locales/de/wateringPlan.json
@@ -152,7 +152,8 @@
     "dropHint": {
       "start": "Einsatzplan starten",
       "cancel": "Einsatzplan abbrechen",
-      "complete": "Einsatzplan abschließen"
+      "complete": "Einsatzplan abschließen",
+      "revertStart": "Start zurücknehmen"
     },
     "mutation": {
       "startRevertedToast": "Start rückgängig gemacht.",

--- a/frontend/app/src/locales/en/wateringPlan.json
+++ b/frontend/app/src/locales/en/wateringPlan.json
@@ -152,7 +152,8 @@
     "dropHint": {
       "start": "Start watering plan",
       "cancel": "Cancel watering plan",
-      "complete": "Complete watering plan"
+      "complete": "Complete watering plan",
+      "revertStart": "Undo start"
     },
     "mutation": {
       "startRevertedToast": "Start undone.",

--- a/frontend/handbook/content/de/30-watering-plans.md
+++ b/frontend/handbook/content/de/30-watering-plans.md
@@ -116,8 +116,12 @@ Einen geplanten Einsatz startest du auf zwei Wegen: Entweder ziehst du seine Kar
 dem Board von der Spalte Geplant in die Spalte Unterwegs, oder du öffnest den
 Einsatzplan und klickst dort auf **Status aktualisieren**, wählst als neuen Status Aktiv
 und speicherst. Nach dem Ziehen bestätigt eine Meldung den Start und bietet für kurze
-Zeit **Rückgängig** an, um ihn zurückzunehmen; danach lässt sich ein gestarteter
-Einsatzplan über **Status aktualisieren** ebenso wieder auf Geplant zurücksetzen.
+Zeit **Rückgängig** an, um ihn zurückzunehmen.
+
+Ist diese Meldung verschwunden, lässt sich ein versehentlicher Start auch später noch
+korrigieren: Ziehe die Karte auf dem Board aus der Spalte Unterwegs zurück in die Spalte
+Geplant, die dabei den Hinweis **Start zurücknehmen** zeigt. Alternativ setzt du den
+Einsatzplan über **Status aktualisieren** wieder auf Geplant.
 
 ## Einsatz abbrechen oder als nicht angetreten melden
 


### PR DESCRIPTION
The board only knew planned -> active, so the Geplant column dimmed when a card was dragged out of Unterwegs and a mistaken start could only be undone through the start toast or Status aktualisieren. dropActionFor now maps active -> planned to the existing revertStart mutation, which brings the optimistic update, toast and invalidation along.