### PR TITLE
fix(frontend): exclude the handbook PDF from the PWA navigation fallback

### DIFF
--- a/frontend/app/src/lib/pwaNavigateFallback.test.ts
+++ b/frontend/app/src/lib/pwaNavigateFallback.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { servedByNetwork } from './pwaNavigateFallback'
+
+describe('navigateFallbackDenylist', () => {
+  it('leaves the handbook PDF to the network', () => {
+    expect(servedByNetwork('/handbook/green-ecolution-handbuch.pdf')).toBe(true)
+  })
+
+  it('leaves the backend routes to the network', () => {
+    expect(servedByNetwork('/api/config.js')).toBe(true)
+    expect(servedByNetwork('/api/v1/tree')).toBe(true)
+  })
+
+  it('keeps the SPA routes on the navigation fallback', () => {
+    expect(servedByNetwork('/')).toBe(false)
+    expect(servedByNetwork('/help')).toBe(false)
+    expect(servedByNetwork('/help/dashboard')).toBe(false)
+    expect(servedByNetwork('/map')).toBe(false)
+  })
+})

--- a/frontend/app/src/lib/pwaNavigateFallback.ts
+++ b/frontend/app/src/lib/pwaNavigateFallback.ts
@@ -1,0 +1,9 @@
+// Paths the service worker must leave to the network. Workbox answers every
+// request with `mode: 'navigate'` from the precached index.html, which turns a
+// PDF download into a 25 KB index.html under a .pdf name and swallows the
+// backend's own routes.
+export const navigateFallbackDenylist = [/^\/handbook\//, /^\/api\//]
+
+export function servedByNetwork(path: string): boolean {
+  return navigateFallbackDenylist.some((pattern) => pattern.test(path))
+}

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -9,6 +9,7 @@ import { VitePWA } from 'vite-plugin-pwa'
 import wasm from 'vite-plugin-wasm'
 import topLevelAwait from 'vite-plugin-top-level-await'
 import { handbook } from '../handbook/src/vite-plugin.mjs'
+import { navigateFallbackDenylist } from './src/lib/pwaNavigateFallback'
 
 const useTraefik = !!process.env.USE_TRAEFIK
 
@@ -61,6 +62,7 @@ export default defineConfig({
         // Handbook screenshots must not enter the precache: they would add their
         // full weight to every install. They are runtime-cached on first read.
         globIgnores: ['**/assets/handbook/**'],
+        navigateFallbackDenylist,
         runtimeCaching: [
           {
             urlPattern: /\/assets\/handbook\/.*\.png$/,


### PR DESCRIPTION
The service worker registered a NavigationRoute bound to index.html without a denylist, so every request with mode 'navigate' was answered from the precache. Clicking the handbook download therefore never reached nginx and saved a 25 KB index.html under a .pdf name, while curl received the correct 12 MB PDF.

Deny /handbook/ and /api/ so both stay on the network.