### PR TITLE
fix(map): keep the map panel content inside the panel

### DIFF
--- a/frontend/app/src/components/general/form/FormForTree.tsx
+++ b/frontend/app/src/components/general/form/FormForTree.tsx
@@ -59,7 +59,7 @@ const FormForTree = (props: FormForTreeProps) => {
     <form
       className={
         props.fullWidth
-          ? 'flex flex-col gap-y-6'
+          ? 'flex shrink-0 flex-col gap-y-6'
           : 'flex flex-col gap-y-6 lg:grid lg:grid-cols-2 lg:gap-11'
       }
       onSubmit={handleSubmit(props.onSubmit)}

--- a/frontend/app/src/components/general/form/types/SelectEntities.tsx
+++ b/frontend/app/src/components/general/form/types/SelectEntities.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import SelectedCard from '../../cards/SelectedCard'
-import { Button } from '@green-ecolution/ui'
+import { Button, cn } from '@green-ecolution/ui'
 
 interface SelectEntitiesProps {
   onChange: (entries: string[]) => void
@@ -31,8 +31,19 @@ const SelectEntities: React.FC<SelectEntitiesProps> = ({
   const hasEntities = entityIds.length > 0
 
   return (
-    <div className={fill ? 'flex min-h-0 flex-1 flex-col' : undefined}>
-      <div className="mb-2.5 flex items-center justify-between gap-2">
+    <div
+      className={
+        fill
+          ? // Needs a floor, never min-h-0: this block is the only shrinkable item in the
+            // panel column, so without one a short viewport shrinks it below its own
+            // content and the form's actions get drawn on top of the selection. The empty
+            // hint takes min-h-fit because its height depends on the translated text; the
+            // list takes a fixed floor so a long selection scrolls inside itself.
+            cn('flex flex-1 flex-col', hasEntities ? 'min-h-40' : 'min-h-fit')
+          : undefined
+      }
+    >
+      <div className="mb-2.5 flex shrink-0 items-center justify-between gap-2">
         <p className="block font-semibold text-dark-800">
           {t('form.selectEntities.selectedLabel', { label })}
           {required && <span className="text-destructive">&nbsp;*</span>}
@@ -66,7 +77,7 @@ const SelectEntities: React.FC<SelectEntitiesProps> = ({
           ))}
         </ul>
       ) : (
-        <div className="rounded-lg border border-dashed border-dark-200 bg-dark-50/60 px-4 py-6 text-center text-sm">
+        <div className="shrink-0 rounded-lg border border-dashed border-dark-200 bg-dark-50/60 px-4 py-6 text-center text-sm">
           {required ? (
             <p className="font-semibold text-destructive">
               {t('form.selectEntities.requiredHint')}

--- a/frontend/app/src/components/map-gl/MapPanel.tsx
+++ b/frontend/app/src/components/map-gl/MapPanel.tsx
@@ -8,6 +8,8 @@ import { useMediaQuery } from '@/hooks/useMediaQuery'
 interface MapPanelProps extends PropsWithChildren {
   title: string
   onClose: () => void
+  // Never for overflow: the panel body scrolls on its own, and an overflow here
+  // would take the header with the close button out of reach.
   className?: string
   // Accessible label for the close button (the panel context differs per flow).
   closeLabel?: string
@@ -87,7 +89,9 @@ const MapPanel = ({
         <h2 className="font-lato text-lg font-semibold">{title}</h2>
         {headerControls}
       </div>
-      {children}
+      {/* Same scroll container as the mobile sheet: the panel height is capped, so
+          without it anything the children cannot shrink escapes the white box. */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">{children}</div>
     </div>
   )
 }

--- a/frontend/app/src/routes/_protected/map/tree/edit/$treeId/index.tsx
+++ b/frontend/app/src/routes/_protected/map/tree/edit/$treeId/index.tsx
@@ -129,7 +129,7 @@ function EditTreeOnMap() {
     <>
       {!isProvider && <DraggableMarker lng={pos.lng} lat={pos.lat} onDragEnd={handleDragEnd} />}
 
-      <MapPanel title={t('tree.editTitle')} onClose={handleCancel} className="overflow-y-auto">
+      <MapPanel title={t('tree.editTitle')} onClose={handleCancel}>
         {!isProvider && (
           <p className="mb-5 shrink-0 text-sm text-dark-600">{t('tree.dragMarkerHint')}</p>
         )}

--- a/frontend/app/src/routes/_protected/map/tree/new/index.tsx
+++ b/frontend/app/src/routes/_protected/map/tree/new/index.tsx
@@ -72,15 +72,10 @@ function NewTree() {
 
   return (
     <>
-      <MapPanel
-        title={t('tree.newTitle')}
-        onClose={handleCancel}
-        className="overflow-y-auto"
-        mobileCollapsedSnap="260px"
-      >
+      <MapPanel title={t('tree.newTitle')} onClose={handleCancel} mobileCollapsedSnap="260px">
         {pos ? (
           <>
-            <div className="mb-5 flex items-center gap-3 rounded-lg bg-dark-50 px-3 py-2.5">
+            <div className="mb-5 flex shrink-0 items-center gap-3 rounded-lg bg-dark-50 px-3 py-2.5">
               <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-white text-primary-500 shadow-sm">
                 <MapPin className="size-4" />
               </span>


### PR DESCRIPTION
The desktop branch of MapPanel capped its height but was not a scroll container, while every consumer's child tree assumed one existed. The only shrinkable item was the selection list, and with min-h-0 it had no floor, so it absorbed the whole height deficit first and collapsed to zero; once that was exhausted the remaining fields, and with them the save button, were painted outside the white panel with no way to reach them. At 1440x900 the tree list was left with 25px.

MapPanel now wraps its children in the same scroll container the mobile sheet already had, so the header with the close button stays put and the body scrolls. That makes the overflow-y-auto workarounds in the two tree routes obsolete: they scrolled the header away with the content.

SelectEntities gets a real floor for the growing block, on the wrapper rather than the list, so both branches are covered. The list keeps a fixed floor and scrolls inside itself; the empty hint takes min-h-fit because its height follows the translated text, where a fixed value would break again on a longer wrap. This also fixes the collapsed list in the mobile sheet at its collapsed snap point.

Growing fields made this reachable well above the reported window sizes: four validation messages plus a rejected save add about 224px, so the panel overflowed at 1080px window height too, exactly when the save button is needed.